### PR TITLE
Add ccache inside debbuild and devel jobs

### DIFF
--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -155,6 +155,7 @@ if pull_request:
         ' -v $WORKSPACE/catkin_workspace:/tmp/catkin_workspace:ro' +
         ' -v $WORKSPACE/docker_build_and_install:/tmp/docker_build_and_install' +
         ' -v $WORKSPACE/docker_build_and_test:/tmp/docker_build_and_test' +
+        ' -v ~/.ccache:/home/buildfarm/.ccache' +
         ' devel_task_generation__%s_%s' % (rosdistro_name, source_repo_spec.name),
         'echo "# END SECTION"',
     ]),

--- a/ros_buildfarm/templates/release/binarydeb_job.xml.em
+++ b/ros_buildfarm/templates/release/binarydeb_job.xml.em
@@ -124,6 +124,7 @@
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/binarydeb:/tmp/binarydeb' +
         ' -v $WORKSPACE/docker_build_binarydeb:/tmp/docker_build_binarydeb' +
+        ' -v ~/.ccache:/home/buildfarm/.ccache' + \
         ' binarydeb_task_generation__%s_%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
         'echo "# END SECTION"',
     ]),

--- a/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
@@ -45,6 +45,8 @@ RUN echo "@today_str"
     os_code_name=os_code_name,
 ))@
 
+RUN python3 -u /tmp/wrapper_scripts/apt-get.py update-and-install -q -y ccache
+
 @(TEMPLATE(
     'snippet/install_dependencies.Dockerfile.em',
     dependencies=dependencies,
@@ -56,6 +58,7 @@ ENTRYPOINT ["sh", "-c"]
 @{
 cmd = \
     'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \
+    ' PATH=/usr/lib/ccache:$PATH' + \
     ' /tmp/ros_buildfarm/scripts/release/build_binarydeb.py' + \
     ' ' + rosdistro_name + \
     ' ' + package_name + \


### PR DESCRIPTION
This will save a lot of processing time. 

On amd64 it takes a 2.5minute build of roscpp to a 12 second rebuild. 
On armhf it takes a 29 minute build of roscpp to 2.1 minute rebuild.

This will only share the cache on a single host. But that will be shared across the 4 executors at the moment. And jenkins does seem to have an affinity for reusing the same executor, but if we're queued up I don't think it takes that into account. 

This requires: https://github.com/ros-infrastructure/buildfarm_deployment/pull/60 for clean startup. 