### PR TITLE
catch invalid rosdoc yaml

### DIFF
--- a/scripts/doc/build_doc.py
+++ b/scripts/doc/build_doc.py
@@ -167,18 +167,24 @@ def get_generator_output_folders(pkg_rosdoc_config_file, pkg_name):
     output_folders = {}
     if pkg_rosdoc_config_file:
         with open(pkg_rosdoc_config_file, 'r') as h:
-            data = yaml.load(h.read())
-        if not isinstance(data, list):
-            print("WARNING: package '%s' has an invalid rosdoc config" %
-                  pkg_name, file=sys.stderr)
+            content = h.read()
+        try:
+            data = yaml.load(content)
+        except Exception as e:
+            print("WARNING: package '%s' has an invalid rosdoc config: %s" %
+                  (pkg_name, e), file=sys.stderr)
         else:
-            for item in data:
-                if 'builder' not in item:
-                    print("WARNING: package '%s' has an invalid rosdoc config "
-                          "- missing builder key" % pkg_name, file=sys.stderr)
-                    continue
-                if item.get('output_dir'):
-                    output_folders[item['builder']] = item['output_dir']
+            if not isinstance(data, list):
+                print("WARNING: package '%s' has an invalid rosdoc config" %
+                      pkg_name, file=sys.stderr)
+            else:
+                for item in data:
+                    if 'builder' not in item:
+                        print("WARNING: package '%s' has an invalid rosdoc config "
+                              "- missing builder key" % pkg_name, file=sys.stderr)
+                        continue
+                    if item.get('output_dir'):
+                        output_folders[item['builder']] = item['output_dir']
     return output_folders
 
 


### PR DESCRIPTION
This will let this doc job pass (as it did before): http://build.ros.org/view/Idoc/job/Idoc__asctec_mav_framework__ubuntu_trusty_amd64/4/console

For this new as well as other existing `WARNINGS` the job should actually be marked marked unstable...