### PR TITLE
Various

### DIFF
--- a/ros_buildfarm/git.py
+++ b/ros_buildfarm/git.py
@@ -112,6 +112,10 @@ def _get_git_repository_version(path):
         [git, 'rev-parse', '--abbrev-ref', 'HEAD'], cwd=path)
     url = url.decode().rstrip()
     if url != 'HEAD':
+        # get plain branch name on Jenkins
+        prefix = 'heads/origin/'
+        if url.startswith(prefix):
+            url = url[len(prefix):]
         return url
 
     # check if working copy is on a tag

--- a/ros_buildfarm/git.py
+++ b/ros_buildfarm/git.py
@@ -116,8 +116,10 @@ def _get_git_repository_version(path):
 
     # check if working copy is on a tag
     try:
-        tags = subprocess.check_output(
-            [git, 'describe', '--exact-match', '--tags'], cwd=path)
+        with open(os.devnull, 'w') as h:
+            tags = subprocess.check_output(
+                [git, 'describe', '--exact-match', '--tags'],
+                cwd=path, stderr=h)
         return tags.decode().splitlines()[0]
     except subprocess.CalledProcessError:
         pass

--- a/ros_buildfarm/templates/dashboard_view_all_jobs.xml.em
+++ b/ros_buildfarm/templates/dashboard_view_all_jobs.xml.em
@@ -25,6 +25,7 @@
   <recurse>false</recurse>
   <useCssStyle>false</useCssStyle>
   <includeStdJobList>false</includeStdJobList>
+  <hideJenkinsPanels>false</hideJenkinsPanels>
   <leftPortletWidth>50%</leftPortletWidth>
   <rightPortletWidth>50%</rightPortletWidth>
   <leftPortlets/>

--- a/ros_buildfarm/templates/dashboard_view_devel_jobs.xml.em
+++ b/ros_buildfarm/templates/dashboard_view_devel_jobs.xml.em
@@ -28,6 +28,7 @@
   <recurse>false</recurse>
   <useCssStyle>false</useCssStyle>
   <includeStdJobList>false</includeStdJobList>
+  <hideJenkinsPanels>false</hideJenkinsPanels>
   <leftPortletWidth>50%</leftPortletWidth>
   <rightPortletWidth>50%</rightPortletWidth>
   <leftPortlets>

--- a/ros_buildfarm/templates/snippet/scm_git.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_git.xml.em
@@ -28,5 +28,8 @@
         <shallow>true</shallow>
         <reference/>
       </hudson.plugins.git.extensions.impl.CloneOption>
+      <hudson.plugins.git.extensions.impl.LocalBranch>
+        <localBranch>$GIT_BRANCH</localBranch>
+      </hudson.plugins.git.extensions.impl.LocalBranch>
     </extensions>
   </scm>


### PR DESCRIPTION
The first commit will get rid of the diff when configuring views: http://build.ros.org/job/Jdev_reconfigure-jobs/9/consoleFull#console-section-5

The second commit suppressed the `fatal: ...` error message in http://build.ros.org/job/Jdev_reconfigure-jobs/9/console

The third commit fixes the problem that the reconfigure job embeds the current hash into every job (http://build.ros.org/job/Jrel_reconfigure-jobs/8/console). Instead it should use the branch name which will prevent long reconfiguration times every night.