### PR TITLE
retry import of sourcedeb once without sending notifications of failed attempt

### DIFF
--- a/ros_buildfarm/templates/release/binarydeb_job.xml.em
+++ b/ros_buildfarm/templates/release/binarydeb_job.xml.em
@@ -219,6 +219,7 @@
     parameters='\n'.join([
         'subfolder=%s/${JOB_NAME}__${BUILD_NUMBER}' % os_code_name,
         'debian_package_name=%s' % debian_package_name]),
+    continue_on_failure=False,
 ))@
   </builders>
   <publishers>

--- a/ros_buildfarm/templates/release/sourcedeb_job.xml.em
+++ b/ros_buildfarm/templates/release/sourcedeb_job.xml.em
@@ -133,6 +133,10 @@
     parameters='\n'.join([
         'subfolder=%s/${JOB_NAME}__${BUILD_NUMBER}' % os_code_name,
         'debian_package_name=%s' % debian_package_name]),
+    continue_on_failure=True,
+))@
+@(SNIPPET(
+    'builder_system-groovy_check-triggered-build',
 ))@
   </builders>
   <publishers>

--- a/ros_buildfarm/templates/snippet/builder_parameterized-trigger.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_parameterized-trigger.xml.em
@@ -14,24 +14,28 @@
           <condition>ALWAYS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <block>
+@[if not continue_on_failure]@
             <buildStepFailureThreshold>
               <name>FAILURE</name>
               <ordinal>2</ordinal>
               <color>RED</color>
               <completeBuild>true</completeBuild>
             </buildStepFailureThreshold>
+@[end if]@
             <unstableThreshold>
               <name>UNSTABLE</name>
               <ordinal>1</ordinal>
               <color>YELLOW</color>
               <completeBuild>true</completeBuild>
             </unstableThreshold>
+@[if not continue_on_failure]@
             <failureThreshold>
               <name>FAILURE</name>
               <ordinal>2</ordinal>
               <color>RED</color>
               <completeBuild>true</completeBuild>
             </failureThreshold>
+@[end if]@
           </block>
           <buildAllNodesWithLabel>false</buildAllNodesWithLabel>
         </hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>

--- a/ros_buildfarm/templates/snippet/builder_system-groovy_check-triggered-build.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy_check-triggered-build.xml.em
@@ -1,0 +1,50 @@
+@(SNIPPET(
+    'builder_system-groovy',
+    command=
+"""// CHECK IF TRIGGERED BUILD HAS FAILED
+// only triggered when previous build step was successful
+import java.io.BufferedReader
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+import hudson.model.Cause
+import hudson.model.Result
+
+println "# BEGIN SECTION: Check if triggered build failed"
+
+try {
+  // search build output for failed build
+  r = build.getLogReader()
+  br = new BufferedReader(r)
+  pattern = Pattern.compile(".* completed. Result was FAILURE.*")
+  def line
+  while ((line = br.readLine()) != null) {
+    if (pattern.matcher(line).matches()) {
+      println "Aborting build since triggered build has failed"
+      // check if previous build was already rescheduling to avoid infinite loop
+      pr = build.getPreviousBuild().getLogReader()
+      if (pr) {
+        pbr = new BufferedReader(pr)
+        while ((line = pbr.readLine()) != null) {
+          if (pattern.matcher(line).matches()) {
+            println "Skip rescheduling new build since this was already a rescheduled build"
+            println ""
+            build.setResult(Result.FAILURE)
+            return
+          }
+        }
+      }
+      println "Immediately rescheduling new build..."
+      println ""
+      build.project.scheduleBuild(new Cause.UserIdCause())
+      throw new InterruptedException()
+    }
+  }
+  println "Pattern not found in build log, continuing..."
+} finally {
+  println "# END SECTION"
+}
+""",
+    script_file=None,
+    classpath='',
+))@


### PR DESCRIPTION
For each package N sourcedeb job are triggered - one for each target platform. Each job tries to import its artifact into the apt repo. All but the last one fail since other platforms are still depending on the `orig.tar.gz`.

This would not happen in the following ticket would be addressed: ros-infrastructure/bloom#150

While the failing sourcedeb jobs are automatically retriggered the notification emails for the failing runs are undesired. This is addressed by marking the sourcedeb job as `aborted` if the triggered import job failed and directly rescheduling another build (but only once to prevent infinite recursion).

This fixes ros-infrastructure/reprepro-updater#16

The debinc 1 shows the problem, while debinc 3 shows the working solution:
* http://54.183.26.131:8080/view/Isrc_uS/job/Isrc_uS__ax2550__ubuntu_saucy__source/
* http://54.183.26.131:8080/view/Isrc_uT/job/Isrc_uT__ax2550__ubuntu_trusty__source/
* http://54.183.26.131:8080/view/Manage/job/Irel_import-package-deb-inc/