### PR TITLE
[doc] sudo was needed to run ./prerelease.sh

### DIFF
--- a/doc/jobs/prerelease_jobs.rst
+++ b/doc/jobs/prerelease_jobs.rst
@@ -70,7 +70,7 @@ The packages defining the *overlay* workspace are: *roscpp*
   mkdir /tmp/prerelease_job
   generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/master/index.yaml indigo default ubuntu trusty amd64 roscpp_core std_msgs --level 0 --pkg roscpp --output-dir /tmp/prerelease_job
   cd /tmp/prerelease_job
-  ./prerelease.sh
+  sudo ./prerelease.sh
 
 Instead of specifying the packages in the *overlay* workspace *by name* the
 script also supports passing a dependency depth (``--level N``) and / or


### PR DESCRIPTION
Besides this change, I don't know if there's usage document for the new docker-based prerelease ([this wiki](http://wiki.ros.org/regression_tests#How_do_I_setup_my_system_to_run_a_prerelease.3F) doesn't tell what to do after some point). I'm not sure if this repository needs to be pointed from there either.