### PR TITLE
call apt-get update before apt-get source, otherwise it will hash sum mismatch

### DIFF
--- a/ros_buildfarm/binarydeb_job.py
+++ b/ros_buildfarm/binarydeb_job.py
@@ -16,6 +16,10 @@ def get_sourcedeb(
 
     debian_package_name = get_debian_package_name(rosdistro_name, package_name)
     if not skip_download_sourcedeb:
+        # update apt index first
+        cmd = ['apt-get', 'update']
+        print("Invoking '%s'" % ' '.join(cmd))
+        subprocess.check_call(cmd, cwd=sourcedeb_dir)
         # download sourcedeb
         cmd = ['apt-get', 'source', debian_package_name, '--download-only']
         print("Invoking '%s'" % ' '.join(cmd))


### PR DESCRIPTION
if a sourcedeb was retriggered since caching

This will avoid errors like this:

```
Traceback (most recent call last):
  File "/tmp/ros_buildfarm/scripts/release/get_sourcedeb.py", line 30, in <module>
    sys.exit(main())
  File "/tmp/ros_buildfarm/scripts/release/get_sourcedeb.py", line 26, in main
    args.skip_download_sourcedeb)
  File "/tmp/ros_buildfarm/ros_buildfarm/binarydeb_job.py", line 23, in get_sourcedeb
    subprocess.check_call(cmd, cwd=sourcedeb_dir)
  File "/usr/lib/python3.4/subprocess.py", line 557, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['apt-get', 'source', 'ros-indigo-catkin', '--download-only']' returned non-zero exit status 100
```

This will also fail for newly uploaded sourcedebs as you will get the older cached version. 

```
Invoking 'apt-get source ros-indigo-genmsg --download-only' Reading package lists... Building dependency tree... Reading state information... E: Unable to find a source package for ros-indigo-genmsg # END SUBSECTION
Traceback (most recent call last):
  File "/tmp/ros_buildfarm/scripts/release/get_sourcedeb.py", line 30, in <module>
    sys.exit(main())
  File "/tmp/ros_buildfarm/scripts/release/get_sourcedeb.py", line 26, in main
    args.skip_download_sourcedeb)
  File "/tmp/ros_buildfarm/ros_buildfarm/binarydeb_job.py", line 23, in get_sourcedeb
    subprocess.check_call(cmd, cwd=sourcedeb_dir)
  File "/usr/lib/python3.4/subprocess.py", line 557, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['apt-get', 'source', 'ros-indigo-genmsg', '--download-only']' returned non-zero exit status 100

```
