### PR TITLE
add missing import to create views

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Forthcoming
 * fix special case in doc jobs where metapackage dependencies was None (`#207 <https://github.com/ros-infrastructure/ros_buildfarm/pull/207>`_)
 * remove non-existing job urls in generated manifest.yaml files (`#208 <https://github.com/ros-infrastructure/ros_buildfarm/pull/208>`_)
 * retry on known apt-get errors when downloading sourcedeb files (`#209 <https://github.com/ros-infrastructure/ros_buildfarm/pull/209>`_)
+* fix groovy script to generate views (`#210 <https://github.com/ros-infrastructure/ros_buildfarm/pull/210>`_)
 
 1.0.0 (2016-02-01)
 ------------------

--- a/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
+++ b/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
@@ -1,6 +1,7 @@
 import difflib.DiffUtils
 import groovy.io.FileType
 import hudson.AbortException
+import hudson.model.View
 import java.io.StringBufferInputStream
 import java.io.StringWriter
 import javax.xml.parsers.DocumentBuilderFactory


### PR DESCRIPTION
It is being used in https://github.com/ros-infrastructure/ros_buildfarm/blob/f3868c55f50f4aa517c15170c2ce0a0cc302848f/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em#L98