### PR TITLE
fix devel and doc reconfiguration if cache is behind

### DIFF
--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -302,7 +302,8 @@ def _get_devel_job_config(
         get_repositories_and_script_generating_key_files(build_file=build_file)
 
     maintainer_emails = set([])
-    if build_file.notify_maintainers and dist_cache and repo_name:
+    if build_file.notify_maintainers and dist_cache and repo_name and \
+            repo_name in dist_cache.distribution_file.repositories:
         # add maintainers listed in latest release to recipients
         repo = dist_cache.distribution_file.repositories[repo_name]
         if repo.release_repository:

--- a/ros_buildfarm/doc_job.py
+++ b/ros_buildfarm/doc_job.py
@@ -241,7 +241,8 @@ def _get_doc_job_config(
         get_repositories_and_script_generating_key_files(build_file=build_file)
 
     maintainer_emails = set([])
-    if build_file.notify_maintainers and dist_cache and repo_name:
+    if build_file.notify_maintainers and dist_cache and repo_name and \
+            repo_name in dist_cache.distribution_file.repositories:
         # add maintainers listed in latest release to recipients
         repo = dist_cache.distribution_file.repositories[repo_name]
         if repo.release_repository:


### PR DESCRIPTION
The last nightly jobs (http://build.ros.org/job/Kdev_reconfigure-jobs/13/console#console-section-5 http://build.ros.org/job/Kdoc_reconfigure-jobs/11/console#console-section-5) failed because the rosdistro cache job for Kinetic was disabled and therefore the cache was out-of-date. While that should be uncommon the race condition still exists and is worked around by this patch.