### PR TITLE
extract warnings from doc jobs and mark build as unstable

### DIFF
--- a/ros_buildfarm/templates/doc/doc_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_job.xml.em
@@ -254,6 +254,9 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         'fi',
     ]),
 ))@
+@(SNIPPET(
+    'builder_system-groovy_extract-warnings',
+))@
   </builders>
   <publishers>
 @[if notify_maintainers]@

--- a/ros_buildfarm/templates/snippet/builder_system-groovy_extract-warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy_extract-warnings.xml.em
@@ -1,0 +1,47 @@
+@(SNIPPET(
+    'builder_system-groovy',
+    command=
+"""// EXTRACT WARNINGS AND MARK BUILD UNSTABLE
+import java.io.BufferedReader
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+import hudson.model.Result
+
+println "# BEGIN SECTION: Look for warnings"
+
+try {
+  // search build output for warning messages
+  r = build.getLogReader()
+  br = new BufferedReader(r)
+  pattern = Pattern.compile(".*WARNING:.*")
+  ignore_pattern = Pattern.compile(".*WARNING: No swap limit support.*")
+  def warnings = []
+  def line
+  while ((line = br.readLine()) != null) {
+    if (pattern.matcher(line).matches()) {
+      if (ignore_pattern.matcher(line).matches()) continue
+      warnings << line
+    }
+  }
+  if (warnings.size() == 0) {
+    println "No warnings found"
+  } else {
+    println "Found " + warnings.size() + " warnings:"
+    println ""
+    for (warning in warnings) {
+      println "- " + warning
+      println ""
+    }
+    if (build.getResult().isBetterThan(Result.UNSTABLE)) {
+      println "Marking build as unstable"
+      build.setResult(Result.UNSTABLE)
+    }
+  }
+} finally {
+  println "# END SECTION"
+}
+""",
+    script_file=None,
+    classpath='',
+))@


### PR DESCRIPTION
Fixes #185.

E.g. http://build.ros.org/job/Jdoc__genmsg__ubuntu_trusty_amd64/9/

Upstream fix ros/genmsg#60 made the job stable again: http://build.ros.org/job/Jdoc__genmsg__ubuntu_trusty_amd64/11/

On Jade 19 jobs will produce warning:
* camera_info_manager_py
* catkin
* dynpick_driver
* eleased-packages-withou
* genpy
* geometry
* geometry_experimental
* moveit_ros
* multimaster_fkie
* robot_upstart
* ros_comm
* rosdoc_lite
* roswww
* rqt_ez_publisher
* rviz
* unique_identifier
* vision_opencv
* visualization_rwt
* visualization_tutorials