### PR TITLE
strip newlines for debug output, fix grammar

### DIFF
--- a/scripts/wrapper/apt-get.py
+++ b/scripts/wrapper/apt-get.py
@@ -130,8 +130,8 @@ def call_apt_get(argv, known_error_strings):
         print('Invocation failed without any known error condition, '
               'printing all lines to debug known error detection:')
         for index, line in enumerate(lines):
-            print(' ', index + 1, "'%s'" % line)
-        print('Neither of the following known errors was detected:')
+            print(' ', index + 1, "'%s'" % line.rstrip('\n\r'))
+        print('None of the following known errors were detected:')
         for index, known_error_string in enumerate(known_error_strings):
             print(' ', index + 1, "'%s'" % known_error_string)
     return rc, known_error_conditions


### PR DESCRIPTION
Based on the output: http://build.ros.org/job/Jbin_uT32__teb_local_planner__ubuntu_trusty_i386__binary/9/console