### PR TITLE
improve missing source error. Fixes #97

### DIFF
--- a/scripts/prerelease/generate_prerelease_script.py
+++ b/scripts/prerelease/generate_prerelease_script.py
@@ -163,6 +163,11 @@ def main(argv=sys.argv[1:]):
 
     # use random source repo to pass to devel job template
     source_repository = deepcopy(list(repositories.values())[0])
+    if not source_repository:
+        print(("The repository '%s' does not have a source entry in the distribution " +
+               'file. We cannot generate a prerelease without a source entry.') % repo_name,
+              file=sys.stderr)
+        return 1
     source_repository.name = 'prerelease'
     print('Evaluating job templates...')
     configure_devel_job(


### PR DESCRIPTION
New error output:
```
$ ~/work/dbf/ros_buildfarm/scripts/prerelease/generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/master/index.yaml   jade default ubuntu trusty amd64   hector_slam   --level 1   --output-dir ./
Fetching buildfarm configuration...
Fetching rosdistro cache...
The repository 'hector_slam' did not have a source entry in the distribution file. We cannot generate a prerelease without a source entry.
```