### PR TITLE
don't use shallow cloning when using merge-before-build

### DIFF
--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -55,8 +55,7 @@ if pull_request:
     path='catkin_workspace/src/%s' % source_repo_spec.name,
     git_ssh_credential_id=git_ssh_credential_id,
 ))@
-@[end if]@
-@[if pull_request]@
+@[else]@
 @(SNIPPET(
     'scm_git',
     url=source_repo_spec.url,

--- a/ros_buildfarm/templates/snippet/scm_git.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_git.xml.em
@@ -24,12 +24,13 @@
         <relativeTargetDir>@ESCAPE(relative_target_dir)</relativeTargetDir>
       </hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
 @[end if]@
+@[if not vars().get('merge_branch')]@
       <hudson.plugins.git.extensions.impl.CloneOption>
         <shallow>true</shallow>
         <noTags>false</noTags>
         <reference/>
       </hudson.plugins.git.extensions.impl.CloneOption>
-@[if vars().get('merge_branch')]@
+@[else]@
       <hudson.plugins.git.extensions.impl.PreBuildMerge>
         <options>
           <mergeRemote>origin</mergeRemote>


### PR DESCRIPTION
Based on the discussion in http://discourse.ros.org/t/clone-depth-for-pr-devel-jobs/419 about failing PR jobs.

Consider the following scenario:
* a job uses a shallow clone as well as "merge before build" (which currently all PR jobs do)
* the branch is not built on top of the latest master
* a newer version of the Jenkins Git plugin actually applies the depth option for the shallow clone correctly

The "merge before build" fails since it doesn't have enough history to determine how to perform the merge. Since we can't set a depth which will work in all cases this patch disables the use of shallow clone for the case of PR jobs. Other jobs which don't use "build before merge" can continue to use shallow clones.