### PR TITLE
use exact sourcedeb version when building binarydeb

### DIFF
--- a/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
@@ -57,6 +57,7 @@ ENTRYPOINT ["sh", "-c"]
 cmds = [
     'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' +
     ' /tmp/ros_buildfarm/scripts/release/get_sourcedeb.py' +
+    ' --rosdistro-index-url ' + rosdistro_index_url +
     ' ' + rosdistro_name +
     ' ' + package_name +
     ' --sourcedeb-dir ' + binarydeb_dir +

--- a/scripts/release/get_sourcedeb.py
+++ b/scripts/release/get_sourcedeb.py
@@ -4,6 +4,7 @@ import argparse
 import sys
 
 from ros_buildfarm.argument import add_argument_package_name
+from ros_buildfarm.argument import add_argument_rosdistro_index_url
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.argument import add_argument_skip_download_sourcedeb
 from ros_buildfarm.argument import add_argument_sourcedeb_dir
@@ -15,6 +16,7 @@ def main(argv=sys.argv[1:]):
     with Scope('SUBSECTION', 'get sourcedeb'):
         parser = argparse.ArgumentParser(
             description='Get released package sourcedeb')
+        add_argument_rosdistro_index_url(parser)
         add_argument_rosdistro_name(parser)
         add_argument_package_name(parser)
         add_argument_sourcedeb_dir(parser)
@@ -22,8 +24,8 @@ def main(argv=sys.argv[1:]):
         args = parser.parse_args(argv)
 
         return get_sourcedeb(
-            args.rosdistro_name, args.package_name, args.sourcedeb_dir,
-            args.skip_download_sourcedeb)
+            args.rosdistro_index_url, args.rosdistro_name, args.package_name,
+            args.sourcedeb_dir, args.skip_download_sourcedeb)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I modified the patch mentioned in #114 to use the distro cache rather then the distro file directly. I also added some asserts just in case something is not as expected.

See http://build.ros.org/job/Ibin_uT64__ax2550__ubuntu_trusty_amd64__binary/10/consoleFull#console-section-10

Connect to #114.