### PR TITLE
add known error string to apt-get wrapper

### DIFF
--- a/scripts/wrapper/apt-get.py
+++ b/scripts/wrapper/apt-get.py
@@ -7,7 +7,11 @@ from time import sleep
 
 def main(argv=sys.argv[1:]):
     max_tries = 10
-    known_error_strings = ['Failed to fetch', 'Hash Sum mismatch']
+    known_error_strings = [
+        'Failed to fetch',
+        'Hash Sum mismatch',
+        'is not what the server reported',
+    ]
 
     command = argv[0]
     if command == 'update':


### PR DESCRIPTION
Should catch http://build.ros.org/view/All/job/Idev__ridgeback__ubuntu_trusty_amd64/3/console next time.