### PR TITLE
Allow custom repo override of existing source entry

### DIFF
--- a/scripts/prerelease/generate_prerelease_script.py
+++ b/scripts/prerelease/generate_prerelease_script.py
@@ -130,10 +130,11 @@ def main(argv=sys.argv[1:]):
         repositories[repo_name] = source_repo
 
     for repo_name, repo_type, repo_url, version in args.custom_repo:
-        if repo_name in repositories:
-            print("The repository '%s' appears multiple times" % repo_name,
+        if repo_name in repositories and repositories[repo_name]:
+            print("custom_repos option overriding '%s' to pull via '%s' "
+                  "from '%s' with version '%s'. " %
+                  (repo_name, repo_type, repo_url, version),
                   file=sys.stderr)
-            return 1
         source_repo = RepositorySpecification(
             repo_name, {
                 'type': repo_type,


### PR DESCRIPTION
From @meyerj 's [comment](https://github.com/ros-infrastructure/ros_buildfarm/issues/97#issuecomment-155903982) 

The custom repo logic is not quite right.  if the source entry is defined it will refuse to override it. 

The new implementation will print to the screen if a url is being overridden instead of aborting. If the user multiply defines the overrides it will print each successive override. 

Without the patch:
```
tfoote@yeti:/tmp/prerelease Last: [1] (2s Seconds)
$ ~/work/dbf/ros_buildfarm/scripts/prerelease/generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/master/index.yaml   jade default ubuntu trusty amd64   hector_slam   --level 1   --output-dir ./ --custom-repo hector_slam:git:https://github.com/tu-darmstadt-ros-pkg/hector_slam.git:catkin hector_slam:git:https://github.com/tu-darmstadt-ros-pkg/hector_slam2.git:catkin hector_slam:git:https://github.com/tu-darmstadt-ros-pkg/hector_slam3.git:catkin
Fetching buildfarm configuration...
Fetching rosdistro cache...
The repository 'hector_slam' appears multiple times
tfoote@yeti:/tmp/prerelease Last: [1] (1s Seconds)
$ ~/work/dbf/ros_buildfarm/scripts/prerelease/generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/master/index.yaml   jade default ubuntu trusty amd64   hector_slam   --level 1   --output-dir ./ --custom-repo hector_slam:git:https://github.com/tu-darmstadt-ros-pkg/hector_slam.git:catkin
Fetching buildfarm configuration...
Fetching rosdistro cache...
The repository 'hector_slam' appears multiple times
tfoote@yeti:/tmp/prerelease Last: [1] (2s Seconds)
$ ~/work/dbf/ros_buildfarm/scripts/prerelease/generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/master/index.yaml   jade default ubuntu trusty amd64   hector_slam   --level 1   --output-dir ./ 
Fetching buildfarm configuration...
Fetching rosdistro cache...
The repository 'hector_slam' does not have a source entry in the distribution file. We cannot generate a prerelease without a source entry.
tfoote@yeti:/tmp/prerelease Last: [1] (2s Seconds)
```

With the patch
```
$ ~/work/dbf/ros_buildfarm/scripts/prerelease/generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/master/index.yaml   jade default ubuntu trusty amd64   hector_slam   --level 1   --output-dir ./ --custom-repo hector_slam:git:https://github.com/tu-darmstadt-ros-pkg/hector_slam.git:catkin hector_slam:git:https://github.com/tu-darmstadt-ros-pkg/hector_slam2.git:catkin hector_slam:git:https://github.com/tu-darmstadt-ros-pkg/hector_slam3.git:catkin
Fetching buildfarm configuration...
Fetching rosdistro cache...
custom_repos option overiding 'hector_slam' to 'git': 'https://github.com/tu-darmstadt-ros-pkg/hector_slam2.git' 'catkin'. 
custom_repos option overiding 'hector_slam' to 'git': 'https://github.com/tu-darmstadt-ros-pkg/hector_slam3.git' 'catkin'. 
Evaluating job templates...
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/log-rotator.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/property_github-project.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/property_job-priority.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/property_parameters-definition.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/property_requeue-job.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/scm.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/scm_git.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/trigger_poll.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_system-groovy_check-free-disk-space.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell_docker-info.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_check-docker.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell_key-files.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/publisher_xunit.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/publisher_mailer.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/build-wrapper_build-timeout.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/build-wrapper_timestamper.xml.em

Generated prerelease script - to execute it run:
  ./prerelease.sh
tfoote@yeti:/tmp/prerelease Last: [0] (2s Seconds)
$ ~/work/dbf/ros_buildfarm/scripts/prerelease/generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/master/index.yaml   jade default ubuntu trusty amd64   hector_slam   --level 1   --output-dir ./ --custom-repo hector_slam:git:https://github.com/tu-darmstadt-ros-pkg/hector_slam.git:catkin
Fetching buildfarm configuration...
Fetching rosdistro cache...
Evaluating job templates...
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/log-rotator.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/property_github-project.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/property_job-priority.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/property_parameters-definition.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/property_requeue-job.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/scm.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/scm_git.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/trigger_poll.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_system-groovy_check-free-disk-space.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell_docker-info.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_check-docker.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell_key-files.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/builder_shell.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/publisher_xunit.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/publisher_mailer.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/build-wrapper_build-timeout.xml.em
/usr/lib/python2.7/dist-packages/ros_buildfarm/templates/snippet/build-wrapper_timestamper.xml.em

Generated prerelease script - to execute it run:
  ./prerelease.sh
tfoote@yeti:/tmp/prerelease Last: [0] (2s Seconds)
$ ~/work/dbf/ros_buildfarm/scripts/prerelease/generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/master/index.yaml   jade default ubuntu trusty amd64   hector_slam   --level 1   --output-dir ./ 
Fetching buildfarm configuration...
Fetching rosdistro cache...
The repository 'hector_slam' does not have a source entry in the distribution file. We cannot generate a prerelease without a source entry.
```
