### PR TITLE
catch socket errors

### DIFF
--- a/ros_buildfarm/config/loader.py
+++ b/ros_buildfarm/config/loader.py
@@ -61,6 +61,8 @@ def load_url(url, retry=2, retry_period=1, timeout=10, skip_decode=False):
                 url, retry=retry - 1, retry_period=retry_period,
                 timeout=timeout)
         raise URLError(str(e) + ' (%s)' % url)
+    except socket.timeout as e:
+        raise socket.timeout(str(e) + ' (%s)' % url)
     # Python 2/3 Compatibility
     contents = fh.read()
     if isinstance(contents, str) or skip_decode:


### PR DESCRIPTION
This hit us a bunch last night such as: http://54.183.26.131:8080/job/Irel_release-status-page/27614/

The traceback does not show the url which failed to load. 

