### PR TITLE
Prevent release script from failing on non-existent *.debian.tar.xz

### DIFF
--- a/ros_buildfarm/templates/release/release_script.sh.em
+++ b/ros_buildfarm/templates/release/release_script.sh.em
@@ -44,7 +44,7 @@ cd $WORKSPACE
 echo ""
 echo "Get artifacts from source job"
 mkdir -p $WORKSPACE/binarydeb
-(set -x; cp $BASEPATH/source/sourcedeb/*.debian.tar.gz $BASEPATH/source/sourcedeb/*.debian.tar.xz $BASEPATH/source/sourcedeb/*.dsc $BASEPATH/source/sourcedeb/*.orig.tar.gz $WORKSPACE/binarydeb/)
+(set -x; cp $BASEPATH/source/sourcedeb/*.debian.tar.[gx]z $BASEPATH/source/sourcedeb/*.dsc $BASEPATH/source/sourcedeb/*.orig.tar.gz $WORKSPACE/binarydeb/)
 
 # run all binary build steps
 @[for i, script in enumerate(binary_scripts)]@


### PR DESCRIPTION
https://github.com/ros-infrastructure/ros_buildfarm/blob/master/doc/jobs/release_jobs.rst#example-invocation fails with
```
cp: cannot stat '/home/mdl/buildfarm/source/sourcedeb/*.debian.tar.xz': No such file or directory
```
This patched version matches *.debian.tar.xz and/or *.debian.tar.gz.