### PR TITLE
add more default labels

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -163,11 +163,11 @@ The following options are valid in version ``2`` (beside the generic options):
   For ROS 1 this flag must always be ``true``.
 
 * ``jenkins_binary_job_label``: the label expression for *binary* jobs
-  (default: ``buildslave``).
+  (default: ``buildslave <ROSDISTRO_NAME>_binarydeb_<BUILD_FILE_NAME>``).
 * ``jenkins_binary_job_priority``: the job priority of *binary* jobs.
 * ``jenkins_binary_job_timeout``: the job timeout for *binary* jobs.
 * ``jenkins_source_job_label``: the label expression for *source* jobs
-  (default: ``buildslave``).
+  (default: ``buildslave <ROSDISTRO_NAME>_sourcedeb_<BUILD_FILE_NAME>``).
 * ``jenkins_source_job_priority``: the job priority of *source* jobs.
 * ``jenkins_source_job_timeout``: the job timeout for *source* jobs.
 
@@ -211,7 +211,8 @@ The following options are valid in version ``2`` (beside the generic options):
 
 * ``jenkins_commit_job_priority``: the job priority of *devel* jobs.
 * ``jenkins_job_label``: the label expression for both *devel* and
-  *pull request* jobs (default: ``buildslave``).
+  *pull request* jobs (default:
+  ``buildslave <ROSDISTRO_NAME>_devel_<BUILD_FILE_NAME>``).
 * ``jenkins_job_timeout``: the job timeout for both *devel* and *pull request*
   jobs.
 * ``jenkins_pull_request_job_priority``: the job priority of *pull request*
@@ -268,7 +269,7 @@ The following options are valid in version ``2`` (beside the generic options):
 
 * ``jenkins_job_priority``: the job priority of *doc* jobs.
 * ``jenkins_job_label``: the label expression for both *doc* jobs (default:
-  ``buildslave``).
+  ``buildslave <ROSDISTRO_NAME>_doc_<BUILD_FILE_NAME>``).
 * ``jenkins_job_timeout``: the job timeout for *doc* jobs.
 
 * ``notifications``: a dictionary with the following keys:

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -444,3 +444,18 @@ def topological_order_packages(packages):
         if pkg_path is None:
             raise RuntimeError('Circular dependency in: %s' % pkg)
     return ordered_pkg_tuples
+
+
+def get_node_label(config_job_label, default_label=None):
+    if config_job_label is not None:
+        return config_job_label
+    if default_label is None:
+        default_label = get_default_node_label()
+    return default_label
+
+
+def get_default_node_label(additional_label=None):
+    label = 'buildslave'
+    if additional_label:
+        label += ' ' + additional_label
+    return label

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -6,10 +6,12 @@ from catkin_pkg.package import parse_package_string
 from rosdistro import get_distribution_cache
 from rosdistro import get_index
 
+from ros_buildfarm.common import get_default_node_label
 from ros_buildfarm.common import get_devel_job_name
 from ros_buildfarm.common import get_devel_view_name
 from ros_buildfarm.common import git_github_orgunit
 from ros_buildfarm.common import get_github_project_url
+from ros_buildfarm.common import get_node_label
 from ros_buildfarm.common \
     import get_repositories_and_script_generating_key_files
 from ros_buildfarm.common import JobValidationError
@@ -324,7 +326,10 @@ def _get_devel_job_config(
         'github_url': get_github_project_url(source_repo_spec.url),
 
         'job_priority': job_priority,
-        'node_label': build_file.jenkins_job_label,
+        'node_label': get_node_label(
+            build_file.jenkins_job_label,
+            get_default_node_label('%s_%s_%s' % (
+                rosdistro_name, 'devel', source_build_name))),
 
         'pull_request': pull_request,
 

--- a/ros_buildfarm/doc_job.py
+++ b/ros_buildfarm/doc_job.py
@@ -6,10 +6,12 @@ from catkin_pkg.package import parse_package_string
 from rosdistro import get_distribution_cache
 from rosdistro import get_index
 
+from ros_buildfarm.common import get_default_node_label
 from ros_buildfarm.common import get_doc_job_name
 from ros_buildfarm.common import get_doc_view_name
 from ros_buildfarm.common import git_github_orgunit
 from ros_buildfarm.common import get_github_project_url
+from ros_buildfarm.common import get_node_label
 from ros_buildfarm.common \
     import get_repositories_and_script_generating_key_files
 from ros_buildfarm.common import JobValidationError
@@ -258,7 +260,10 @@ def _get_doc_job_config(
         'github_url': get_github_project_url(doc_repo_spec.url),
 
         'job_priority': build_file.jenkins_job_priority,
-        'node_label': build_file.jenkins_job_label,
+        'node_label': get_node_label(
+            build_file.jenkins_job_label,
+            get_default_node_label('%s_%s_%s' % (
+                rosdistro_name, 'doc', doc_build_name))),
 
         'doc_repo_spec': doc_repo_spec,
 
@@ -329,7 +334,10 @@ def _get_doc_metadata_job_config(
 
     job_data = {
         'job_priority': build_file.jenkins_job_priority,
-        'node_label': build_file.jenkins_job_label,
+        'node_label': get_node_label(
+            build_file.jenkins_job_label,
+            get_default_node_label('%s_%s_%s' % (
+                rosdistro_name, 'doc', doc_build_name))),
 
         'ros_buildfarm_repository': get_repository(),
 
@@ -381,7 +389,7 @@ def _get_doc_independent_job_config(
 
     job_data = {
         'job_priority': build_file.jenkins_job_priority,
-        'node_label': build_file.jenkins_job_label,
+        'node_label': get_node_label(build_file.jenkins_job_label),
 
         'ros_buildfarm_repository': get_repository(),
 

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -8,7 +8,9 @@ from rosdistro import get_index
 
 from ros_buildfarm.common import get_binarydeb_job_name
 from ros_buildfarm.common import get_debian_package_name
+from ros_buildfarm.common import get_default_node_label
 from ros_buildfarm.common import get_github_project_url
+from ros_buildfarm.common import get_node_label
 from ros_buildfarm.common import get_release_binary_view_name
 from ros_buildfarm.common import get_release_job_prefix
 from ros_buildfarm.common import get_release_source_view_name
@@ -579,7 +581,10 @@ def _get_sourcedeb_job_config(
         'github_url': get_github_project_url(release_repository.url),
 
         'job_priority': build_file.jenkins_source_job_priority,
-        'node_label': build_file.jenkins_source_job_label,
+        'node_label': get_node_label(
+            build_file.jenkins_source_job_label,
+            get_default_node_label('%s_%s_%s' % (
+                rosdistro_name, 'sourcedeb', release_build_name))),
 
         'disabled': is_disabled,
 
@@ -642,7 +647,10 @@ def _get_binarydeb_job_config(
         'github_url': get_github_project_url(release_repository.url),
 
         'job_priority': build_file.jenkins_binary_job_priority,
-        'node_label': build_file.jenkins_binary_job_label,
+        'node_label': get_node_label(
+            build_file.jenkins_binary_job_label,
+            get_default_node_label('%s_%s_%s' % (
+                rosdistro_name, 'binarydeb', release_build_name))),
 
         'disabled': is_disabled,
 

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -68,7 +68,7 @@ if pull_request:
 ))@
 @[end if]@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>@(node_label if node_label else 'buildslave')</assignedNode>
+  <assignedNode>@(node_label)</assignedNode>
   <canRoam>false</canRoam>
   <disabled>@('true' if disabled else 'false')</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/doc/doc_independent_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_job.xml.em
@@ -21,7 +21,7 @@
 @(SNIPPET(
     'scm_null',
 ))@
-  <assignedNode>@(node_label if node_label else 'buildslave')</assignedNode>
+  <assignedNode>@(node_label)</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/doc/doc_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_job.xml.em
@@ -51,7 +51,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
     git_ssh_credential_id=git_ssh_credential_id,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>@(node_label if node_label else 'buildslave')</assignedNode>
+  <assignedNode>@(node_label)</assignedNode>
   <canRoam>false</canRoam>
   <disabled>@('true' if disabled else 'false')</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
@@ -21,7 +21,7 @@
 @(SNIPPET(
     'scm_null',
 ))@
-  <assignedNode>@(node_label if node_label else 'buildslave')</assignedNode>
+  <assignedNode>@(node_label)</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/release/binarydeb_job.xml.em
+++ b/ros_buildfarm/templates/release/binarydeb_job.xml.em
@@ -39,7 +39,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 @(SNIPPET(
     'scm_null',
 ))@
-  <assignedNode>@(node_label if node_label else 'buildslave')</assignedNode>
+  <assignedNode>@(node_label)</assignedNode>
   <canRoam>false</canRoam>
   <disabled>@('true' if disabled else 'false')</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/release/sourcedeb_job.xml.em
+++ b/ros_buildfarm/templates/release/sourcedeb_job.xml.em
@@ -39,7 +39,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 @(SNIPPET(
     'scm_null',
 ))@
-  <assignedNode>@(node_label if node_label else 'buildslave')</assignedNode>
+  <assignedNode>@(node_label)</assignedNode>
   <canRoam>false</canRoam>
   <disabled>@('true' if disabled else 'false')</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>


### PR DESCRIPTION
Replaces #68.

Since each build file can already override the label onyl in the case where the default is being used additional labels are being used. Beside the default (`buildslave`) another label is being added which is created from the following three parts:

* rosdistro name
* build type (`devel`, `doc`, `binarydeb`, `sourcedeb`)
* name of the build file

Since the user can choose the level of granularity of the build files he can therefore influence the granularity of the default labels.