### PR TITLE
improve the error message printed when a package build fails

### DIFF
--- a/ros_buildfarm/binarydeb_job.py
+++ b/ros_buildfarm/binarydeb_job.py
@@ -1,6 +1,8 @@
 import os
 import subprocess
+import sys
 from time import strftime
+import traceback
 
 from ros_buildfarm.common import get_debian_package_name
 from ros_buildfarm.release_common import dpkg_parsechangelog
@@ -86,7 +88,18 @@ def build_binarydeb(rosdistro_name, package_name, sourcedeb_dir):
 
     cmd = ['apt-src', 'build', source]
     print("Invoking '%s' in '%s'" % (' '.join(cmd), source_dir))
-    subprocess.check_call(cmd, cwd=source_dir)
+    try:
+        subprocess.check_call(cmd, cwd=source_dir)
+    except subprocess.CalledProcessError:
+        traceback.print_exc()
+        sys.exit("""
+--------------------------------------------------------------------------------------------------
+`{0}` failed.
+This is usually because of an error building the package.
+The traceback from this failure (just above) is printed for completeness, but you can ignore it.
+You should look above `E: Building failed` in the build log for the actual cause of the failure.
+--------------------------------------------------------------------------------------------------
+""".format(' '.join(cmd)))
 
 
 def _get_package_subfolders(basepath, debian_package_name):


### PR DESCRIPTION
When a binary job fails for a package you get something like this:

```
[ 16%] Building CXX object CMakeFiles/freefloating_gazebo_control.dir/src/freefloating_gazebo_control.cpp.o
/usr/lib/ccache/i686-linux-gnu-g++   -DROSCONSOLE_BACKEND_LOG4CXX -DROS_PACKAGE_NAME=\"freefloating_gazebo\" -Dfreefloating_gazebo_control_EXPORTS -std=c++0x -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -DNDEBUG -D_FORTIFY_SOURCE=2  -fPIC -I/tmp/binarydeb/ros-jade-freefloating-gazebo-1.0.3/obj-i686-linux-gnu/devel/include -I/tmp/binarydeb/ros-jade-freefloating-gazebo-1.0.3/include -I/opt/ros/jade/include -I/usr/include/gazebo-5.0 -I/usr/include/sdformat-2.3 -I/usr/include/OGRE -I/usr/include/OGRE/Terrain -I/usr/include/OGRE/Paging    -o CMakeFiles/freefloating_gazebo_control.dir/src/freefloating_gazebo_control.cpp.o -c /tmp/binarydeb/ros-jade-freefloating-gazebo-1.0.3/src/freefloating_gazebo_control.cpp
In file included from /tmp/binarydeb/ros-jade-freefloating-gazebo-1.0.3/src/freefloating_gazebo_control.cpp:14:0:
/tmp/binarydeb/ros-jade-freefloating-gazebo-1.0.3/include/freefloating_gazebo/freefloating_gazebo_control.h:14:29: fatal error: eigen3/Eigen/Core: No such file or directory
 #include <eigen3/Eigen/Core>
                             ^
compilation terminated.
CMakeFiles/freefloating_gazebo_control.dir/build.make:57: recipe for target 'CMakeFiles/freefloating_gazebo_control.dir/src/freefloating_gazebo_control.cpp.o' failed
make[4]: *** [CMakeFiles/freefloating_gazebo_control.dir/src/freefloating_gazebo_control.cpp.o] Error 1
make[4]: Leaving directory '/tmp/binarydeb/ros-jade-freefloating-gazebo-1.0.3/obj-i686-linux-gnu'
CMakeFiles/Makefile2:776: recipe for target 'CMakeFiles/freefloating_gazebo_control.dir/all' failed
make[3]: *** [CMakeFiles/freefloating_gazebo_control.dir/all] Error 2
make[3]: Leaving directory '/tmp/binarydeb/ros-jade-freefloating-gazebo-1.0.3/obj-i686-linux-gnu'
Makefile:120: recipe for target 'all' failed
make[2]: *** [all] Error 2
make[2]: Leaving directory '/tmp/binarydeb/ros-jade-freefloating-gazebo-1.0.3/obj-i686-linux-gnu'
dh_auto_build: make -j1 returned exit code 2
debian/rules:36: recipe for target 'override_dh_auto_build' failed
make[1]: *** [override_dh_auto_build] Error 2
make[1]: Leaving directory '/tmp/binarydeb/ros-jade-freefloating-gazebo-1.0.3'
debian/rules:23: recipe for target 'build' failed
make: *** [build] Error 2
dpkg-buildpackage: error: debian/rules build gave error exit status 2
E: Building failed
# END SUBSECTION
Traceback (most recent call last):
  File "/tmp/ros_buildfarm/scripts/release/build_binarydeb.py", line 27, in <module>
    sys.exit(main())
  File "/tmp/ros_buildfarm/scripts/release/build_binarydeb.py", line 23, in main
    args.rosdistro_name, args.package_name, args.sourcedeb_dir)
  File "/tmp/ros_buildfarm/ros_buildfarm/binarydeb_job.py", line 89, in build_binarydeb
    subprocess.check_call(cmd, cwd=source_dir)
  File "/usr/lib/python3.4/subprocess.py", line 561, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['apt-src', 'build', 'ros-jade-freefloating-gazebo']' returned non-zero exit status 1
Build step 'Execute shell' marked build as failure
[ssh-agent] Stopped.
[description-setter] Could not determine description.
```

The failure is a result of a failed include in C++, but the traceback at the end can be misleading. This pull request just catches that failure and provides a helpful message. It should look something like this:

```
[ 16%] Building CXX object CMakeFiles/freefloating_gazebo_control.dir/src/freefloating_gazebo_control.cpp.o
/usr/lib/ccache/i686-linux-gnu-g++   -DROSCONSOLE_BACKEND_LOG4CXX -DROS_PACKAGE_NAME=\"freefloating_gazebo\" -Dfreefloating_gazebo_control_EXPORTS -std=c++0x -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -DNDEBUG -D_FORTIFY_SOURCE=2  -fPIC -I/tmp/binarydeb/ros-jade-freefloating-gazebo-1.0.3/obj-i686-linux-gnu/devel/include -I/tmp/binarydeb/ros-jade-freefloating-gazebo-1.0.3/include -I/opt/ros/jade/include -I/usr/include/gazebo-5.0 -I/usr/include/sdformat-2.3 -I/usr/include/OGRE -I/usr/include/OGRE/Terrain -I/usr/include/OGRE/Paging    -o CMakeFiles/freefloating_gazebo_control.dir/src/freefloating_gazebo_control.cpp.o -c /tmp/binarydeb/ros-jade-freefloating-gazebo-1.0.3/src/freefloating_gazebo_control.cpp
In file included from /tmp/binarydeb/ros-jade-freefloating-gazebo-1.0.3/src/freefloating_gazebo_control.cpp:14:0:
/tmp/binarydeb/ros-jade-freefloating-gazebo-1.0.3/include/freefloating_gazebo/freefloating_gazebo_control.h:14:29: fatal error: eigen3/Eigen/Core: No such file or directory
 #include <eigen3/Eigen/Core>
                             ^
compilation terminated.
CMakeFiles/freefloating_gazebo_control.dir/build.make:57: recipe for target 'CMakeFiles/freefloating_gazebo_control.dir/src/freefloating_gazebo_control.cpp.o' failed
make[4]: *** [CMakeFiles/freefloating_gazebo_control.dir/src/freefloating_gazebo_control.cpp.o] Error 1
make[4]: Leaving directory '/tmp/binarydeb/ros-jade-freefloating-gazebo-1.0.3/obj-i686-linux-gnu'
CMakeFiles/Makefile2:776: recipe for target 'CMakeFiles/freefloating_gazebo_control.dir/all' failed
make[3]: *** [CMakeFiles/freefloating_gazebo_control.dir/all] Error 2
make[3]: Leaving directory '/tmp/binarydeb/ros-jade-freefloating-gazebo-1.0.3/obj-i686-linux-gnu'
Makefile:120: recipe for target 'all' failed
make[2]: *** [all] Error 2
make[2]: Leaving directory '/tmp/binarydeb/ros-jade-freefloating-gazebo-1.0.3/obj-i686-linux-gnu'
dh_auto_build: make -j1 returned exit code 2
debian/rules:36: recipe for target 'override_dh_auto_build' failed
make[1]: *** [override_dh_auto_build] Error 2
make[1]: Leaving directory '/tmp/binarydeb/ros-jade-freefloating-gazebo-1.0.3'
debian/rules:23: recipe for target 'build' failed
make: *** [build] Error 2
dpkg-buildpackage: error: debian/rules build gave error exit status 2
E: Building failed
# END SUBSECTION
Traceback (most recent call last):
  File "/tmp/ros_buildfarm/scripts/release/build_binarydeb.py", line 27, in <module>
    sys.exit(main())
  File "/tmp/ros_buildfarm/scripts/release/build_binarydeb.py", line 23, in main
    args.rosdistro_name, args.package_name, args.sourcedeb_dir)
  File "/tmp/ros_buildfarm/ros_buildfarm/binarydeb_job.py", line 89, in build_binarydeb
    subprocess.check_call(cmd, cwd=source_dir)
  File "/usr/lib/python3.4/subprocess.py", line 561, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['apt-src', 'build', 'ros-jade-freefloating-gazebo']' returned non-zero exit status 1

--------------------------------------------------------------------------------------------------
`apt-src build ros-jade-freefloating-gazebo` failed.
This is usually because of an error building the package.
The traceback from this failure (just above) is printed for completeness, but you can ignore it.
You should look above `E: Building failed` in the build log for the actual cause of the failure.
--------------------------------------------------------------------------------------------------

Build step 'Execute shell' marked build as failure
[ssh-agent] Stopped.
[description-setter] Could not determine description.
```