### PR TITLE
install Python 3 using wrapper script

### DIFF
--- a/ros_buildfarm/templates/snippet/install_python3.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/install_python3.Dockerfile.em
@@ -1,4 +1,4 @@
 @[if os_name == 'ubuntu' and os_code_name in ['saucy', 'vivid']]@
 @# Ubuntu Saucy and Vivid have neither Python 2 nor 3 installed by default
-RUN apt-get update && apt-get install -q -y python3
+RUN python -u /tmp/wrapper_scripts/apt-get.py update-and-install -q -y python3
 @[end if]@


### PR DESCRIPTION
Fixing the problem in the following jobs:
* http://build.ros.org/job/Jbin_uV32__jsk_recognition_utils__ubuntu_vivid_i386__binary/3/console
* http://build.ros.org/job/Jbin_uV32__vision_opencv__ubuntu_vivid_i386__binary/4/console