### PR TITLE
allow status page jobs to run on master as well as slave_on_master

### DIFF
--- a/ros_buildfarm/templates/status/release_compare_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_compare_page_job.xml.em
@@ -24,7 +24,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>slave_on_master</assignedNode>
+  <assignedNode>master||slave_on_master</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/status/release_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_status_page_job.xml.em
@@ -24,7 +24,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>slave_on_master</assignedNode>
+  <assignedNode>master||slave_on_master</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/status/repos_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/repos_status_page_job.xml.em
@@ -24,7 +24,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>slave_on_master</assignedNode>
+  <assignedNode>master||slave_on_master</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>


### PR DESCRIPTION
It's common when long running reconfigure jobs are going that the status pages cannot be updated since they are sharing the same executor. 

Reviewing the jobs there's no reason that the status page jobs cannot run in parallel. They upload the same resources into the same target directory, but they upload the exact same files and which ever one writes last will be fine. 

This leaves the reconfigure jobs tied to a single executor as well as the release trigger jobs which are good to wait for the reconfigure jobs to finish. 