### PR TITLE
Update git scm checkout to support branches with slashes

### DIFF
--- a/ros_buildfarm/templates/snippet/scm_git.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_git.xml.em
@@ -10,7 +10,7 @@
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>@ESCAPE(branch_name)</name>
+        <name>refs/heads/@ESCAPE(branch_name)</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>


### PR DESCRIPTION
From: https://issues.jenkins-ci.org/browse/JENKINS-27115 and https://github.com/ros/rosdistro/issues/7346

It looks like using the wildcard syntax */branch/name should work. 

By default the git plugin trims after a slash in the branch name. 

@dirk-thomas I think this is the right place. 