### PR TITLE
use build, run and test dependencies for topological order

### DIFF
--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -148,7 +148,7 @@ def configure_release_jobs(
 
     # binary jobs must be generated in topological order
     from catkin_pkg.package import parse_package_string
-    from catkin_pkg.topological_order import topological_order_packages
+    from ros_buildfarm.common import topological_order_packages
     pkgs = {}
     for pkg_name in pkg_names:
         if pkg_name not in dist_cache.release_package_xmls:

--- a/scripts/doc/create_doc_task_generator.py
+++ b/scripts/doc/create_doc_task_generator.py
@@ -11,7 +11,6 @@ import time
 import yaml
 
 from catkin_pkg.packages import find_packages
-from catkin_pkg.topological_order import topological_order_packages
 from rosdep2 import create_default_installer_context
 from rosdep2.catkin_support import get_catkin_view
 from rosdep2.catkin_support import resolve_for_os
@@ -37,6 +36,7 @@ from ros_buildfarm.common import get_doc_job_url
 from ros_buildfarm.common import get_release_job_urls
 from ros_buildfarm.common import get_user_id
 from ros_buildfarm.common import Scope
+from ros_buildfarm.common import topological_order_packages
 from ros_buildfarm.config import get_distribution_file as \
     get_distribution_file_matching_build_file
 from ros_buildfarm.config import get_doc_build_files


### PR DESCRIPTION
Before `message_runtime` was reconfigured very early (http://build.ros.org/job/Krel_reconfigure-jobs/30/) since it only has a build dependency on catkin.

After it is being reconfigured much later (http://build.ros.org/job/Krel_reconfigure-jobs/31/) since its run dependencies on `roscpp_core` are being considered.