### PR TITLE
merge branch before building PR

### DIFF
--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -64,6 +64,7 @@ if pull_request:
     branch_name='${sha1}',
     relative_target_dir='catkin_workspace/src/%s' % source_repo_spec.name,
     git_ssh_credential_id=git_ssh_credential_id,
+    merge_branch=source_repo_spec.version,
 ))@
 @[end if]@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>

--- a/ros_buildfarm/templates/snippet/scm_git.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_git.xml.em
@@ -29,5 +29,15 @@
         <noTags>false</noTags>
         <reference/>
       </hudson.plugins.git.extensions.impl.CloneOption>
+@[if vars().get('merge_branch')]@
+      <hudson.plugins.git.extensions.impl.PreBuildMerge>
+        <options>
+          <mergeRemote>origin</mergeRemote>
+          <mergeTarget>@merge_branch</mergeTarget>
+          <mergeStrategy>default</mergeStrategy>
+          <fastForwardMode>FF</fastForwardMode>
+        </options>
+      </hudson.plugins.git.extensions.impl.PreBuildMerge>
+@[end if]@
     </extensions>
   </scm>


### PR DESCRIPTION
Before: it build the branch of the PR without merging it. The result does not help in judging if the PR can be safely merged: http://build.ros.org/job/Ipr__ros_comm__ubuntu_trusty_amd64/77/ 

After: it fails the build in case of merge conflicts: http://build.ros.org/job/Ipr__ros_comm__ubuntu_trusty_amd64/86/console