### PR TITLE
Fix repository name component error w/ Docker 1.8

### DIFF
--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -143,7 +143,7 @@ if pull_request:
         'echo "# BEGIN SECTION: Build Dockerfile - generating devel tasks"',
         'cd $WORKSPACE/docker_generating_dockers',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
-        'docker build -t devel_task_generation__%s_%s .' % (rosdistro_name, source_repo_spec.name),
+        'docker build -t devel_task_generation.%s_%s .' % (rosdistro_name, source_repo_spec.name),
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - generating devel tasks"',
@@ -160,7 +160,7 @@ if pull_request:
         ' -v $WORKSPACE/docker_build_and_install:/tmp/docker_build_and_install' +
         ' -v $WORKSPACE/docker_build_and_test:/tmp/docker_build_and_test' +
         ' -v ~/.ccache:/home/buildfarm/.ccache' +
-        ' devel_task_generation__%s_%s' % (rosdistro_name, source_repo_spec.name),
+        ' devel_task_generation.%s_%s' % (rosdistro_name, source_repo_spec.name),
         'echo "# END SECTION"',
     ]),
 ))@
@@ -176,7 +176,7 @@ if pull_request:
         '# build and run build_and_install Dockerfile',
         'cd $WORKSPACE/docker_build_and_install',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
-        'docker build -t devel_build_and_install__%s_%s .' % (rosdistro_name, source_repo_spec.name),
+        'docker build -t devel_build_and_install.%s_%s .' % (rosdistro_name, source_repo_spec.name),
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - build and install"',
@@ -185,7 +185,7 @@ if pull_request:
         ' --cidfile=$WORKSPACE/docker_build_and_install/docker.cid' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/catkin_workspace:/tmp/catkin_workspace' +
-        ' devel_build_and_install__%s_%s' % (rosdistro_name, source_repo_spec.name),
+        ' devel_build_and_install.%s_%s' % (rosdistro_name, source_repo_spec.name),
         'echo "# END SECTION"',
     ]),
 ))@
@@ -201,7 +201,7 @@ if pull_request:
         '# build and run build_and_test Dockerfile',
         'cd $WORKSPACE/docker_build_and_test',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
-        'docker build -t devel_build_and_test__%s_%s .' % (rosdistro_name, source_repo_spec.name),
+        'docker build -t devel_build_and_test.%s_%s .' % (rosdistro_name, source_repo_spec.name),
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - build and test"',
@@ -210,7 +210,7 @@ if pull_request:
         ' --cidfile=$WORKSPACE/docker_build_and_test/docker.cid' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/catkin_workspace:/tmp/catkin_workspace' +
-        ' devel_build_and_test__%s_%s' % (rosdistro_name, source_repo_spec.name),
+        ' devel_build_and_test.%s_%s' % (rosdistro_name, source_repo_spec.name),
         'echo "# END SECTION"',
     ]),
 ))@

--- a/ros_buildfarm/templates/doc/doc_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_job.xml.em
@@ -157,7 +157,7 @@
         'echo "# BEGIN SECTION: Build Dockerfile - generating doc task"',
         'cd $WORKSPACE/docker_generating_docker',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
-        'docker build -t doc_task_generation__%s_%s .' % (rosdistro_name, doc_repo_spec.name),
+        'docker build -t doc_task_generation.%s_%s .' % (rosdistro_name, doc_repo_spec.name),
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - generating doc task"',
@@ -174,7 +174,7 @@
         ' -v $WORKSPACE/catkin_workspace:/tmp/catkin_workspace' +
         ' -v $WORKSPACE/generated_documentation:/tmp/generated_documentation' +
         ' -v $WORKSPACE/docker_doc:/tmp/docker_doc' +
-        ' doc_task_generation__%s_%s' % (rosdistro_name, doc_repo_spec.name),
+        ' doc_task_generation.%s_%s' % (rosdistro_name, doc_repo_spec.name),
         'echo "# END SECTION"',
     ]),
 ))@
@@ -194,7 +194,7 @@
         '# build and run build_and_install Dockerfile',
         'cd $WORKSPACE/docker_doc',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
-        'docker build -t doc__%s_%s .' % (rosdistro_name, doc_repo_spec.name),
+        'docker build -t doc.%s_%s .' % (rosdistro_name, doc_repo_spec.name),
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - doc"',
@@ -207,7 +207,7 @@
         ' -v $WORKSPACE/rosdoc_index:/tmp/rosdoc_index:ro' +
         ' -v $WORKSPACE/catkin_workspace:/tmp/catkin_workspace' +
         ' -v $WORKSPACE/generated_documentation:/tmp/generated_documentation' +
-        ' doc__%s_%s' % (rosdistro_name, doc_repo_spec.name),
+        ' doc.%s_%s' % (rosdistro_name, doc_repo_spec.name),
         'echo "# END SECTION"',
     ]),
 ))@

--- a/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
@@ -88,7 +88,7 @@
         'echo "# BEGIN SECTION: Build Dockerfile - doc metadata"',
         'cd $WORKSPACE/docker_doc_metadata',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
-        'docker build -t doc_metadata__%s .' % rosdistro_name,
+        'docker build -t doc_metadata.%s .' % rosdistro_name,
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - doc metadata"',
@@ -98,7 +98,7 @@
         ' -e=HOME=/home/buildfarm' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/generated_documentation:/tmp/generated_documentation' +
-        ' doc_metadata__%s' % rosdistro_name,
+        ' doc_metadata.%s' % rosdistro_name,
         'echo "# END SECTION"',
     ]),
 ))@

--- a/ros_buildfarm/templates/release/binarydeb_job.xml.em
+++ b/ros_buildfarm/templates/release/binarydeb_job.xml.em
@@ -114,7 +114,7 @@
         'echo "# BEGIN SECTION: Build Dockerfile - binarydeb task"',
         'cd $WORKSPACE/docker_generating_docker',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
-        'docker build -t binarydeb_task_generation__%s_%s_%s_%s_%s .' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
+        'docker build -t binarydeb_task_generation.%s_%s_%s_%s_%s .' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - binarydeb task"',
@@ -129,7 +129,7 @@
         ' -v $WORKSPACE/binarydeb:/tmp/binarydeb' +
         ' -v $WORKSPACE/docker_build_binarydeb:/tmp/docker_build_binarydeb' +
         ' -v ~/.ccache:/home/buildfarm/.ccache' + \
-        ' binarydeb_task_generation__%s_%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
+        ' binarydeb_task_generation.%s_%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
         'echo "# END SECTION"',
     ]),
 ))@
@@ -145,7 +145,7 @@
         '# build and run build_binarydeb Dockerfile',
         'cd $WORKSPACE/docker_build_binarydeb',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
-        'docker build -t binarydeb_build__%s_%s_%s_%s_%s .' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
+        'docker build -t binarydeb_build.%s_%s_%s_%s_%s .' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - build binarydeb"',
@@ -159,7 +159,7 @@
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/binarydeb:/tmp/binarydeb' +
         ' -v ~/.ccache:/home/buildfarm/.ccache' +
-        ' binarydeb_build__%s_%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
+        ' binarydeb_build.%s_%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
         'echo "# END SECTION"',
     ]),
 ))@
@@ -202,7 +202,7 @@
 @#         'echo "# BEGIN SECTION: Build Dockerfile - install"',
 @#         'cd $WORKSPACE/docker_install_binarydeb',
 @#         'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
-@#         'docker build -t binarydeb_install__%s_%s_%s_%s_%s .' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
+@#         'docker build -t binarydeb_install.%s_%s_%s_%s_%s .' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
 @#         'echo "# END SECTION"',
 @#         '',
 @#         'echo "# BEGIN SECTION: Run Dockerfile - install"',
@@ -210,7 +210,7 @@
 @#         ' --rm ' +
 @#         ' --cidfile=$WORKSPACE/docker_install_binarydeb/docker.cid' +
 @#         ' -v $WORKSPACE/binarydeb:/tmp/binarydeb:ro' +
-@#         ' binarydeb_install__%s_%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
+@#         ' binarydeb_install.%s_%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
 @#         'echo "# END SECTION"',
 @#     ]),
 @# ))@

--- a/ros_buildfarm/templates/release/sourcedeb_job.xml.em
+++ b/ros_buildfarm/templates/release/sourcedeb_job.xml.em
@@ -102,7 +102,7 @@
         'echo "# BEGIN SECTION: Build Dockerfile - generate sourcedeb"',
         'cd $WORKSPACE/docker_sourcedeb',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
-        'docker build -t sourcedeb__%s_%s_%s_%s .' % (rosdistro_name, os_name, os_code_name, pkg_name),
+        'docker build -t sourcedeb.%s_%s_%s_%s .' % (rosdistro_name, os_name, os_code_name, pkg_name),
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - generate sourcedeb"',
@@ -114,7 +114,7 @@
         ' --net=host' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/sourcedeb:/tmp/sourcedeb' +
-        ' sourcedeb__%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, pkg_name),
+        ' sourcedeb.%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, pkg_name),
         'echo "# END SECTION"',
     ]),
 ))@


### PR DESCRIPTION
Apparently Docker 1.8 enforces the following regex for container names: `[a-z0-9]+(?:[._-][a-z0-9]+)*`. Therefore it does not allow repetitive `_` characters for repository name components. This PR replaces all occurrences of `__` with `_` in `empy` templates to fix this issue. Currently pre-release script fails on Docker 1.8 with the following error:

```
repository name component must match \"[a-z0-9]+(?:[._-][a-z0-9]+)*\"
```

PS. [This is the commit in Docker source tree](https://github.com/docker/docker/commit/f011d722ce2ec7ef00654130f7f4ff8d295f025f) which implements this feature. It must have been presented in Docker releases since v1.7. However I started getting this error after upgrading to Docker v1.8.
