### PR TITLE
Development tweaks

### DIFF
--- a/ros_buildfarm/config/index.py
+++ b/ros_buildfarm/config/index.py
@@ -89,3 +89,4 @@ class Index(object):
         self.prerequisites = data['prerequisites']
 
         self.rosdistro_index_url = data['rosdistro_index_url']
+        self.ros_buildfarm_repo = data['ros_buildfarm_repo']

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -211,6 +211,8 @@ def _get_devel_job_config(
 
         'script_generating_key_files': script_generating_key_files,
 
+        'ros_buildfarm_repo': config.ros_buildfarm_repo,
+
         'rosdistro_index_url': config.rosdistro_index_url,
         'rosdistro_name': rosdistro_name,
         'source_build_name': source_build_name,

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -338,6 +338,8 @@ def _get_sourcedeb_job_config(
 
         'script_generating_key_files': script_generating_key_files,
 
+        'ros_buildfarm_repo': config.ros_buildfarm_repo,
+
         'rosdistro_index_url': config.rosdistro_index_url,
         'rosdistro_name': rosdistro_name,
         'release_build_name': release_build_name,
@@ -400,6 +402,8 @@ def _get_binarydeb_job_config(
         'release_repo_spec': release_repo_spec,
 
         'script_generating_key_files': script_generating_key_files,
+
+        'ros_buildfarm_repo': config.ros_buildfarm_repo,
 
         'rosdistro_index_url': config.rosdistro_index_url,
         'rosdistro_name': rosdistro_name,

--- a/templates/devel/devel_job.xml.em
+++ b/templates/devel/devel_job.xml.em
@@ -46,7 +46,7 @@
         '',
         'echo "# BEGIN SECTION: Clone ros_buildfarm"',
         'rm -fr ros_buildfarm',
-        'git clone https://github.com/ros-infrastructure/ros_buildfarm.git ros_buildfarm',
+        'git clone ' + ros_buildfarm_repo + ' ros_buildfarm',
         'echo "# END SECTION"',
     ]),
 ))@

--- a/templates/release/binarydeb_job.xml.em
+++ b/templates/release/binarydeb_job.xml.em
@@ -49,7 +49,7 @@
         '',
         'echo "# BEGIN SECTION: Clone ros_buildfarm"',
         'rm -fr ros_buildfarm',
-        'git clone https://github.com/ros-infrastructure/ros_buildfarm.git ros_buildfarm',
+        'git clone ' + ros_buildfarm_repo + ' ros_buildfarm',
         'echo "# END SECTION"',
     ]),
 ))@

--- a/templates/release/sourcedeb_job.xml.em
+++ b/templates/release/sourcedeb_job.xml.em
@@ -39,7 +39,7 @@
         '',
         'echo "# BEGIN SECTION: Clone ros_buildfarm"',
         'rm -fr ros_buildfarm',
-        'git clone https://github.com/ros-infrastructure/ros_buildfarm.git ros_buildfarm',
+        'git clone ' + ros_buildfarm_repo + ' ros_buildfarm',
         'echo "# END SECTION"',
     ]),
 ))@


### PR DESCRIPTION
Two fixes:
- Print release job generation to stderr so that it doesn't end up in the script when I run generate_release_script.py and redirect stdout to a file
- Add a config option for the ros_buildfarm repo, so that my build jobs can easily use my repo instead of having it hardcoded. This may need to be tweaked if you want to provide a default repo.
