### PR TITLE
download sourcedeb file using the apt-get wrapper

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Forthcoming
 * fix unnecessary triggering of devel jobs using Mercurial (`#206 <https://github.com/ros-infrastructure/ros_buildfarm/pull/206>`_)
 * fix special case in doc jobs where metapackage dependencies was None (`#207 <https://github.com/ros-infrastructure/ros_buildfarm/pull/207>`_)
 * remove non-existing job urls in generated manifest.yaml files (`#208 <https://github.com/ros-infrastructure/ros_buildfarm/pull/208>`_)
+* retry on known apt-get errors when downloading sourcedeb files (`#209 <https://github.com/ros-infrastructure/ros_buildfarm/pull/209>`_)
 
 1.0.0 (2016-02-01)
 ------------------

--- a/ros_buildfarm/binarydeb_job.py
+++ b/ros_buildfarm/binarydeb_job.py
@@ -43,8 +43,12 @@ def get_sourcedeb(
             (package_version, ', '.join(debian_package_versions))
 
         # download sourcedeb
+        apt_get_script = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            'scripts', 'wrapper', 'apt-get.py')
         cmd = [
-            'apt-get', 'source', '--download-only', '--only-source',
+            sys.executable, apt_get_script,
+            'source', '--download-only', '--only-source',
             debian_package_name + '=' + debian_package_versions[0]]
         print("Invoking '%s'" % ' '.join(cmd))
         subprocess.check_call(cmd, cwd=sourcedeb_dir)

--- a/scripts/wrapper/apt-get.py
+++ b/scripts/wrapper/apt-get.py
@@ -15,7 +15,7 @@ def main(argv=sys.argv[1:]):
     ]
 
     command = argv[0]
-    if command == 'update':
+    if command in ['update', 'source']:
         rc, _, _ = call_apt_get_repeatedly(
             argv, known_error_strings, max_tries)
         return rc


### PR DESCRIPTION
Fixes known apt-get problems when downloading the sourcedeb file: e.g. http://build.ros.org/job/Ibin_uT64__moveit_visual_tools__ubuntu_trusty_amd64__binary/8/console

Now: http://build.ros.org/job/Ibin_uT64__ax2550__ubuntu_trusty_amd64__binary/12/consoleFull#console-section-11