### PR TITLE
store packages of metapackage in manifest.yaml

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,11 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package ros_buildfarm
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* fix navigation bar in the wiki to list the packages which are part of a meta package (`#193 <https://github.com/ros-infrastructure/ros_buildfarm/pull/193>`_)
+
+1.0.0 (2016-02-01)
+------------------
+* This is the first stable release. Please look at the git commit log for more information.

--- a/scripts/doc/create_doc_task_generator.py
+++ b/scripts/doc/create_doc_task_generator.py
@@ -123,7 +123,7 @@ def main(argv=sys.argv[1:]):
     with Scope('SUBSECTION', 'determine need to run documentation generation'):
         # compare hashes to determine if documentation needs to be regenerated
         current_hashes = {}
-        current_hashes['ros_buildfarm'] = 1  # increase to retrigger doc jobs
+        current_hashes['ros_buildfarm'] = 2  # increase to retrigger doc jobs
         current_hashes['rosdoc_lite'] = get_git_hash(args.rosdoc_lite_dir)
         current_hashes['catkin-sphinx'] = get_git_hash(args.catkin_sphinx_dir)
         repo_dir = os.path.join(

--- a/scripts/doc/create_doc_task_generator.py
+++ b/scripts/doc/create_doc_task_generator.py
@@ -321,6 +321,9 @@ def main(argv=sys.argv[1:]):
             if pkg.name in rosdoc_index.metapackage_index:
                 data['metapackages'] = rosdoc_index.metapackage_index[pkg.name]
 
+            if pkg.name in rosdoc_index.metapackage_deps:
+                data['packages'] = rosdoc_index.metapackage_deps[pkg.name]
+
             if pkg.name in package_names_with_changelogs:
                 data['has_changelog_rst'] = True
 


### PR DESCRIPTION
Without the navigation header of a metapackage (e.g. http://wiki.ros.org/roscpp?distro=indigo) doesn't list the packages within the metapackage.

@gavanderhoorn Thank you for reporting this.