### PR TITLE
add documentation how to use Travis

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -86,12 +86,16 @@ Run jobs locally
 Some of the job types can be easily run locally.
 This allows to reproduce the behavior of the build farm locally, eases
 debugging, and shortens the round-trip time for testing.
+It also means that you can run any of these jobs anywhere, e.g. on Travis.
 
 * `release jobs#run-the-release-job-locally <jobs/release_jobs.rst#run-the-release-job-locally>`_
   generate binary packages
 
 * `devel jobs#run-the-devel-job-locally <jobs/devel_jobs.rst#run-the-devel-job-locally>`_
   build and test ROS repositories
+
+  * `devel jobs#run-the-devel-job-on-travis <jobs/devel_jobs.rst#run-the-devel-job-on-travis>`_
+    build and test ROS repositories using Travis
 
 * `doc jobs#run-the-doc-job-locally <jobs/doc_jobs.rst#run-the-doc-job-locally>`_
   generate the documentation for ROS repositories

--- a/doc/jobs/devel_jobs.rst
+++ b/doc/jobs/devel_jobs.rst
@@ -144,3 +144,52 @@ from ROS *Indigo* for Ubuntu *Trusty* *amd64*:
   generate_devel_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/master/index.yaml indigo default roscpp_core ubuntu trusty amd64 > /tmp/devel_job/devel_job_indigo_roscpp_core.sh
   cd /tmp/devel_job
   sh devel_job_indigo_roscpp_core.sh
+
+
+Run the *devel* job on Travis
+-----------------------------
+
+Since it is easy to run a *devel* job locally it can also be run on Travis to either test every commit or pull request.
+The setup and invocation is the same as locally.
+The following .travis.yml template is a good starting point and is ready to be use:
+
+.. code:: yaml
+
+  # while this doesn't require sudo we don't want to run within a Docker container
+  sudo: true
+  dist: trusty
+  language: python
+  python:
+    - "3.4"
+  env:
+    global:
+      - JOB_PATH=/tmp/devel_job
+    matrix:
+      - ROS_DISTRO_NAME=indigo OS_NAME=ubuntu OS_CODE_NAME=trusty ARCH=amd64
+      #- ROS_DISTRO_NAME=jade OS_NAME=ubuntu OS_CODE_NAME=trusty ARCH=amd64
+      #- ROS_DISTRO_NAME=kinetic OS_NAME=ubuntu OS_CODE_NAME=xenial ARCH=amd64
+  install:
+    # either install the latest released version of ros_buildfarm
+    # (TODO the current release 1.0.1 is not sufficient so for now use the master branch)
+    #- pip install ros_buildfarm
+    # or checkout a specific branch
+    - git clone -b master https://github.com/ros-infrastructure/ros_buildfarm /tmp/ros_buildfarm
+    - pip install /tmp/ros_buildfarm
+    # checkout catkin for catkin_test_results script
+    - git clone https://github.com/ros/catkin /tmp/catkin
+    # run devel job for a ROS repository with the same name as this repo
+    - export REPOSITORY_NAME=`basename $TRAVIS_BUILD_DIR`
+    # use the code already checked out by Travis
+    - mkdir -p $JOB_PATH/catkin_workspace/src
+    - cp -R $TRAVIS_BUILD_DIR $JOB_PATH/catkin_workspace/src/
+    # generate the script to run a devel job for that target and repo
+    - generate_devel_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml $ROS_DISTRO_NAME default $REPOSITORY_NAME $OS_NAME $OS_CODE_NAME $ARCH > $JOB_PATH/devel_job.sh
+    - cd $JOB_PATH
+    - cat devel_job.sh
+    # run the actual job which involves Docker
+    - sh devel_job.sh -y
+  script:
+    # get summary of test results
+    - /tmp/catkin/bin/catkin_test_results $JOB_PATH/catkin_workspace/test_results --all
+  notifications:
+    email: false


### PR DESCRIPTION
After some smallish fixes and improvements it is now easily possible to automate running the jobs from the command line.

For an example see the following fork: https://github.com/dirk-thomas/genmsg/blob/indigo-devel/.travis.yml

And the resulting Travis build: https://travis-ci.org/dirk-thomas/genmsg/builds/116466985