### PR TITLE
simplify logic

### DIFF
--- a/ros_buildfarm/templates/snippet/from_base_image.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/from_base_image.Dockerfile.em
@@ -1,13 +1,5 @@
-@[if os_name == 'ubuntu' and arch in ['i386', 'armhf', 'arm64']]@
-@[if arch == 'i386']@
-FROM osrf/ubuntu_32bit:@os_code_name
-@[else]@
-@[if arch == 'armhf']@
-FROM osrf/ubuntu_armhf:@os_code_name
-@[else]@
-FROM osrf/ubuntu_arm64:@os_code_name
-@[end if]@
-@[end if]@
+@[if arch in ['i386', 'armhf', 'arm64']]@
+FROM osrf/@(os_name)_@arch:@os_code_name
 @[else]@
 FROM @os_name:@os_code_name
 @[end if]@


### PR DESCRIPTION
See https://github.com/ros-infrastructure/ros_buildfarm/commit/f96ee6e1578838c2ba5763fbcc1de1d8ea33a514#commitcomment-16663472

I suggest this instead of #258 

Before we merge this we just make sure to backfill the older images. We can either rebuild them or pull them and rename them via docker.