### PR TITLE
Add support for git clone over SSH (fixes #91)

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -40,6 +40,10 @@ The following options are valid in version ``1``:
   * ``notification_emails``: a list of email addresses for notification about
     ROS distribution specific administrative jobs.
 
+* ``git_ssh_credential_id``: the ID of the credential entry managed on the
+  Jenkins master which is used to clone sources using Git over SSH.
+  This credential id is set in the buildfarm_deployment.
+
 * ``jenkins_url``: the URL of the Jenkins master.
 
 * ``notification_emails``: a list of email addresses for notification about

--- a/ros_buildfarm/config/index.py
+++ b/ros_buildfarm/config/index.py
@@ -113,6 +113,11 @@ class Index(object):
                 v = _resolve_url(base_url, v)
                 self.doc_builds[k] = v
 
+        self.git_ssh_credential_id = ''
+        if 'git_ssh_credential_id' in data:
+            self.git_ssh_credential_id = data['git_ssh_credential_id']
+            assert isinstance(self.git_ssh_credential_id, str)
+
         self.jenkins_url = data['jenkins_url']
 
         self.notify_emails = []

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -338,6 +338,8 @@ def _get_devel_job_config(
         'notify_committers': build_file.notify_committers,
 
         'timeout_minutes': build_file.jenkins_job_timeout,
+
+        'git_ssh_credential_id': config.git_ssh_credential_id,
     }
     job_config = expand_template(template_name, job_data)
     return job_config

--- a/ros_buildfarm/doc_job.py
+++ b/ros_buildfarm/doc_job.py
@@ -277,6 +277,8 @@ def _get_doc_job_config(
         'timeout_minutes': build_file.jenkins_job_timeout,
 
         'credential_id': build_file.upload_credential_id,
+
+        'git_ssh_credential_id': config.git_ssh_credential_id,
     }
     job_config = expand_template(template_name, job_data)
     return job_config

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -529,6 +529,8 @@ def _get_sourcedeb_job_config(
         'timeout_minutes': build_file.jenkins_source_job_timeout,
 
         'credential_id': build_file.upload_credential_id,
+
+        'git_ssh_credential_id': config.git_ssh_credential_id,
     }
     job_config = expand_template(template_name, job_data)
     return job_config

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -53,6 +53,7 @@ if pull_request:
     'scm',
     repo_spec=source_repo_spec,
     path='catkin_workspace/src/%s' % source_repo_spec.name,
+    git_ssh_credential_id=git_ssh_credential_id,
 ))@
 @[end if]@
 @[if pull_request]@
@@ -62,6 +63,7 @@ if pull_request:
     refspec='+refs/pull/*:refs/remotes/origin/pr/*',
     branch_name='${sha1}',
     relative_target_dir='catkin_workspace/src/%s' % source_repo_spec.name,
+    git_ssh_credential_id=git_ssh_credential_id,
 ))@
 @[end if]@
   <assignedNode>@(node_label if node_label else 'buildslave')</assignedNode>

--- a/ros_buildfarm/templates/doc/doc_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_job.xml.em
@@ -47,6 +47,7 @@
     'scm',
     repo_spec=doc_repo_spec,
     path='catkin_workspace/src/%s' % doc_repo_spec.name,
+    git_ssh_credential_id = git_ssh_credential_id,
 ))@
   <assignedNode>@(node_label if node_label else 'buildslave')</assignedNode>
   <canRoam>false</canRoam>

--- a/ros_buildfarm/templates/misc/rosdistro_cache_job.xml.em
+++ b/ros_buildfarm/templates/misc/rosdistro_cache_job.xml.em
@@ -79,6 +79,9 @@
         ' --cidfile=$WORKSPACE/docker_generate_rosdistro_cache/docker.cid' +
         ' --net=host' +
         ' -v $WORKSPACE/rosdistro_cache:/tmp/rosdistro_cache' +
+        ' -v $HOME/.ssh/known_hosts:/etc/ssh/ssh_known_hosts:ro' +
+        ' -v $SSH_AUTH_SOCK:/tmp/ssh_auth_sock' +
+        ' -e SSH_AUTH_SOCK=/tmp/ssh_auth_sock' +
         ' rosdistro_cache_generation',
         'echo "# END SECTION"',
     ]),
@@ -103,5 +106,11 @@
 @(SNIPPET(
     'build-wrapper_timestamper',
 ))@
+@[if git_ssh_credential_id]@
+@(SNIPPET(
+    'build-wrapper_ssh-agent',
+    credential_id=git_ssh_credential_id,
+))@
+@[end if]@
   </buildWrappers>
 </project>

--- a/ros_buildfarm/templates/misc/rosdistro_cache_job.xml.em
+++ b/ros_buildfarm/templates/misc/rosdistro_cache_job.xml.em
@@ -79,9 +79,9 @@
         ' --cidfile=$WORKSPACE/docker_generate_rosdistro_cache/docker.cid' +
         ' --net=host' +
         ' -v $WORKSPACE/rosdistro_cache:/tmp/rosdistro_cache' +
-        ' -v $HOME/.ssh/known_hosts:/etc/ssh/ssh_known_hosts:ro' +
-        ' -v $SSH_AUTH_SOCK:/tmp/ssh_auth_sock' +
-        ' -e SSH_AUTH_SOCK=/tmp/ssh_auth_sock' +
+        (' -v $HOME/.ssh/known_hosts:/etc/ssh/ssh_known_hosts:ro'
+         ' -v $SSH_AUTH_SOCK:/tmp/ssh_auth_sock'
+         ' -e SSH_AUTH_SOCK=/tmp/ssh_auth_sock' if git_ssh_credential_id else '') +
         ' rosdistro_cache_generation',
         'echo "# END SECTION"',
     ]),

--- a/ros_buildfarm/templates/release/sourcedeb_job.xml.em
+++ b/ros_buildfarm/templates/release/sourcedeb_job.xml.em
@@ -114,9 +114,9 @@
         ' --net=host' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/sourcedeb:/tmp/sourcedeb' +
-        ' -v $HOME/.ssh/known_hosts:/etc/ssh/ssh_known_hosts:ro' +
-        ' -v $SSH_AUTH_SOCK:/tmp/ssh_auth_sock' +
-        ' -e SSH_AUTH_SOCK=/tmp/ssh_auth_sock' +
+        (' -v $HOME/.ssh/known_hosts:/etc/ssh/ssh_known_hosts:ro' +
+         ' -v $SSH_AUTH_SOCK:/tmp/ssh_auth_sock' +
+         ' -e SSH_AUTH_SOCK=/tmp/ssh_auth_sock' if git_ssh_credential_id else '') +
         ' sourcedeb.%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, pkg_name),
         'echo "# END SECTION"',
     ]),

--- a/ros_buildfarm/templates/release/sourcedeb_job.xml.em
+++ b/ros_buildfarm/templates/release/sourcedeb_job.xml.em
@@ -118,7 +118,6 @@
         ' -v $SSH_AUTH_SOCK:/tmp/ssh_auth_sock' +
         ' -e SSH_AUTH_SOCK=/tmp/ssh_auth_sock' +
         ' sourcedeb.%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, pkg_name),
-        ' sourcedeb.%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, pkg_name),
         'echo "# END SECTION"',
     ]),
 ))@

--- a/ros_buildfarm/templates/release/sourcedeb_job.xml.em
+++ b/ros_buildfarm/templates/release/sourcedeb_job.xml.em
@@ -114,6 +114,9 @@
         ' --net=host' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/sourcedeb:/tmp/sourcedeb' +
+        ' -v $HOME/.ssh/known_hosts:/etc/ssh/ssh_known_hosts:ro' +
+        ' -v $SSH_AUTH_SOCK:/tmp/ssh_auth_sock' +
+        ' -e SSH_AUTH_SOCK=/tmp/ssh_auth_sock' +
         ' sourcedeb__%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, pkg_name),
         'echo "# END SECTION"',
     ]),
@@ -174,7 +177,7 @@
 ))@
 @(SNIPPET(
     'build-wrapper_ssh-agent',
-    credential_id=credential_id,
+    credential_id=git_ssh_credential_id,
 ))@
   </buildWrappers>
 </project>

--- a/ros_buildfarm/templates/snippet/scm.xml.em
+++ b/ros_buildfarm/templates/snippet/scm.xml.em
@@ -5,6 +5,7 @@
     branch_name=repo_spec.version,
     relative_target_dir=path,
     refspec=None,
+    git_ssh_credential_id=git_ssh_credential_id,
 ))@
 @[elif repo_spec.type == 'hg']@
 @(SNIPPET(

--- a/ros_buildfarm/templates/snippet/scm_git.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_git.xml.em
@@ -6,6 +6,9 @@
         <refspec>@ESCAPE(refspec)</refspec>
 @[end if]@
         <url>@ESCAPE(url)</url>
+@[if vars().get('git_ssh_credential_id')]@
+        <credentialsId>@git_ssh_credential_id</credentialsId>
+@[end if]@
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>

--- a/scripts/misc/generate_rosdistro_cache_job.py
+++ b/scripts/misc/generate_rosdistro_cache_job.py
@@ -52,6 +52,8 @@ def get_job_config(args, config):
 
         'notification_emails':
         config.distributions[args.rosdistro_name]['notification_emails'],
+
+        'git_ssh_credential_id': config.git_ssh_credential_id,
     })
     job_config = expand_template(template_name, job_data)
     return job_config


### PR DESCRIPTION
At a high level, I have made the following changes to support cloning git repositories via SSH in rosdistro cache jobs, devel jobs, doc jobs, and release jobs:

* I have added a parameter git_ssh_credential_id in the index.yaml of ros_buildfarm_config. This is the ID of a credential that has already been set on the master that should be used for git+ssh cloning. This parameter is optional.
* When this parameter is defined, it is inserted into the following places:
	* Jenkins SCM plugin configuration for devel and doc jobs
	* SSH agent configuration for rosdistro cache jobs and sourcedeb jobs
* I have edited the docker run parameters for sourcedeb and rosdistro cache jobs to forward the SSH agent into the container. This allows the SSH agent configuration set in the job to be used in a git clone operation running inside the container.

One notable limitation in the code in this PR is that it is assumed that one SSH key will provide access to all repositories accessed by the buildfarm. 

This PR depends on the changes in buildfarm_deployment [#72](https://github.com/ros-infrastructure/buildfarm_deployment/pull/72) which provide the following:

* A credential on the Jenkins master containing a private SSH key
* Entries in the known_hosts file on the slave corresponding to any servers hosting repositories that will be cloned over SSH. If these entries are not present, jobs will fail with a "Host key verification failed" error.
