### PR TITLE
use the configured mercurial installation to enable caching

### DIFF
--- a/ros_buildfarm/templates/snippet/scm_hg.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_hg.xml.em
@@ -1,4 +1,5 @@
   <scm class="hudson.plugins.mercurial.MercurialSCM" plugin="mercurial@@1.54">
+    <installation>(Default)</installation>
     <source>@ESCAPE(source)</source>
     <modules/>
     <revisionType>BRANCH</revisionType>


### PR DESCRIPTION
This is a matching change to https://github.com/ros-infrastructure/buildfarm_deployment/pull/117 which will enable mercurial caching for the scm polling. 

Otherwise it relies on workspace based polling, which triggers a job anytime the workspace is cleared. (Such as when the last slave executed upon is destroyed.)