### PR TITLE
adding a bootstrap job. It should bring in the full dependencies of ROS ...

### DIFF
--- a/scripts/release/generate_release_maintenance_jobs.py
+++ b/scripts/release/generate_release_maintenance_jobs.py
@@ -39,6 +39,8 @@ def main(argv=sys.argv[1:]):
         args, build_file)
     trigger_jobs_job_config = get_trigger_jobs_job_config(
         args, build_file)
+    import_upstream_job_config = get_import_upstream_job_config(
+        args, build_file)
 
     jenkins = connect(build_file.jenkins_url)
 
@@ -53,6 +55,9 @@ def main(argv=sys.argv[1:]):
     job_name = '%s_%s' % (group_name, 'trigger-jobs')
     configure_job(jenkins, job_name, trigger_jobs_job_config, view=view)
 
+    job_name = 'import_upstream'
+    configure_job(jenkins, job_name, import_upstream_job_config, view=view)
+
 
 def get_reconfigure_jobs_job_config(args, build_file):
     template_name = 'release/release_reconfigure-jobs_job.xml.em'
@@ -61,6 +66,11 @@ def get_reconfigure_jobs_job_config(args, build_file):
 
 def get_trigger_jobs_job_config(args, build_file):
     template_name = 'release/release_trigger-jobs_job.xml.em'
+    return _get_job_config(args, build_file, template_name)
+
+
+def get_import_upstream_job_config(args, build_file):
+    template_name = 'release/import_upstream_job.xml.em'
     return _get_job_config(args, build_file, template_name)
 
 

--- a/templates/release/import_upstream_job.xml.em
+++ b/templates/release/import_upstream_job.xml.em
@@ -1,0 +1,65 @@
+<project>
+  <actions/>
+  <description>Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'</description>
+@(SNIPPET(
+    'log-rotator',
+    days_to_keep=100,
+    num_to_keep=100,
+))@
+  <keepDependencies>false</keepDependencies>
+  <properties>
+@(SNIPPET(
+    'property_parameters-definition',
+    parameters=[
+        {
+            'type': 'string',
+            'name': 'config_file',
+            'description': 'A specific yaml file or files. If unset it defaults to aggregating all yaml files in the directory defined by upstream_config in reprepro-updater.ini',
+            'default_value': None,
+        },
+    ],
+))@
+@(SNIPPET(
+    'property_requeue-job',
+))@
+  </properties>
+@(SNIPPET(
+    'scm_git',
+    url='https://github.com/ros-infrastructure/reprepro-updater.git',
+    refspec='upstream_config',
+    relative_target_dir='reprepro-updater',
+))@
+  <assignedNode>building_repository</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'echo "# BEGIN SECTION: import debian packages"',
+        'export PYTHONPATH=$WORKSPACE/reprepro-updater/src:$PYTHONPATH',
+        'echo "# BEGIN SUBSECTION: import debian packages for ubuntu_building"',
+        '$WORKSPACE/reprepro-updater/scripts/import_upstream.py ubuntu_building $config_file --commit',
+        'echo "# END SUBSECTION"',
+        'echo "# BEGIN SUBSECTION: import debian packages for ubuntu_testing"',
+        '$WORKSPACE/reprepro-updater/scripts/import_upstream.py ubuntu_testing $config_file --commit',
+        'echo "# END SUBSECTION"',
+        'echo "# BEGIN SUBSECTION: import debian packages for ubuntu_main"',
+        '$WORKSPACE/reprepro-updater/scripts/import_upstream.py ubuntu_main $config_file --commit',
+        'echo "# END SUBSECTION"',
+        'echo "# END SECTION"',
+    ]),
+))@
+  </builders>
+  <publishers>
+  </publishers>
+  <buildWrappers>
+@(SNIPPET(
+    'build-wrapper_timestamper',
+))@
+  </buildWrappers>
+</project>


### PR DESCRIPTION
...not just the python tools now. This needs to be run before kicking off any release jobs.

@dirk-thomas This is a rough approximation of what needs to happen. I wasn't sure where this would best fit into the architecture. 

This or equivalent is needed to land: https://github.com/ros-infrastructure/buildfarm_deployment/pull/10
