### PR TITLE
install python3 for wily and xenial

### DIFF
--- a/ros_buildfarm/templates/snippet/install_python3.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/install_python3.Dockerfile.em
@@ -1,4 +1,4 @@
-@[if os_name == 'ubuntu' and os_code_name in ['saucy', 'vivid']]@
-@# Ubuntu Saucy and Vivid have neither Python 2 nor 3 installed by default
+@[if os_name == 'ubuntu' and os_code_name in ['saucy', 'vivid', 'wily', 'xenial']]@
+@# Ubuntu Saucy, Vivid and newer have neither Python 2 nor 3 installed by default
 RUN for i in 1 2 3; do apt-get update && apt-get install -q -y python3 && break || sleep 5; done
 @[end if]@


### PR DESCRIPTION
Neither the `wily` nor `xenial` Docker images have any Python executable installed.