### PR TITLE
maintain the job order when reconfiguring using Groovy

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -396,7 +396,13 @@ def write_groovy_script_and_configs(
     job_config_dir = os.path.join(os.path.dirname(filename), 'job_configs')
     if not os.path.isdir(job_config_dir):
         os.makedirs(job_config_dir)
+    # prefix each config file with a serial number to maintain order
+    format_str = '%0' + str(len(str(len(job_configs)))) + 'd'
+    i = 0
     for config_name, config_body in job_configs.items():
-        config_filename = os.path.join(job_config_dir, config_name)
+        i += 1
+        config_filename = os.path.join(
+            job_config_dir,
+            format_str % i + ' ' + config_name)
         with open(config_filename, 'w') as config_fh:
             config_fh.write(config_body)

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from collections import OrderedDict
 import sys
 
 from rosdistro import get_distribution_cache
@@ -110,7 +111,7 @@ def configure_release_jobs(
     jenkins = connect(config.jenkins_url) if groovy_script is None else False
 
     all_view_configs = {}
-    all_job_configs = {}
+    all_job_configs = OrderedDict()
 
     job_name, job_config = configure_import_package_job(
         config_url, rosdistro_name, release_build_name,
@@ -206,7 +207,10 @@ def configure_release_jobs(
                 if groovy_script is not None:
                     print('Configuration for jobs: ' +
                           ', '.join(source_job_names + binary_job_names))
-                    all_job_configs.update(job_configs)
+                    for source_job_name in source_job_names:
+                        all_job_configs[source_job_name] = job_configs[source_job_name]
+                    for binary_job_name in binary_job_names:
+                        all_job_configs[binary_job_name] = job_configs[binary_job_name]
             except JobValidationError as e:
                 print(e.message, file=sys.stderr)
 

--- a/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
+++ b/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
@@ -166,6 +166,8 @@ def mergePullRequestData(job_name, current_file, job_config) {
 jobs.each{
     found_project = false
     job_name = it.getName()
+    // remove leading serial number
+    job_name = job_name[job_name.indexOf(' ') + 1..-1]
     job_config = new File(it.path).getText('UTF-8')
     for (p in Jenkins.instance.allItems) {
         if (p.name != job_name) continue


### PR DESCRIPTION
Currently the Groovy script processes the job configuration in alphabetical order. But if e.g. a new binary job is created before its related source job the job dependency is not established. (The binary job contains the information and if it is saved again, after the source job exists, the connection is established correctly.)