### PR TITLE
fallback to get branch name when detached

### DIFF
--- a/ros_buildfarm/git.py
+++ b/ros_buildfarm/git.py
@@ -128,6 +128,15 @@ def _get_git_repository_version(path):
     except subprocess.CalledProcessError:
         pass
 
+    # if the HEAD is detached the only way to retrieve the branch is
+    # looking for the environment variable set by Jenkins
+    env_var = 'GIT_BRANCH'
+    if env_var in os.environ:
+        git_branch = os.environ[env_var]
+        prefix = 'origin/'
+        if git_branch.startswith(prefix):
+            return git_branch[len(prefix):]
+
     # use current hash
     return get_hash(path)
 

--- a/ros_buildfarm/templates/snippet/scm_git.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_git.xml.em
@@ -28,8 +28,5 @@
         <shallow>true</shallow>
         <reference/>
       </hudson.plugins.git.extensions.impl.CloneOption>
-      <hudson.plugins.git.extensions.impl.LocalBranch>
-        <localBranch>$GIT_BRANCH</localBranch>
-      </hudson.plugins.git.extensions.impl.LocalBranch>
     </extensions>
   </scm>


### PR DESCRIPTION
Workaround for Jenkins issue introduced with #144.