### PR TITLE
adding additional labels to provide better introspection

### DIFF
--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -64,7 +64,13 @@ if pull_request:
     relative_target_dir='catkin_workspace/src/%s' % source_repo_spec.name,
 ))@
 @[end if]@
-  <assignedNode>@(node_label if node_label else 'buildslave')</assignedNode>
+@(SNIPPET(
+    'assigned_node',
+    jobtype='devel',
+    node_label=node_label,
+    rosdistro_name=rosdistro_name,
+    arch=arch,
+))@
   <canRoam>false</canRoam>
   <disabled>@('true' if disabled else 'false')</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/doc/doc_independent_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_job.xml.em
@@ -21,7 +21,13 @@
 @(SNIPPET(
     'scm_null',
 ))@
-  <assignedNode>@(node_label if node_label else 'buildslave')</assignedNode>
+@(SNIPPET(
+    'assigned_node',
+    jobtype='doc_independent',
+    node_label=node_label,
+    rosdistro_name=rosdistro_name,
+    arch=arch,
+))@
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/doc/doc_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_job.xml.em
@@ -48,7 +48,13 @@
     repo_spec=doc_repo_spec,
     path='catkin_workspace/src/%s' % doc_repo_spec.name,
 ))@
-  <assignedNode>@(node_label if node_label else 'buildslave')</assignedNode>
+@(SNIPPET(
+    'assigned_node',
+    jobtype='doc',
+    node_label=node_label,
+    rosdistro_name=rosdistro_name,
+    arch=arch,
+))@
   <canRoam>false</canRoam>
   <disabled>@('true' if disabled else 'false')</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
@@ -21,7 +21,13 @@
 @(SNIPPET(
     'scm_null',
 ))@
-  <assignedNode>@(node_label if node_label else 'buildslave')</assignedNode>
+@(SNIPPET(
+    'assigned_node',
+    jobtype='doc_metadata',
+    node_label=node_label,
+    rosdistro_name=rosdistro_name,
+    arch=arch,
+))@
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/release/binarydeb_job.xml.em
+++ b/ros_buildfarm/templates/release/binarydeb_job.xml.em
@@ -39,7 +39,13 @@
 @(SNIPPET(
     'scm_null',
 ))@
-  <assignedNode>@(node_label if node_label else 'buildslave')</assignedNode>
+@(SNIPPET(
+    'assigned_node',
+    jobtype='binarydeb',
+    node_label=node_label,
+    rosdistro_name=rosdistro_name,
+    arch=arch,
+))@
   <canRoam>false</canRoam>
   <disabled>@('true' if disabled else 'false')</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/release/sourcedeb_job.xml.em
+++ b/ros_buildfarm/templates/release/sourcedeb_job.xml.em
@@ -39,7 +39,13 @@
 @(SNIPPET(
     'scm_null',
 ))@
-  <assignedNode>@(node_label if node_label else 'buildslave')</assignedNode>
+@(SNIPPET(
+    'assigned_node',
+    jobtype='sourcedeb',
+    node_label=node_label,
+    rosdistro_name=rosdistro_name,
+    arch=arch,
+))@
   <canRoam>false</canRoam>
   <disabled>@('true' if disabled else 'false')</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/snippet/assigned_node.xml.em
+++ b/ros_buildfarm/templates/snippet/assigned_node.xml.em
@@ -1,0 +1,6 @@
+  <assignedNode>@
+@(node_label if node_label else 'buildslave') || @
+@('_'.join(['', job_type, rosdistro_name, arch])) || @
+@('_'.join(['', job_type, rosdistro_name])) || @
+@('_'.join(['', job_type, arch])) @
+</assignedNode>


### PR DESCRIPTION
This adds a snippet which adds executor labels which will not be actually used, but can provide charts like I use here: https://rawgit.com/tfoote/b7e87790e41d6f383755/raw/ros_multi_load.html

Then use the snippet in each of the job build types. 

@dirk-thomas Please review. Is there a way to test this without deploying?

