### PR TITLE
Add locale to locale.gen before setting the locale in Debian

### DIFF
--- a/ros_buildfarm/templates/snippet/setup_locale.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/setup_locale.Dockerfile.em
@@ -1,6 +1,7 @@
 @[if os_name == 'debian']@
 @# Debian does not have locales installed by default but ubuntu does
 RUN for i in 1 2 3; do apt-get update && apt-get install -q -y locales && break || sleep 5; done
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
 @[end if]@
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
According to the warnings on the failing Kinetic job reported by @dlu, it appears that the locale is not set properly on Debian.

According to these guides, the line must be added before running locale-gen.

https://wiki.debian.org/Locale
https://people.debian.org/~schultmc/locales.html