### PR TITLE
only require a source entry for the target repo

### DIFF
--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -154,6 +154,12 @@ def add_argument_distribution_repository_key_files(parser):
              'corresponding URLs')
 
 
+def add_argument_target_repository(parser):
+    parser.add_argument(
+        '--target-repository',
+        help='The target repository where generated packages are pushed to')
+
+
 def add_argument_custom_rosdep_urls(parser):
     parser.add_argument(
         '--custom-rosdep-urls',

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -625,6 +625,8 @@ def _get_binarydeb_job_config(
 
     repository_args, script_generating_key_files = \
         get_repositories_and_script_generating_key_files(build_file=build_file)
+    repository_args.append(
+        '--target-repository ' + build_file.target_repository)
 
     binarydeb_files = [
         'binarydeb/*.changes',

--- a/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
@@ -34,6 +34,7 @@ RUN useradd -u @uid -m buildfarm
     distribution_repository_urls=distribution_repository_urls,
     os_code_name=os_code_name,
     add_source=True,
+    target_repository=target_repository,
 ))@
 
 @(TEMPLATE(

--- a/ros_buildfarm/templates/snippet/add_distribution_repositories.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/add_distribution_repositories.Dockerfile.em
@@ -4,7 +4,7 @@ RUN echo "@('\\n'.join(key.splitlines()))" > /tmp/keys/@(i).key && apt-key add /
 @[end for]@
 @[for url in distribution_repository_urls]@
 RUN echo deb @url @os_code_name main | tee -a /etc/apt/sources.list.d/buildfarm.list
-@[if add_source]@
+@[if add_source and url == target_repository]@
 RUN echo deb-src @url @os_code_name main | tee -a /etc/apt/sources.list.d/buildfarm.list
 @[end if]@
 @[end for]@

--- a/scripts/release/run_binarydeb_job.py
+++ b/scripts/release/run_binarydeb_job.py
@@ -17,6 +17,7 @@ from ros_buildfarm.argument import add_argument_package_name
 from ros_buildfarm.argument import add_argument_rosdistro_index_url
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.argument import add_argument_skip_download_sourcedeb
+from ros_buildfarm.argument import add_argument_target_repository
 from ros_buildfarm.common import get_distribution_repository_keys
 from ros_buildfarm.common import get_user_id
 from ros_buildfarm.templates import create_dockerfile
@@ -33,6 +34,7 @@ def main(argv=sys.argv[1:]):
     add_argument_arch(parser)
     add_argument_distribution_repository_urls(parser)
     add_argument_distribution_repository_key_files(parser)
+    add_argument_target_repository(parser)
     add_argument_binarydeb_dir(parser)
     add_argument_dockerfile_dir(parser)
     add_argument_skip_download_sourcedeb(parser)
@@ -47,6 +49,7 @@ def main(argv=sys.argv[1:]):
         'distribution_repository_keys': get_distribution_repository_keys(
             args.distribution_repository_urls,
             args.distribution_repository_key_files),
+        'target_repository': args.target_repository,
 
         'skip_download_sourcedeb': args.skip_download_sourcedeb,
 


### PR DESCRIPTION
Fixes #92.

Instead of requiring source entries for all repos this patch only uses a source entry for the target repo since that is the only repo we ever fetch a sourcedeb from (which we have pushed there before).