### PR TITLE
Add cannot be authenticated to our retry strings.

### DIFF
--- a/scripts/wrapper/apt-get.py
+++ b/scripts/wrapper/apt-get.py
@@ -45,7 +45,10 @@ def call_apt_get_update_and_install(
             # any call is considered a try
             tries += 1
             known_error_strings_redo_update = [
-                'Size mismatch', 'maybe run apt-get update']
+                'Size mismatch',
+                'maybe run apt-get update',
+                'The following packages cannot be authenticated!',
+                ]
             rc, known_error_conditions = \
                 call_apt_get(
                     [command] + install_argv,


### PR DESCRIPTION
This was observed on several jobs as a failure reason. It was an intermittent configuration error on the upstream server and resolved itself with a rerun of the jobs. Hopefully this will catch it and it will be resolved before the jobs fails.


Failed jobs include: 
- http://build.ros.org/view/Ibin_uT32/job/Ibin_uT32__aruco_mapping__ubuntu_trusty_i386__binary/4/console
- http://build.ros.org/view/Ibin_uT32/job/Ibin_uT32__bwi_tools__ubuntu_trusty_i386__binary/4/console
- http://build.ros.org/view/Ibin_uT32/job/Ibin_uT32__velodyne_height_map__ubuntu_trusty_i386__binary/2/console


console output looks like this: 
```
11:15:46 W: GPG error: http://extras.ubuntu.com trusty Release: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 16126D3A3E5C1192
11:15:46 Invoking 'apt-get install -q -y -o Debug::pkgProblemResolver=yes libboost-all-dev'
11:15:49 Reading package lists...
11:15:49 Building dependency tree...
11:15:49 Reading state information...
11:15:49 Starting pkgProblemResolver with broken count: 0
11:15:49 Starting 2 pkgProblemResolver with broken count: 0
11:15:49 Done
11:15:49 The following extra packages will be installed:
11:15:49   icu-devtools libboost-atomic-dev libboost-atomic1.54-dev
11:15:49   libboost-atomic1.54.0 libboost-chrono-dev libboost-chrono1.54-dev
11:15:49   libboost-chrono1.54.0 libboost-context-dev libboost-context1.54-dev
11:15:49   libboost-context1.54.0 libboost-coroutine-dev libboost-coroutine1.54-dev
11:15:49   libboost-date-time-dev libboost-date-time1.54-dev libboost-date-time1.54.0
11:15:49   libboost-dev libboost-exception-dev libboost-exception1.54-dev
11:15:49   libboost-filesystem-dev libboost-filesystem1.54-dev
11:15:49   libboost-filesystem1.54.0 libboost-graph-dev libboost-graph-parallel-dev
11:15:49   libboost-graph-parallel1.54-dev libboost-graph-parallel1.54.0
11:15:49   libboost-graph1.54-dev libboost-graph1.54.0 libboost-iostreams-dev
11:15:49   libboost-iostreams1.54-dev libboost-iostreams1.54.0 libboost-locale-dev
11:15:49   libboost-locale1.54-dev libboost-locale1.54.0 libboost-log-dev
11:15:49   libboost-log1.54-dev libboost-log1.54.0 libboost-math-dev
11:15:49   libboost-math1.54-dev libboost-math1.54.0 libboost-mpi-dev
11:15:49   libboost-mpi-python-dev libboost-mpi-python1.54-dev
11:15:49   libboost-mpi-python1.54.0 libboost-mpi1.54-dev libboost-mpi1.54.0
11:15:49   libboost-program-options-dev libboost-program-options1.54-dev
11:15:49   libboost-program-options1.54.0 libboost-python-dev libboost-python1.54-dev
11:15:49   libboost-python1.54.0 libboost-random-dev libboost-random1.54-dev
11:15:49   libboost-random1.54.0 libboost-regex-dev libboost-regex1.54-dev
11:15:49   libboost-regex1.54.0 libboost-serialization-dev
11:15:49   libboost-serialization1.54-dev libboost-serialization1.54.0
11:15:49   libboost-signals-dev libboost-signals1.54-dev libboost-signals1.54.0
11:15:49   libboost-system-dev libboost-system1.54-dev libboost-system1.54.0
11:15:49   libboost-test-dev libboost-test1.54-dev libboost-test1.54.0
11:15:49   libboost-thread-dev libboost-thread1.54-dev libboost-thread1.54.0
11:15:49   libboost-timer-dev libboost-timer1.54-dev libboost-timer1.54.0
11:15:49   libboost-tools-dev libboost-wave-dev libboost-wave1.54-dev
11:15:49   libboost-wave1.54.0 libboost1.54-dev libboost1.54-tools-dev libcr0
11:15:49   libexpat1-dev libhwloc-dev libhwloc-plugins libhwloc5 libibverbs-dev
11:15:49   libibverbs1 libicu-dev libicu52 libltdl7 libnuma1 libopenmpi-dev
11:15:49   libopenmpi1.6 libpci-dev libpci3 libpciaccess0 libpython-dev
11:15:49   libpython-stdlib libpython2.7 libpython2.7-dev libpython2.7-minimal
11:15:49   libpython2.7-stdlib libtorque2 libxml2-dev mpi-default-bin mpi-default-dev
11:15:49   ocl-icd-libopencl1 openmpi-bin openmpi-common python python-minimal
11:15:49   python2.7 python2.7-minimal zlib1g-dev
11:15:49 Suggested packages:
11:15:49   libboost-doc graphviz libboost1.54-doc python-pyste
11:15:49   libboost-coroutine.54-dev libboost-log.54-dev libmpfrc++-dev libntl-dev
11:15:49   xsltproc doxygen docbook-xml docbook-xsl default-jdk fop blcr-dkms
11:15:49   libhwloc-contrib-plugins icu-doc pciutils pkg-config opencl-icd gfortran
11:15:49   openmpi-checkpoint python-doc python-tk python2.7-doc binfmt-support
11:15:49 The following NEW packages will be installed:
11:15:49   icu-devtools libboost-all-dev libboost-atomic-dev libboost-atomic1.54-dev
11:15:49   libboost-atomic1.54.0 libboost-chrono-dev libboost-chrono1.54-dev
11:15:49   libboost-chrono1.54.0 libboost-context-dev libboost-context1.54-dev
11:15:49   libboost-context1.54.0 libboost-coroutine-dev libboost-coroutine1.54-dev
11:15:49   libboost-date-time-dev libboost-date-time1.54-dev libboost-date-time1.54.0
11:15:49   libboost-dev libboost-exception-dev libboost-exception1.54-dev
11:15:49   libboost-filesystem-dev libboost-filesystem1.54-dev
11:15:49   libboost-filesystem1.54.0 libboost-graph-dev libboost-graph-parallel-dev
11:15:49   libboost-graph-parallel1.54-dev libboost-graph-parallel1.54.0
11:15:49   libboost-graph1.54-dev libboost-graph1.54.0 libboost-iostreams-dev
11:15:49   libboost-iostreams1.54-dev libboost-iostreams1.54.0 libboost-locale-dev
11:15:49   libboost-locale1.54-dev libboost-locale1.54.0 libboost-log-dev
11:15:49   libboost-log1.54-dev libboost-log1.54.0 libboost-math-dev
11:15:49   libboost-math1.54-dev libboost-math1.54.0 libboost-mpi-dev
11:15:49   libboost-mpi-python-dev libboost-mpi-python1.54-dev
11:15:49   libboost-mpi-python1.54.0 libboost-mpi1.54-dev libboost-mpi1.54.0
11:15:49   libboost-program-options-dev libboost-program-options1.54-dev
11:15:49   libboost-program-options1.54.0 libboost-python-dev libboost-python1.54-dev
11:15:49   libboost-python1.54.0 libboost-random-dev libboost-random1.54-dev
11:15:49   libboost-random1.54.0 libboost-regex-dev libboost-regex1.54-dev
11:15:49   libboost-regex1.54.0 libboost-serialization-dev
11:15:49   libboost-serialization1.54-dev libboost-serialization1.54.0
11:15:49   libboost-signals-dev libboost-signals1.54-dev libboost-signals1.54.0
11:15:49   libboost-system-dev libboost-system1.54-dev libboost-system1.54.0
11:15:49   libboost-test-dev libboost-test1.54-dev libboost-test1.54.0
11:15:49   libboost-thread-dev libboost-thread1.54-dev libboost-thread1.54.0
11:15:49   libboost-timer-dev libboost-timer1.54-dev libboost-timer1.54.0
11:15:49   libboost-tools-dev libboost-wave-dev libboost-wave1.54-dev
11:15:49   libboost-wave1.54.0 libboost1.54-dev libboost1.54-tools-dev libcr0
11:15:49   libexpat1-dev libhwloc-dev libhwloc-plugins libhwloc5 libibverbs-dev
11:15:49   libibverbs1 libicu-dev libicu52 libltdl7 libnuma1 libopenmpi-dev
11:15:49   libopenmpi1.6 libpci-dev libpci3 libpciaccess0 libpython-dev
11:15:49   libpython-stdlib libpython2.7 libpython2.7-dev libpython2.7-minimal
11:15:49   libpython2.7-stdlib libtorque2 libxml2-dev mpi-default-bin mpi-default-dev
11:15:49   ocl-icd-libopencl1 openmpi-bin openmpi-common python python-minimal
11:15:49   python2.7 python2.7-minimal zlib1g-dev
11:15:52 0 upgraded, 116 newly installed, 0 to remove and 64 not upgraded.
11:15:52 Need to get 56.6 MB of archives.
11:15:52 After this operation, 281 MB of additional disk space will be used.
11:15:52 WARNING: The following packages cannot be authenticated!
11:15:52   libcr0 libltdl7 libtorque2 libopenmpi1.6 python-minimal libpython-stdlib
11:15:52   python openmpi-common openmpi-bin mpi-default-bin libpciaccess0
11:15:52   ocl-icd-libopencl1 libboost-dev libboost-tools-dev libboost-atomic-dev
11:15:52   libboost-chrono-dev libboost-context-dev libboost-coroutine-dev
11:15:52   libboost-date-time-dev libboost-exception-dev libboost-filesystem-dev
11:15:52   libboost-graph-dev libboost-graph-parallel-dev libboost-iostreams-dev
11:15:52   libboost-locale-dev libboost-log-dev libboost-math-dev zlib1g-dev
11:15:52   libopenmpi-dev mpi-default-dev libboost-mpi-dev libboost-mpi-python-dev
11:15:52   libboost-program-options-dev libpython-dev libboost-python-dev
11:15:52   libboost-random-dev libboost-regex-dev libboost-serialization-dev
11:15:52   libboost-signals-dev libboost-system-dev libboost-test-dev
11:15:52   libboost-thread-dev libboost-timer-dev libboost-wave-dev libboost-all-dev
11:15:52 E: There are problems and -y was used without --force-yes
11:15:52 Invocation failed without any known error condition, printing all lines to debug known error detection:
11:15:52   1 'Reading package lists...
11:15:52 '
11:15:52   2 'Building dependency tree...
11:15:52 '
11:15:52   3 'Reading state information...
11:15:52 '
11:15:52   4 'Starting pkgProblemResolver with broken count: 0
11:15:52 '
11:15:52   5 'Starting 2 pkgProblemResolver with broken count: 0
11:15:52 '
11:15:52   6 'Done
11:15:52 '
11:15:52   7 'The following extra packages will be installed:
11:15:52 '
11:15:52   8 '  icu-devtools libboost-atomic-dev libboost-atomic1.54-dev
11:15:52 '
11:15:52   9 '  libboost-atomic1.54.0 libboost-chrono-dev libboost-chrono1.54-dev
11:15:52 '
11:15:52   10 '  libboost-chrono1.54.0 libboost-context-dev libboost-context1.54-dev
11:15:52 '
11:15:52   11 '  libboost-context1.54.0 libboost-coroutine-dev libboost-coroutine1.54-dev
11:15:52 '
11:15:52   12 '  libboost-date-time-dev libboost-date-time1.54-dev libboost-date-time1.54.0
11:15:52 '
11:15:52   13 '  libboost-dev libboost-exception-dev libboost-exception1.54-dev
11:15:52 '
11:15:52   14 '  libboost-filesystem-dev libboost-filesystem1.54-dev
11:15:52 '
11:15:52   15 '  libboost-filesystem1.54.0 libboost-graph-dev libboost-graph-parallel-dev
11:15:52 '
11:15:52   16 '  libboost-graph-parallel1.54-dev libboost-graph-parallel1.54.0
11:15:52 '
11:15:52   17 '  libboost-graph1.54-dev libboost-graph1.54.0 libboost-iostreams-dev
11:15:52 '
11:15:52   18 '  libboost-iostreams1.54-dev libboost-iostreams1.54.0 libboost-locale-dev
11:15:52 '
11:15:52   19 '  libboost-locale1.54-dev libboost-locale1.54.0 libboost-log-dev
11:15:52 '
11:15:52   20 '  libboost-log1.54-dev libboost-log1.54.0 libboost-math-dev
11:15:52 '
11:15:52   21 '  libboost-math1.54-dev libboost-math1.54.0 libboost-mpi-dev
11:15:52 '
11:15:52   22 '  libboost-mpi-python-dev libboost-mpi-python1.54-dev
11:15:52 '
11:15:52   23 '  libboost-mpi-python1.54.0 libboost-mpi1.54-dev libboost-mpi1.54.0
11:15:52 '
11:15:52   24 '  libboost-program-options-dev libboost-program-options1.54-dev
11:15:52 '
11:15:52   25 '  libboost-program-options1.54.0 libboost-python-dev libboost-python1.54-dev
11:15:52 '
11:15:52   26 '  libboost-python1.54.0 libboost-random-dev libboost-random1.54-dev
11:15:52 '
11:15:52   27 '  libboost-random1.54.0 libboost-regex-dev libboost-regex1.54-dev
11:15:52 '
11:15:52   28 '  libboost-regex1.54.0 libboost-serialization-dev
11:15:52 '
11:15:52   29 '  libboost-serialization1.54-dev libboost-serialization1.54.0
11:15:52 '
11:15:52   30 '  libboost-signals-dev libboost-signals1.54-dev libboost-signals1.54.0
11:15:52 '
11:15:52   31 '  libboost-system-dev libboost-system1.54-dev libboost-system1.54.0
11:15:52 '
11:15:52   32 '  libboost-test-dev libboost-test1.54-dev libboost-test1.54.0
11:15:52 '
11:15:52   33 '  libboost-thread-dev libboost-thread1.54-dev libboost-thread1.54.0
11:15:52 '
11:15:52   34 '  libboost-timer-dev libboost-timer1.54-dev libboost-timer1.54.0
11:15:52 '
11:15:52   35 '  libboost-tools-dev libboost-wave-dev libboost-wave1.54-dev
11:15:52 '
11:15:52   36 '  libboost-wave1.54.0 libboost1.54-dev libboost1.54-tools-dev libcr0
11:15:52 '
11:15:52   37 '  libexpat1-dev libhwloc-dev libhwloc-plugins libhwloc5 libibverbs-dev
11:15:52 '
11:15:52   38 '  libibverbs1 libicu-dev libicu52 libltdl7 libnuma1 libopenmpi-dev
11:15:52 '
11:15:52   39 '  libopenmpi1.6 libpci-dev libpci3 libpciaccess0 libpython-dev
11:15:52 '
11:15:52   40 '  libpython-stdlib libpython2.7 libpython2.7-dev libpython2.7-minimal
11:15:52 '
11:15:52   41 '  libpython2.7-stdlib libtorque2 libxml2-dev mpi-default-bin mpi-default-dev
11:15:52 '
11:15:52   42 '  ocl-icd-libopencl1 openmpi-bin openmpi-common python python-minimal
11:15:52 '
11:15:52   43 '  python2.7 python2.7-minimal zlib1g-dev
11:15:52 '
11:15:52   44 'Suggested packages:
11:15:52 '
11:15:52   45 '  libboost-doc graphviz libboost1.54-doc python-pyste
11:15:52 '
11:15:52   46 '  libboost-coroutine.54-dev libboost-log.54-dev libmpfrc++-dev libntl-dev
11:15:52 '
11:15:52   47 '  xsltproc doxygen docbook-xml docbook-xsl default-jdk fop blcr-dkms
11:15:52 '
11:15:52   48 '  libhwloc-contrib-plugins icu-doc pciutils pkg-config opencl-icd gfortran
11:15:52 '
11:15:52   49 '  openmpi-checkpoint python-doc python-tk python2.7-doc binfmt-support
11:15:52 '
11:15:52   50 'The following NEW packages will be installed:
11:15:52 '
11:15:52   51 '  icu-devtools libboost-all-dev libboost-atomic-dev libboost-atomic1.54-dev
11:15:52 '
11:15:52   52 '  libboost-atomic1.54.0 libboost-chrono-dev libboost-chrono1.54-dev
11:15:52 '
11:15:52   53 '  libboost-chrono1.54.0 libboost-context-dev libboost-context1.54-dev
11:15:52 '
11:15:52   54 '  libboost-context1.54.0 libboost-coroutine-dev libboost-coroutine1.54-dev
11:15:52 '
11:15:52   55 '  libboost-date-time-dev libboost-date-time1.54-dev libboost-date-time1.54.0
11:15:52 '
11:15:52   56 '  libboost-dev libboost-exception-dev libboost-exception1.54-dev
11:15:52 '
11:15:52   57 '  libboost-filesystem-dev libboost-filesystem1.54-dev
11:15:52 '
11:15:52   58 '  libboost-filesystem1.54.0 libboost-graph-dev libboost-graph-parallel-dev
11:15:52 '
11:15:52   59 '  libboost-graph-parallel1.54-dev libboost-graph-parallel1.54.0
11:15:52 '
11:15:52   60 '  libboost-graph1.54-dev libboost-graph1.54.0 libboost-iostreams-dev
11:15:52 '
11:15:52   61 '  libboost-iostreams1.54-dev libboost-iostreams1.54.0 libboost-locale-dev
11:15:52 '
11:15:52   62 '  libboost-locale1.54-dev libboost-locale1.54.0 libboost-log-dev
11:15:52 '
11:15:52   63 '  libboost-log1.54-dev libboost-log1.54.0 libboost-math-dev
11:15:52 '
11:15:52   64 '  libboost-math1.54-dev libboost-math1.54.0 libboost-mpi-dev
11:15:52 '
11:15:52   65 '  libboost-mpi-python-dev libboost-mpi-python1.54-dev
11:15:52 '
11:15:52   66 '  libboost-mpi-python1.54.0 libboost-mpi1.54-dev libboost-mpi1.54.0
11:15:52 '
11:15:52   67 '  libboost-program-options-dev libboost-program-options1.54-dev
11:15:52 '
11:15:52   68 '  libboost-program-options1.54.0 libboost-python-dev libboost-python1.54-dev
11:15:52 '
11:15:52   69 '  libboost-python1.54.0 libboost-random-dev libboost-random1.54-dev
11:15:52 '
11:15:52   70 '  libboost-random1.54.0 libboost-regex-dev libboost-regex1.54-dev
11:15:52 '
11:15:52   71 '  libboost-regex1.54.0 libboost-serialization-dev
11:15:52 '
11:15:52   72 '  libboost-serialization1.54-dev libboost-serialization1.54.0
11:15:52 '
11:15:52   73 '  libboost-signals-dev libboost-signals1.54-dev libboost-signals1.54.0
11:15:52 '
11:15:52   74 '  libboost-system-dev libboost-system1.54-dev libboost-system1.54.0
11:15:52 '
11:15:52   75 '  libboost-test-dev libboost-test1.54-dev libboost-test1.54.0
11:15:52 '
11:15:52   76 '  libboost-thread-dev libboost-thread1.54-dev libboost-thread1.54.0
11:15:52 '
11:15:52   77 '  libboost-timer-dev libboost-timer1.54-dev libboost-timer1.54.0
11:15:52 '
11:15:52   78 '  libboost-tools-dev libboost-wave-dev libboost-wave1.54-dev
11:15:52 '
11:15:52   79 '  libboost-wave1.54.0 libboost1.54-dev libboost1.54-tools-dev libcr0
11:15:52 '
11:15:52   80 '  libexpat1-dev libhwloc-dev libhwloc-plugins libhwloc5 libibverbs-dev
11:15:52 '
11:15:52   81 '  libibverbs1 libicu-dev libicu52 libltdl7 libnuma1 libopenmpi-dev
11:15:52 '
11:15:52   82 '  libopenmpi1.6 libpci-dev libpci3 libpciaccess0 libpython-dev
11:15:52 '
11:15:52   83 '  libpython-stdlib libpython2.7 libpython2.7-dev libpython2.7-minimal
11:15:52 '
11:15:52   84 '  libpython2.7-stdlib libtorque2 libxml2-dev mpi-default-bin mpi-default-dev
11:15:52 '
11:15:52   85 '  ocl-icd-libopencl1 openmpi-bin openmpi-common python python-minimal
11:15:52 '
11:15:52   86 '  python2.7 python2.7-minimal zlib1g-dev
11:15:52 '
11:15:52   87 '0 upgraded, 116 newly installed, 0 to remove and 64 not upgraded.
11:15:52 '
11:15:52   88 'Need to get 56.6 MB of archives.
11:15:52 '
11:15:52   89 'After this operation, 281 MB of additional disk space will be used.
11:15:52 '
11:15:52   90 'WARNING: The following packages cannot be authenticated!
11:15:52 '
11:15:52   91 '  libcr0 libltdl7 libtorque2 libopenmpi1.6 python-minimal libpython-stdlib
11:15:52 '
11:15:52   92 '  python openmpi-common openmpi-bin mpi-default-bin libpciaccess0
11:15:52 '
11:15:52   93 '  ocl-icd-libopencl1 libboost-dev libboost-tools-dev libboost-atomic-dev
11:15:52 '
11:15:52   94 '  libboost-chrono-dev libboost-context-dev libboost-coroutine-dev
11:15:52 '
11:15:52   95 '  libboost-date-time-dev libboost-exception-dev libboost-filesystem-dev
11:15:52 '
11:15:52   96 '  libboost-graph-dev libboost-graph-parallel-dev libboost-iostreams-dev
11:15:52 '
11:15:52   97 '  libboost-locale-dev libboost-log-dev libboost-math-dev zlib1g-dev
11:15:52 '
11:15:52   98 '  libopenmpi-dev mpi-default-dev libboost-mpi-dev libboost-mpi-python-dev
11:15:52 '
11:15:52   99 '  libboost-program-options-dev libpython-dev libboost-python-dev
11:15:52 '
11:15:52   100 '  libboost-random-dev libboost-regex-dev libboost-serialization-dev
11:15:52 '
11:15:52   101 '  libboost-signals-dev libboost-system-dev libboost-test-dev
11:15:52 '
11:15:52   102 '  libboost-thread-dev libboost-timer-dev libboost-wave-dev libboost-all-dev
11:15:52 '
11:15:52   103 'E: There are problems and -y was used without --force-yes
11:15:52 '
11:15:52 Neither of the following known errors was detected:
11:15:52   1 'Failed to fetch'
11:15:52   2 'Hash Sum mismatch'
11:15:52   3 'Unable to locate package'
11:15:52   4 'is not what the server reported'
11:15:52   5 'Size mismatch'
11:15:52   6 'maybe run apt-get update'
11:15:52 Removing intermediate container 37355586a3b9
11:15:52 The command '/bin/sh -c echo "libboost-all-dev: 1.54.0.1ubuntu1" && python3 -u /tmp/wrapper_scripts/apt-get.py update-and-install -q -y -o Debug::pkgProblemResolver=yes libboost-all-dev' returned a non-zero code: 100
11:15:52 Build step 'Execute shell' marked build as failure
```