### PR TITLE
Allow token urls

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -278,7 +278,9 @@ def get_short_arch(arch):
 def git_github_orgunit(url):
     if github_url_pattern.match(url) is None:
         return None
-    path = url[len(prefix):]
+    git_domain = 'github.com/'
+    path_index = url.find(git_domain)
+    path = url[path_index + len(git_domain):]
     index = path.index('/')
     return path[:index]
 

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -44,6 +44,7 @@ class Scope(object):
 
 
 Target = namedtuple('Target', 'os_name os_code_name arch')
+github_url_pattern = re.compile("https:\/\/([a-f0-9]{40}@)?github\.com\/.*")
 
 
 def get_repositories_and_script_generating_key_files(
@@ -275,9 +276,7 @@ def get_short_arch(arch):
 
 
 def git_github_orgunit(url):
-    pattern = re.compile("https:\/\/([a-f0-9]{40}@)?github\.com\/.*")
-
-    if pattern.match(url) is None:
+    if github_url_pattern.match(url) is None:
         return None
     path = url[len(prefix):]
     index = path.index('/')
@@ -285,9 +284,7 @@ def git_github_orgunit(url):
 
 
 def get_github_project_url(url):
-    pattern = re.compile("https:\/\/([a-f0-9]{40}@)?github\.com\/.*")
-
-    if pattern.match(url) is None:
+    if github_url_pattern.match(url) is None:
         return None
     git_suffix = '.git'
     if not url.endswith(git_suffix):

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -14,7 +14,7 @@
 
 from collections import namedtuple
 import os
-
+import re
 
 class JobValidationError(Exception):
     """
@@ -274,8 +274,10 @@ def get_short_arch(arch):
 
 
 def git_github_orgunit(url):
-    prefix = 'https://github.com/'
-    if not url.startswith(prefix):
+    pattern = re.compile("https:\/\/([a-z0-9]{40}@)?github\.com\/.*")
+    pattern.match(url)
+
+    if pattern.match(url) is None:
         return None
     path = url[len(prefix):]
     index = path.index('/')
@@ -283,7 +285,10 @@ def git_github_orgunit(url):
 
 
 def get_github_project_url(url):
-    if not url.startswith('https://github.com/'):
+    pattern = re.compile("https:\/\/([a-z0-9]{40}@)?github\.com\/.*")
+    pattern.match(url)
+
+    if pattern.match(url) is None:
         return None
     git_suffix = '.git'
     if not url.endswith(git_suffix):

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -274,7 +274,7 @@ def get_short_arch(arch):
 
 
 def git_github_orgunit(url):
-    pattern = re.compile("https:\/\/([a-z0-9]{40}@)?github\.com\/.*")
+    pattern = re.compile("https:\/\/([a-f0-9]{40}@)?github\.com\/.*")
     pattern.match(url)
 
     if pattern.match(url) is None:
@@ -285,7 +285,7 @@ def git_github_orgunit(url):
 
 
 def get_github_project_url(url):
-    pattern = re.compile("https:\/\/([a-z0-9]{40}@)?github\.com\/.*")
+    pattern = re.compile("https:\/\/([a-f0-9]{40}@)?github\.com\/.*")
     pattern.match(url)
 
     if pattern.match(url) is None:

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -276,7 +276,6 @@ def get_short_arch(arch):
 
 def git_github_orgunit(url):
     pattern = re.compile("https:\/\/([a-f0-9]{40}@)?github\.com\/.*")
-    pattern.match(url)
 
     if pattern.match(url) is None:
         return None
@@ -287,7 +286,6 @@ def git_github_orgunit(url):
 
 def get_github_project_url(url):
     pattern = re.compile("https:\/\/([a-f0-9]{40}@)?github\.com\/.*")
-    pattern.match(url)
 
     if pattern.match(url) is None:
         return None

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -16,6 +16,7 @@ from collections import namedtuple
 import os
 import re
 
+
 class JobValidationError(Exception):
     """
     Indicates that the validation of a build job failed.


### PR DESCRIPTION
For some background, the issue is that our Jenkins PR check jobs were not firing. Looking at the logs in Jenkins, I found these lines:

`INFO: GitHub project property is missing the URL, cannot start ghprb trigger for job Ipr__robot_localization__ubuntu_trusty_amd64`

Looking around online and looking at the manual configuration for the job, I noticed this:

![image](https://cloud.githubusercontent.com/assets/5042191/17766135/8500152e-6521-11e6-8b59-ceb73bfe1e3c.png)

By checking the "GitHub project" box and manually filling out the project URL, the jobs were successfully triggered on subsequent PRs. I tracked the issue down to the fact that the `get_github_project_url` was returning None. This was due to the fact that we were using URLs in our rosdistro that started with OAuth tokens, as we need to clone private repos, but `get_github_project_url `was assuming that the URLs would start with `https://github.com/`. 

I've addressed the issue by using a regex instead. Please note that my testing of this has only involved manually checking the regex and running these methods in isolation. If there's a way for me to force our build server to point to our `ros_buildfarm` fork instead of the OSRF one, I can do that to verify that it works. Here are the tests I ran for the regex:

```
>>> pattern = re.compile("https:\/\/([a-f0-9]{40}@)?github\.com\/.*")
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abe5@github.com/"
>>> print pattern.match(url)  # Patten.match returns a Match object if the pattern is found 
<_sre.SRE_Match object at 0x7f2272390eb8>
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abe5@github.com"
>>> print pattern.match(url)  # Pattern.match returns None if no pattern is found
None
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abe5@github.com/whatevER92994/aa"
>>> print pattern.match(url)
<_sre.SRE_Match object at 0x7f22722fa120>
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abe5aaaaa@github.com/"
>>> print pattern.match(url)
None
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abe@github.com/"
>>> print pattern.match(url)
None
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abe5@github.com/"
>>> print pattern.match(url)
<_sre.SRE_Match object at 0x7f2272390eb8>
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abE5@github.com/"
>>> print pattern.match(url)
None
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abe5@github.com/"
>>> print pattern.match(url)
<_sre.SRE_Match object at 0x7f2272390eb8>
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abg5@github.com/"
>>> print pattern.match(url)
None
>>> url = "https:/3dc7fb42354ce39edbc4f92b44786313cc53abf5@github.com/"
>>> print pattern.match(url)
None
>>> url = "http://3dc7fb42354ce39edbc4f92b44786313cc53abf5@github.com/"
>>> print pattern.match(url)
None
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abf5github.com/"
>>> print pattern.match(url)
None
>>> url = "https://3dc7fb42354ce39edbc4f92b44786313cc53abf5@github.com/"
>>> print pattern.match(url)
<_sre.SRE_Match object at 0x7f2272390eb8>
>>> url = "https://github.com/"
>>> print pattern.match(url)
<_sre.SRE_Match object at 0x7f2272390eb8>
>>> url = "https://github.com"
>>> print pattern.match(url)
None
>>> url = "http://github.com/"
>>> print pattern.match(url)
None
>>> url = "https://@github.com"
>>> print pattern.match(url)
None
>>> url = "https://@github.com/"
>>> print pattern.match(url)
None
>>> url = "https://github.com/"
>>> print pattern.match(url)
<_sre.SRE_Match object at 0x7f22722fa120>
```