### PR TITLE
abort on low free disk space

### DIFF
--- a/ros_buildfarm/templates/snippet/builder_system-groovy_check-free-disk-space.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy_check-free-disk-space.xml.em
@@ -2,7 +2,6 @@
     'builder_system-groovy',
     command=
 """// VERFIY THAT FREE DISK SPACE THRESHOLD IS NOT VIOLATED
-import hudson.AbortException
 import hudson.model.Cause.UserIdCause
 import hudson.node_monitors.AbstractDiskSpaceMonitor
 import hudson.node_monitors.DiskSpaceMonitor
@@ -44,7 +43,7 @@ try {
       build.getActions().add(GroovyPostbuildAction.createInfoBadge("Free disk space is too low, disabled slave '" + computer.name + "', rescheduled job"))
 
       // abort this build
-      throw new AbortException("Aborting build due to free disk space being lower than the threshold")
+      throw new InterruptedException()
     }
     break
   }

--- a/ros_buildfarm/templates/snippet/builder_system-groovy_check-triggered-build.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy_check-triggered-build.xml.em
@@ -44,6 +44,7 @@ try {
       println ""
       println "Aborting build, will be rescheduled automatically..."
       println ""
+      // abort this build
       throw new InterruptedException()
     }
   }

--- a/ros_buildfarm/templates/snippet/builder_system-groovy_verify-upstream.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy_verify-upstream.xml.em
@@ -51,6 +51,7 @@ def check_recursive_upstream_projects(project, checked_projects, depth=0) {
     }
     success = check_project(upstream, depth)
     if (!success) {
+      // abort this build
       throw new InterruptedException()
     }
     check_recursive_upstream_projects(upstream, checked_projects, depth + 1)

--- a/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
+++ b/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
@@ -100,6 +100,7 @@ dir.eachFileRecurse (FileType.FILES) { file ->
 
 if (jobs.size() != @(expected_num_jobs)) {
     println "ERROR: Found different number of job configs than expected!! " + jobs.size() + " is not @(expected_num_jobs) as expected."
+    // fail this build
     throw new AbortException("Wrong number of job configs")
 }
 


### PR DESCRIPTION
Fixes #162.

Also adds comments to clarify behavior of non-intuitively named exceptions.