### PR TITLE
disable git pager when performing 'git log' on ros_buildfarm.

### DIFF
--- a/ros_buildfarm/templates/snippet/builder_shell_clone-ros-buildfarm.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_shell_clone-ros-buildfarm.xml.em
@@ -32,7 +32,7 @@ else:
         'echo "# BEGIN SECTION: Clone ros_buildfarm"',
         'rm -fr ros_buildfarm',
     ] + cmds + [
-        'git -C ros_buildfarm log -n 1',
+        'git -C ros_buildfarm --no-pager log -n 1',
         'rm -fr ros_buildfarm/.git',
         'rm -fr ros_buildfarm/doc',
         'echo "# END SECTION"',


### PR DESCRIPTION
This prevents the build job from blocking when `.gitconfig` contains a `pager = ` entry.

I believe this is in line with other instances of calling `git log`, for example in:

ros_buildfarm/ros_buildfarm/templates/devel/devel_script_clone.sh.em