### PR TITLE
improve the behavior of import_upstream

### DIFF
--- a/doc/deploy_configuration.rst
+++ b/doc/deploy_configuration.rst
@@ -36,7 +36,7 @@ Import packages
 ^^^^^^^^^^^^^^^
 
 Trigger the job ``import_upstream`` to get all the required bootstrap packages
-into the repository.
+into the repository, with the ``EXECUTE_IMPORT`` option enabled.
 
 
 rosdistro cache

--- a/ros_buildfarm/templates/release/import_upstream_job.xml.em
+++ b/ros_buildfarm/templates/release/import_upstream_job.xml.em
@@ -19,6 +19,17 @@
     ],
 ))@
 @(SNIPPET(
+    'property_parameters-definition',
+    parameters=[
+        {
+            'type': 'boolean',
+            'name': 'EXECUTE_IMPORT',
+            'description': 'If this is not true, it will only do a dry run and print the expect import but not execute.',
+            'default_value': 'false',
+        },
+    ],
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
   </properties>
@@ -41,15 +52,18 @@
     'builder_shell',
     script='\n'.join([
         'echo "# BEGIN SECTION: import debian packages"',
+        'if [ "$EXECUTE_IMPORT" = "true" ]; then',
+        '  export COMMIT_ARG="--commit"',
+        'fi',
         'export PYTHONPATH=$WORKSPACE/reprepro-updater/src:$PYTHONPATH',
         'echo "# BEGIN SUBSECTION: import debian packages for ubuntu_building"',
-        'python -u $WORKSPACE/reprepro-updater/scripts/import_upstream.py ubuntu_building $config_file --commit',
+        'python -u $WORKSPACE/reprepro-updater/scripts/import_upstream.py ubuntu_building $config_file $COMMIT_ARG',
         'echo "# END SUBSECTION"',
         'echo "# BEGIN SUBSECTION: import debian packages for ubuntu_testing"',
-        'python -u $WORKSPACE/reprepro-updater/scripts/import_upstream.py ubuntu_testing $config_file --commit',
+        'python -u $WORKSPACE/reprepro-updater/scripts/import_upstream.py ubuntu_testing $config_file $COMMIT_ARG',
         'echo "# END SUBSECTION"',
         'echo "# BEGIN SUBSECTION: import debian packages for ubuntu_main"',
-        'python -u $WORKSPACE/reprepro-updater/scripts/import_upstream.py ubuntu_main $config_file --commit',
+        'python -u $WORKSPACE/reprepro-updater/scripts/import_upstream.py ubuntu_main $config_file $COMMIT_ARG',
         'echo "# END SUBSECTION"',
         'echo "# END SECTION"',
     ]),

--- a/ros_buildfarm/templates/release/import_upstream_job.xml.em
+++ b/ros_buildfarm/templates/release/import_upstream_job.xml.em
@@ -14,7 +14,8 @@
         {
             'type': 'string',
             'name': 'config_file',
-            'description': 'A specific yaml file or files. If unset it defaults to aggregating all yaml files in the directory defined by upstream_config in reprepro-updater.ini',
+            'description': 'A specific yaml file or files to use as reprepro_config arguments. The default is the ros_bootstrap config. If unset it defaults to aggregating all yaml files in the directory defined by upstream_config in reprepro-updater.ini(not recommended)',
+            'default_value': '/home/jenkins-slave/reprepro_config/ros_bootstrap.yaml',
         },
     ],
 ))@
@@ -24,7 +25,7 @@
         {
             'type': 'boolean',
             'name': 'EXECUTE_IMPORT',
-            'description': 'If this is not true, it will only do a dry run and print the expect import but not execute.',
+            'description': 'If this is not true, it will only do a dry run and print the expect import, but not execute.',
             'default_value': 'false',
         },
     ],


### PR DESCRIPTION
Default to only ros_bootstrap.

And add an option EXECUTE_IMPORT which when unset provides a dry run option. 
Where dryrun is the default. 

Connects to #128
Connects to ros-infrastructure/buildfarm_deployment#56