### PR TITLE
Remove hard coded os_name ubuntu in devel jobs

### DIFF
--- a/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
@@ -1,6 +1,6 @@
 # generated from @template_name
 
-FROM ubuntu:@os_code_name
+FROM @os_name:@os_code_name
 MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name='ubuntu',
+    os_name=os_name,
     os_code_name=os_code_name,
     timezone=timezone,
 ))@


### PR DESCRIPTION
This allows prerelease jobs to run on debian jessie. And theoretically we could turn on devel jobs on debian jessie as well now too. 