### PR TITLE
change status page threshold

### DIFF
--- a/ros_buildfarm/templates/status/js/setup.js
+++ b/ros_buildfarm/templates/status/js/setup.js
@@ -28,7 +28,7 @@ window.body_ready_with_age = function(age) {
   // Do age stuff
   $(document).ready(function() {
     $('.age p').replaceWith("<p>Page was generated: <br/>" + age.humanize() + " ago</p>");
-    if (age < moment.duration(15, 'minutes')) {
+    if (age < moment.duration(20, 'minutes')) {
       $('.age p').css('color', '#3c763d');
       $('.age').css('background-color', '#dff0d8');
       $('.age').css('border-color', '#d6e9c6');


### PR DESCRIPTION
The status page jobs run every 15 minutes. With the current threshold being identical the page is already marked in orange if the job finishes a second slower than the previous run. Therefore this patch adds some buffer to the threshold.