### PR TITLE
allow empty package entries (which are not lists)

### DIFF
--- a/ros_buildfarm/config/release_build_file.py
+++ b/ros_buildfarm/config/release_build_file.py
@@ -87,11 +87,11 @@ class ReleaseBuildFile(BuildFile):
                 int(data['jenkins_source_job_timeout'])
 
         self.package_whitelist = []
-        if 'package_whitelist' in data:
+        if 'package_whitelist' in data and data['package_whitelist']:
             self.package_whitelist = data['package_whitelist']
             assert isinstance(self.package_whitelist, list)
         self.package_blacklist = []
-        if 'package_blacklist' in data:
+        if 'package_blacklist' in data and data['package_blacklist']:
             self.package_blacklist = data['package_blacklist']
             assert isinstance(self.package_blacklist, list)
         self.skip_ignored_packages = None
@@ -104,7 +104,7 @@ class ReleaseBuildFile(BuildFile):
         if 'sync' in data:
             if 'package_count' in data['sync']:
                 self.sync_package_count = int(data['sync']['package_count'])
-            if 'packages' in data['sync']:
+            if 'packages' in data['sync'] and data['sync']['packages']:
                 self.sync_packages = data['sync']['packages']
                 assert isinstance(self.sync_packages, list)
 


### PR DESCRIPTION
To support the following config: https://github.com/ros-infrastructure/ros_buildfarm_config/blob/18a575b331301d94de2ad21b3caa36e51900351d/kinetic/release-armhf-build.yaml#L14