### PR TITLE
use ccache from source for older distros

### DIFF
--- a/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
@@ -45,7 +45,11 @@ RUN echo "@today_str"
     os_code_name=os_code_name,
 ))@
 
-RUN python3 -u /tmp/wrapper_scripts/apt-get.py update-and-install -q -y ccache
+@(TEMPLATE(
+    'snippet/install_ccache.Dockerfile.em',
+    os_name=os_name,
+    os_code_name=os_code_name,
+))@
 
 @(TEMPLATE(
     'snippet/install_dependencies.Dockerfile.em',

--- a/ros_buildfarm/templates/snippet/install_ccache.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/install_ccache.Dockerfile.em
@@ -1,0 +1,12 @@
+@[if os_name == 'ubuntu' and os_code_name in ['trusty', 'utopic', 'vivid'] or os_name == 'debian' and os_code_name in ['jessie']]@
+@# We need ccache 3.2 or higher: https://github.com/ros-infrastructure/buildfarm_deployment/issues/113
+RUN python3 -u /tmp/wrapper_scripts/apt-get.py update-and-install -q -y curl gcc make
+RUN curl https://www.samba.org/ftp/ccache/ccache-3.2.4.tar.bz2 -o /tmp/ccache.tar.gz
+RUN tar -xf /tmp/ccache.tar.gz --directory /tmp
+RUN mkdir -p /usr/lib/ccache
+RUN cd /tmp/ccache-3.2.4 && ./configure && make && make install
+RUN ln -s /usr/local/bin/ccache /usr/lib/ccache/gcc
+RUN ln -s /usr/local/bin/ccache /usr/lib/ccache/cc
+@[else]@
+RUN python3 -u /tmp/wrapper_scripts/apt-get.py update-and-install -q -y ccache
+@[end if]@


### PR DESCRIPTION
Fixes https://github.com/ros-infrastructure/buildfarm_deployment/issues/113