### PR TITLE
use --exclude-pkg argument for prereleases

### DIFF
--- a/ros_buildfarm/prerelease.py
+++ b/ros_buildfarm/prerelease.py
@@ -77,7 +77,8 @@ def get_overlay_package_names(
     for _ in range(level):
         next_level_pkg_names = get_next_level_of_dependencies(
             next_level_pkg_names, reverse_dependencies,
-            overlay_package_names_from_level | set(underlay_package_names))
+            overlay_package_names_from_level | set(underlay_package_names) |
+            set(excluded_package_names))
         if not next_level_pkg_names:
             break
         overlay_package_names_from_level |= next_level_pkg_names


### PR DESCRIPTION
Addresses #74.

I tried it with invoking:

    ./scripts/prerelease/generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/master/index.yaml indigo default ubuntu trusty amd64 genmsg --level 1 --output-dir /tmp/prerelease --exclude-pkg find_object_2d gencpp geneus genjava genlisp industrial_msgs interaction_cursor_msgs jsk_footstep_controller message_generation multisense_ros razer_hydra ros_core rosbag rosdoc_lite roslang rosmsg rtabmap_ros rtt_roscomm rtt_std_srvs view_controller_msgs wiimote

@wjwwood Please check if that works for your case too.