### PR TITLE
Updating diffutils URL

### DIFF
--- a/ros_buildfarm/templates/devel/devel_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_reconfigure-jobs_job.xml.em
@@ -59,7 +59,7 @@
     script="""rm -fr $WORKSPACE/classpath
 mkdir -p $WORKSPACE/classpath
 cd $WORKSPACE/classpath
-wget --no-verbose https://java-diff-utils.googlecode.com/files/diffutils-1.2.1.jar""",
+wget --no-verbose https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/java-diff-utils/diffutils-1.2.1.jar""",
 ))@
 @(SNIPPET(
     'builder_shell',

--- a/ros_buildfarm/templates/doc/doc_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_reconfigure-jobs_job.xml.em
@@ -59,7 +59,7 @@
     script="""rm -fr $WORKSPACE/classpath
 mkdir -p $WORKSPACE/classpath
 cd $WORKSPACE/classpath
-wget --no-verbose https://java-diff-utils.googlecode.com/files/diffutils-1.2.1.jar""",
+wget --no-verbose https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/java-diff-utils/diffutils-1.2.1.jar""",
 ))@
 @(SNIPPET(
     'builder_shell',

--- a/ros_buildfarm/templates/release/release_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/release/release_reconfigure-jobs_job.xml.em
@@ -64,7 +64,7 @@
     script="""rm -fr $WORKSPACE/classpath
 mkdir -p $WORKSPACE/classpath
 cd $WORKSPACE/classpath
-wget --no-verbose https://java-diff-utils.googlecode.com/files/diffutils-1.2.1.jar""",
+wget --no-verbose https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/java-diff-utils/diffutils-1.2.1.jar""",
 ))@
 @(SNIPPET(
     'builder_shell',


### PR DESCRIPTION
Our reconfigure jobs were failing. It looks like Google moved the location of the diffutils-1.2.1.jar file. Verified that `wget` succeeds with the new URL.