### PR TITLE
change sourcedeb job to use rosdistro cache

### DIFF
--- a/ros_buildfarm/sourcedeb_job.py
+++ b/ros_buildfarm/sourcedeb_job.py
@@ -7,10 +7,10 @@ from ros_buildfarm.release_common import dpkg_parsechangelog
 def get_sources(
         rosdistro_index_url, rosdistro_name, pkg_name, os_name, os_code_name,
         sources_dir):
-    from rosdistro import get_distribution_file
+    from rosdistro import get_cached_distribution
     from rosdistro import get_index
     index = get_index(rosdistro_index_url)
-    dist_file = get_distribution_file(index, rosdistro_name)
+    dist_file = get_cached_distribution(index, rosdistro_name)
     if pkg_name not in dist_file.release_packages:
         return 'Not a released package name: %s' % pkg_name
 


### PR DESCRIPTION
Fixes #41.

This sourcedeb job continues to work with the patch
http://build.ros.org/view/Isrc_uT/job/Isrc_uT__care_o_bot_desktop__ubuntu_trusty__source/8/console#console-section-4

Since we can't easily reproduce the problem since it is based dependent on the response of the GitHub CDN that's all I could check for now.