### PR TITLE
fix script generation with Python 2

### DIFF
--- a/scripts/devel/generate_devel_script.py
+++ b/scripts/devel/generate_devel_script.py
@@ -33,7 +33,7 @@ def main(argv=sys.argv[1:]):
     class IncludeHook(Hook):
 
         def __init__(self):
-            super(IncludeHook, self).__init__()
+            Hook.__init__(self)
             self.scms = []
             self.scripts = []
 

--- a/scripts/devel/generate_devel_script.py
+++ b/scripts/devel/generate_devel_script.py
@@ -66,6 +66,7 @@ def main(argv=sys.argv[1:]):
             'scms': hook.scms,
             'scripts': hook.scripts},
         options={BANGPATH_OPT: False})
+    value = value.replace('python3', sys.executable)
     print(value)
 
 

--- a/scripts/doc/generate_doc_script.py
+++ b/scripts/doc/generate_doc_script.py
@@ -95,6 +95,7 @@ def main(argv=sys.argv[1:]):
             'scms': hook.scms,
             'scripts': scripts},
         options={BANGPATH_OPT: False})
+    value = value.replace('python3', sys.executable)
     print(value)
 
 

--- a/scripts/doc/generate_doc_script.py
+++ b/scripts/doc/generate_doc_script.py
@@ -35,7 +35,7 @@ def main(argv=sys.argv[1:]):
     class IncludeHook(Hook):
 
         def __init__(self):
-            super(IncludeHook, self).__init__()
+            Hook.__init__(self)
             self.scms = []
             self.scripts = []
 

--- a/scripts/release/generate_release_script.py
+++ b/scripts/release/generate_release_script.py
@@ -108,6 +108,7 @@ def main(argv=sys.argv[1:]):
             'source_scripts': source_scripts,
             'binary_scripts': binary_scripts},
         options={BANGPATH_OPT: False})
+    value = value.replace('python3', sys.executable)
     print(value)
 
 

--- a/scripts/release/generate_release_script.py
+++ b/scripts/release/generate_release_script.py
@@ -38,7 +38,7 @@ def main(argv=sys.argv[1:]):
     class IncludeHook(Hook):
 
         def __init__(self):
-            super(IncludeHook, self).__init__()
+            Hook.__init__(self)
             self.scripts = []
 
         def beforeFile(self, *args, **kwargs):


### PR DESCRIPTION
Since `em.Hook` is not using `object` as the base class the subclass can't use `super` with Python 2.