### PR TITLE
ensure that folder can be removed

### DIFF
--- a/ros_buildfarm/templates/release/binarydeb_job.xml.em
+++ b/ros_buildfarm/templates/release/binarydeb_job.xml.em
@@ -110,6 +110,8 @@
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - binarydeb task"',
+        '# ensure to have write permission before trying to delete the folder',
+        'if [ -f $WORKSPACE/binarydeb ] ; then chmod -R u+w $WORKSPACE/binarydeb ; fi',
         'rm -fr $WORKSPACE/binarydeb',
         'rm -fr $WORKSPACE/docker_build_binarydeb',
         'mkdir -p $WORKSPACE/binarydeb',
@@ -160,6 +162,8 @@
     script='\n'.join([
         'if [ "$skip_cleanup" = "false" ]; then',
         'echo "# BEGIN SECTION: Clean up to save disk space on slaves"',
+        '# ensure to have write permission before trying to delete the folder',
+        'chmod -R u+w $WORKSPACE/binarydeb',
         'rm -fr binarydeb/*/*',
         'echo "# END SECTION"',
         'fi',


### PR DESCRIPTION
This was necessary to build http://build.ros.org/view/Ibin_uT64/job/Ibin_uT64__sr_external_dependencies__ubuntu_trusty_amd64__binary/ successfully.

While the Jenkins user is still the owner he doesn't have write permissions for the directories (due to what the ROS package does internally when building the deb) which makes the `rm -fr` command fail.