### PR TITLE
add dry run option

### DIFF
--- a/doc/deploy_configuration.rst
+++ b/doc/deploy_configuration.rst
@@ -20,6 +20,12 @@ accordingly)::
 
   generate_all_jobs.py https://raw.githubusercontent.com/YOUR_FORK/ros_buildfarm_config/master/index.yaml
 
+By default the script will only show the desired Jenkins configuration (or
+changes compared to the existing configuration) but not actually change
+any view or job on Jenkins.
+To actually perform the configuration you must pass the option `--commit` to
+the script.
+
 Instead of generating all jobs at once there are similar scripts to only deploy
 the jobs of a specific type.
 

--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -218,3 +218,10 @@ def add_argument_vcs_information(parser):
         '--vcs-info',
         required=True,
         help='The vcs type, version and url separated by a space')
+
+
+def add_argument_dry_run(parser):
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help="Only show the changes without apply them to Jenkins")

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -273,11 +273,11 @@ def configure_devel_job(
     return job_name, job_config
 
 
-def configure_devel_view(jenkins, view_name):
+def configure_devel_view(jenkins, view_name, dry_run=False):
     from ros_buildfarm.jenkins import configure_view
     return configure_view(
         jenkins, view_name, include_regex='%s__.+' % view_name,
-        template_name='dashboard_view_devel_jobs.xml.em')
+        template_name='dashboard_view_devel_jobs.xml.em', dry_run=dry_run)
 
 
 def _get_devel_job_config(

--- a/ros_buildfarm/doc_job.py
+++ b/ros_buildfarm/doc_job.py
@@ -216,11 +216,11 @@ def configure_doc_job(
     return job_name, job_config
 
 
-def configure_doc_view(jenkins, view_name):
+def configure_doc_view(jenkins, view_name, dry_run=False):
     from ros_buildfarm.jenkins import configure_view
     return configure_view(
         jenkins, view_name, include_regex='%s__.+' % view_name,
-        template_name='dashboard_view_all_jobs.xml.em')
+        template_name='dashboard_view_all_jobs.xml.em', dry_run=dry_run)
 
 
 def _get_doc_job_config(
@@ -291,7 +291,7 @@ def _get_doc_job_config(
 
 def configure_doc_metadata_job(
         config_url, rosdistro_name, doc_build_name,
-        config=None, build_file=None):
+        config=None, build_file=None, dry_run=False):
     if config is None:
         config = get_config_index(config_url)
     if build_file is None:
@@ -308,7 +308,7 @@ def configure_doc_metadata_job(
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
     if isinstance(jenkins, object) and jenkins is not False:
         from ros_buildfarm.jenkins import configure_job
-        configure_job(jenkins, job_name, job_config)
+        configure_job(jenkins, job_name, job_config, dry_run=dry_run)
 
 
 def _get_doc_metadata_job_config(
@@ -342,7 +342,8 @@ def _get_doc_metadata_job_config(
 
 
 def configure_doc_independent_job(
-        config_url, doc_build_name, config=None, build_file=None):
+        config_url, doc_build_name, config=None, build_file=None,
+        dry_run=False):
     if config is None:
         config = get_config_index(config_url)
     if build_file is None:
@@ -359,7 +360,7 @@ def configure_doc_independent_job(
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
     if isinstance(jenkins, object) and jenkins is not False:
         from ros_buildfarm.jenkins import configure_job
-        configure_job(jenkins, job_name, job_config)
+        configure_job(jenkins, job_name, job_config, dry_run=dry_run)
 
 
 def _get_doc_independent_job_config(

--- a/scripts/doc/generate_doc_independent_job.py
+++ b/scripts/doc/generate_doc_independent_job.py
@@ -5,6 +5,7 @@ import sys
 
 from ros_buildfarm.argument import add_argument_build_name
 from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_dry_run
 from ros_buildfarm.config import get_global_doc_build_files
 from ros_buildfarm.config import get_index
 from ros_buildfarm.config.doc_build_file import DOC_TYPE_MAKE
@@ -16,6 +17,7 @@ def main(argv=sys.argv[1:]):
         description="Generate a 'doc_independent' job on Jenkins")
     add_argument_config_url(parser)
     add_argument_build_name(parser, 'doc')
+    add_argument_dry_run(parser)
     args = parser.parse_args(argv)
 
     config = get_index(args.config_url)
@@ -30,7 +32,7 @@ def main(argv=sys.argv[1:]):
 
     return configure_doc_independent_job(
         args.config_url, args.doc_build_name,
-        config=config, build_file=build_file)
+        config=config, build_file=build_file, dry_run=args.dry_run)
 
 
 if __name__ == '__main__':

--- a/scripts/doc/generate_doc_maintenance_jobs.py
+++ b/scripts/doc/generate_doc_maintenance_jobs.py
@@ -6,6 +6,7 @@ import sys
 
 from ros_buildfarm.argument import add_argument_build_name
 from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_dry_run
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.common import get_doc_view_name
 from ros_buildfarm.common import \
@@ -27,6 +28,7 @@ def main(argv=sys.argv[1:]):
     add_argument_config_url(parser)
     add_argument_rosdistro_name(parser)
     add_argument_build_name(parser, 'doc')
+    add_argument_dry_run(parser)
     args = parser.parse_args(argv)
 
     config = get_index(args.config_url)
@@ -40,20 +42,21 @@ def main(argv=sys.argv[1:]):
         return 1
 
     jenkins = connect(config.jenkins_url)
-    configure_management_view(jenkins)
+    configure_management_view(jenkins, dry_run=args.dry_run)
     group_name = get_doc_view_name(
         args.rosdistro_name, args.doc_build_name)
 
     configure_reconfigure_jobs_job(
-        jenkins, group_name, args, config, build_file)
-    configure_trigger_jobs_job(jenkins, group_name, build_file)
+        jenkins, group_name, args, config, build_file, dry_run=args.dry_run)
+    configure_trigger_jobs_job(
+        jenkins, group_name, build_file, dry_run=args.dry_run)
 
 
 def configure_reconfigure_jobs_job(
-        jenkins, group_name, args, config, build_file):
+        jenkins, group_name, args, config, build_file, dry_run=False):
     job_config = get_reconfigure_jobs_job_config(args, config, build_file)
     job_name = '%s_%s' % (group_name, 'reconfigure-jobs')
-    configure_job(jenkins, job_name, job_config)
+    configure_job(jenkins, job_name, job_config, dry_run=dry_run)
 
 
 def get_reconfigure_jobs_job_config(args, config, build_file):
@@ -85,10 +88,10 @@ def get_reconfigure_jobs_job_config(args, config, build_file):
 
 
 def configure_trigger_jobs_job(
-        jenkins, group_name, build_file):
+        jenkins, group_name, build_file, dry_run=False):
     job_config = get_trigger_jobs_job_config(group_name, build_file)
     job_name = '%s_%s' % (group_name, 'trigger-jobs')
-    configure_job(jenkins, job_name, job_config)
+    configure_job(jenkins, job_name, job_config, dry_run=dry_run)
 
 
 def get_trigger_jobs_job_config(group_name, build_file):

--- a/scripts/doc/generate_doc_metadata_job.py
+++ b/scripts/doc/generate_doc_metadata_job.py
@@ -5,6 +5,7 @@ import sys
 
 from ros_buildfarm.argument import add_argument_build_name
 from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_dry_run
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.config import get_doc_build_files
 from ros_buildfarm.config import get_index
@@ -18,6 +19,7 @@ def main(argv=sys.argv[1:]):
     add_argument_config_url(parser)
     add_argument_rosdistro_name(parser)
     add_argument_build_name(parser, 'doc')
+    add_argument_dry_run(parser)
     args = parser.parse_args(argv)
 
     config = get_index(args.config_url)
@@ -32,7 +34,7 @@ def main(argv=sys.argv[1:]):
 
     return configure_doc_metadata_job(
         args.config_url, args.rosdistro_name, args.doc_build_name,
-        config=config, build_file=build_file)
+        config=config, build_file=build_file, dry_run=args.dry_run)
 
 
 if __name__ == '__main__':

--- a/scripts/misc/generate_check_slaves_job.py
+++ b/scripts/misc/generate_check_slaves_job.py
@@ -4,6 +4,7 @@ import argparse
 import sys
 
 from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_dry_run
 from ros_buildfarm.config import get_index
 from ros_buildfarm.jenkins import configure_job
 from ros_buildfarm.jenkins import configure_management_view
@@ -15,6 +16,7 @@ def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
         description="Generate the 'check_slaves' job on Jenkins")
     add_argument_config_url(parser)
+    add_argument_dry_run(parser)
     args = parser.parse_args(argv)
 
     config = get_index(args.config_url)
@@ -22,10 +24,10 @@ def main(argv=sys.argv[1:]):
 
     jenkins = connect(config.jenkins_url)
 
-    configure_management_view(jenkins)
+    configure_management_view(jenkins, dry_run=args.dry_run)
 
     job_name = 'check_slaves'
-    configure_job(jenkins, job_name, job_config)
+    configure_job(jenkins, job_name, job_config, dry_run=args.dry_run)
 
 
 def get_job_config(notification_emails):

--- a/scripts/misc/generate_dashboard_job.py
+++ b/scripts/misc/generate_dashboard_job.py
@@ -4,6 +4,7 @@ import argparse
 import sys
 
 from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_dry_run
 from ros_buildfarm.config import get_index
 from ros_buildfarm.jenkins import configure_job
 from ros_buildfarm.jenkins import configure_management_view
@@ -15,6 +16,7 @@ def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
         description="Generate the 'dashboard' job on Jenkins")
     add_argument_config_url(parser)
+    add_argument_dry_run(parser)
     args = parser.parse_args(argv)
 
     config = get_index(args.config_url)
@@ -22,10 +24,10 @@ def main(argv=sys.argv[1:]):
 
     jenkins = connect(config.jenkins_url)
 
-    configure_management_view(jenkins)
+    configure_management_view(jenkins, dry_run=args.dry_run)
 
     job_name = 'dashboard'
-    configure_job(jenkins, job_name, job_config)
+    configure_job(jenkins, job_name, job_config, dry_run=args.dry_run)
 
 
 def get_job_config(notification_emails):

--- a/scripts/misc/generate_rosdistro_cache_job.py
+++ b/scripts/misc/generate_rosdistro_cache_job.py
@@ -5,6 +5,7 @@ import copy
 import sys
 
 from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_dry_run
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.common import \
     get_repositories_and_script_generating_key_files
@@ -21,6 +22,7 @@ def main(argv=sys.argv[1:]):
         description="Generate the 'dashboard' job on Jenkins")
     add_argument_config_url(parser)
     add_argument_rosdistro_name(parser)
+    add_argument_dry_run(parser)
     args = parser.parse_args(argv)
 
     config = get_index(args.config_url)
@@ -28,10 +30,10 @@ def main(argv=sys.argv[1:]):
 
     jenkins = connect(config.jenkins_url)
 
-    configure_management_view(jenkins)
+    configure_management_view(jenkins, dry_run=args.dry_run)
 
     job_name = '%s_rosdistro-cache' % args.rosdistro_name
-    configure_job(jenkins, job_name, job_config)
+    configure_job(jenkins, job_name, job_config, dry_run=args.dry_run)
 
 
 def get_job_config(args, config):

--- a/scripts/release/generate_release_maintenance_jobs.py
+++ b/scripts/release/generate_release_maintenance_jobs.py
@@ -6,6 +6,7 @@ import sys
 
 from ros_buildfarm.argument import add_argument_build_name
 from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_dry_run
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.config import get_index
 from ros_buildfarm.config import get_release_build_files
@@ -28,6 +29,7 @@ def main(argv=sys.argv[1:]):
     add_argument_config_url(parser)
     add_argument_rosdistro_name(parser)
     add_argument_build_name(parser, 'release')
+    add_argument_dry_run(parser)
     args = parser.parse_args(argv)
 
     config = get_index(args.config_url)
@@ -49,21 +51,25 @@ def main(argv=sys.argv[1:]):
 
     jenkins = connect(config.jenkins_url)
 
-    configure_management_view(jenkins)
+    configure_management_view(jenkins, dry_run=args.dry_run)
 
     job_name = '%s_%s' % (group_name, 'reconfigure-jobs')
-    configure_job(jenkins, job_name, reconfigure_jobs_job_config)
+    configure_job(
+        jenkins, job_name, reconfigure_jobs_job_config, dry_run=args.dry_run)
 
     job_name = '%s_%s' % (group_name, 'trigger-jobs')
-    configure_job(jenkins, job_name, trigger_jobs_job_config)
+    configure_job(
+        jenkins, job_name, trigger_jobs_job_config, dry_run=args.dry_run)
 
     job_name = 'import_upstream'
-    configure_job(jenkins, job_name, import_upstream_job_config)
+    configure_job(
+        jenkins, job_name, import_upstream_job_config, dry_run=args.dry_run)
 
     job_name = '%s_%s' % \
         (group_name, 'trigger-broken-with-non-broken-upstream')
     configure_job(
-        jenkins, job_name, trigger_broken_with_non_broken_upstream_job_config)
+        jenkins, job_name, trigger_broken_with_non_broken_upstream_job_config,
+        dry_run=args.dry_run)
 
 
 def get_reconfigure_jobs_job_config(args, config, build_file):

--- a/scripts/status/generate_release_compare_page_job.py
+++ b/scripts/status/generate_release_compare_page_job.py
@@ -5,6 +5,7 @@ import copy
 import sys
 
 from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_dry_run
 from ros_buildfarm.argument import add_argument_other_rosdistro_name
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.common import get_release_job_prefix
@@ -24,6 +25,7 @@ def main(argv=sys.argv[1:]):
     add_argument_config_url(parser)
     add_argument_rosdistro_name(parser)
     add_argument_other_rosdistro_name(parser)
+    add_argument_dry_run(parser)
     args = parser.parse_args(argv)
 
     config = get_index(args.config_url)
@@ -31,11 +33,11 @@ def main(argv=sys.argv[1:]):
 
     jenkins = connect(config.jenkins_url)
 
-    configure_management_view(jenkins)
+    configure_management_view(jenkins, dry_run=args.dry_run)
 
     prefix = get_release_job_prefix(args.rosdistro_name)
     job_name = '%s_release-compare-page' % prefix
-    configure_job(jenkins, job_name, job_config)
+    configure_job(jenkins, job_name, job_config, dry_run=args.dry_run)
 
 
 def get_job_config(args, config):

--- a/scripts/status/generate_release_status_page_job.py
+++ b/scripts/status/generate_release_status_page_job.py
@@ -6,6 +6,7 @@ import sys
 
 from ros_buildfarm.argument import add_argument_build_name
 from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_dry_run
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.common import get_release_job_prefix
 from ros_buildfarm.common import \
@@ -24,6 +25,7 @@ def main(argv=sys.argv[1:]):
     add_argument_config_url(parser)
     add_argument_rosdistro_name(parser)
     add_argument_build_name(parser, 'release')
+    add_argument_dry_run(parser)
     args = parser.parse_args(argv)
 
     config = get_index(args.config_url)
@@ -31,12 +33,12 @@ def main(argv=sys.argv[1:]):
 
     jenkins = connect(config.jenkins_url)
 
-    configure_management_view(jenkins)
+    configure_management_view(jenkins, dry_run=args.dry_run)
 
     prefix = get_release_job_prefix(
         args.rosdistro_name, args.release_build_name)
     job_name = '%s_release-status-page' % prefix
-    configure_job(jenkins, job_name, job_config)
+    configure_job(jenkins, job_name, job_config, dry_run=args.dry_run)
 
 
 def get_job_config(args, config):

--- a/scripts/status/generate_repos_status_page_job.py
+++ b/scripts/status/generate_repos_status_page_job.py
@@ -5,6 +5,7 @@ import copy
 import sys
 
 from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_dry_run
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.common import get_release_job_prefix
 from ros_buildfarm.config import get_index
@@ -21,6 +22,7 @@ def main(argv=sys.argv[1:]):
         description="Generate the 'repos_status_page' job on Jenkins")
     add_argument_config_url(parser)
     add_argument_rosdistro_name(parser)
+    add_argument_dry_run(parser)
     args = parser.parse_args(argv)
 
     config = get_index(args.config_url)
@@ -28,11 +30,11 @@ def main(argv=sys.argv[1:]):
 
     jenkins = connect(config.jenkins_url)
 
-    configure_management_view(jenkins)
+    configure_management_view(jenkins, dry_run=args.dry_run)
 
     prefix = get_release_job_prefix(args.rosdistro_name)
     job_name = '%s_repos-status-page' % prefix
-    configure_job(jenkins, job_name, job_config)
+    configure_job(jenkins, job_name, job_config, dry_run=args.dry_run)
 
 
 def get_job_config(args, config):


### PR DESCRIPTION
For the top level script `generate_all_jobs` I used a `--commit` option so that the default invocation is to not modify anything.