### PR TITLE
do not override the sourcedeb container codename

### DIFF
--- a/scripts/release/run_sourcedeb_job.py
+++ b/scripts/release/run_sourcedeb_job.py
@@ -46,9 +46,6 @@ def main(argv=sys.argv[1:]):
 
     data = copy.deepcopy(args.__dict__)
     data.update({
-        'os_name': 'ubuntu',
-        'os_code_name': 'trusty',
-
         'maintainer_email': 'dthomas+buildfarm@osrfoundation.org',
         'maintainer_name': 'Dirk Thomas',
 


### PR DESCRIPTION
This causes our "saucy" sourcdebs to be built with trusty content. 

For example the Project IrelUbu__genmsg__ubuntu_saucy__source
creates: 0.5.5-0trusty

It is true that the sourcedeb container image could be standardized on [trusty](https://github.com/ros-infrastructure/ros_buildfarm/blob/master/templates/release/sourcedeb_task.Dockerfile.em#L1). But the os_code_name is used in 2 other places which set the apt sources and get_source.py arguments which leads to cross talk. 
https://github.com/ros-infrastructure/ros_buildfarm/blob/master/templates/release/sourcedeb_task.Dockerfile.em#L16
https://github.com/ros-infrastructure/ros_buildfarm/blob/master/templates/release/sourcedeb_task.Dockerfile.em#L49

I tested this works on my test deployment. It created: 0.5.5-0saucy
