### PR TITLE
add check if any upstream project is in progress

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog for package ros_buildfarm
 Forthcoming
 -----------
 * fix navigation bar in the wiki to list the packages which are part of a meta package (`#193 <https://github.com/ros-infrastructure/ros_buildfarm/pull/193>`_)
+* add check if any upstream project is in progress to prevent notification email for jobs known to fail and being retriggered anyway (`#194 <https://github.com/ros-infrastructure/ros_buildfarm/pull/194>`_)
 
 1.0.0 (2016-02-01)
 ------------------

--- a/ros_buildfarm/templates/snippet/builder_system-groovy_verify-upstream.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy_verify-upstream.xml.em
@@ -1,7 +1,7 @@
 @(SNIPPET(
     'builder_system-groovy',
     command=
-"""// VERFIY THAT NO RECURSIVE UPSTREAM PROJECT IS BROKEN
+"""// VERFIY THAT NO RECURSIVE UPSTREAM PROJECT IS IN PROGRESS OR BROKEN
 import hudson.model.Result
 
 println ""
@@ -9,6 +9,20 @@ println "# BEGIN SECTION: Check upstream projects"
 println "Verify that no recursive upstream project is broken:"
 
 def check_project(project, depth) {
+  if (project.isBuilding()) {
+    println ""
+    println "  " * depth + "- '" + project.name + "' is currently building"
+    println "  " * depth + "-> aborting build"
+    println ""
+    return false
+  }
+  if (project.isInQueue()) {
+    println ""
+    println "  " * depth + "- '" + project.name + "' is currently queued"
+    println "  " * depth + "-> aborting build"
+    println ""
+    return false
+  }
   if (project.getNextBuildNumber() == 1) {
     println ""
     println "  " * depth + "- '" + project.name + "' has not been built yet"


### PR DESCRIPTION
In the following example Jenkins is not honoring the flag to block a build when any of its upstream packages is queued:

* Job A: http://build.ros.org/job/Ibin_uT32__object_recognition_capture__ubuntu_trusty_i386__binary/
* Job B: http://build.ros.org/job/Ibin_uT32__object_recognition_core__ubuntu_trusty_i386__binary/
* Job C: http://build.ros.org/job/Ibin_uT32__ecto_image_pipeline__ubuntu_trusty_i386__binary/
* Job D: http://build.ros.org/job/Ibin_uT32__ecto_ros__ubuntu_trusty_i386__binary/

The dependencies are as follows:
* A depends on B, C and D
* B depends on C
* C depends on D

The timeline of the events was:
* D5 got triggered (4:08)
* D5 finished which triggered A and C
* C4 starts building (4:47), A waits in the queue (nice)
* C4 finished which triggered A (already queued) and B
* A4 starts building (4:54:34) **bad**
  * since B was already queued and is an upstream project
  * it will fail since the Debian package of the upstream project B has been invalidated, but it can't detect it since all upstream projects are still "green"
* B3 starts building (4:54:42)
* B finished which triggered A5
* A5 starts and finished successfully

While that should be ensured by Jenkins we need to double check for it since Jenkins seems to not do that correctly, see pending tickets related to this:
* https://issues.jenkins-ci.org/browse/JENKINS-5125
* https://issues.jenkins-ci.org/browse/JENKINS-5150

This patch will ensure that A(4) does not only check the status of the last build result of all upstream project but also consideres if any of them are currently building or are currently queued.