### PR TITLE
fix newline expansion for some shells

### DIFF
--- a/ros_buildfarm/templates/snippet/builder_shell_clone-ros-buildfarm.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_shell_clone-ros-buildfarm.xml.em
@@ -1,7 +1,8 @@
 @{
 filename = 'git.py'
 wrapper_script = wrapper_scripts[filename]
-cmd = 'echo "%s" > wrapper_scripts/%s' % ('\\n'.join(wrapper_script.replace('\\', '\\\\\\\\').replace('"', '\\"').splitlines()), filename)
+# depending on the shell echo might not expand the escaped newlines
+cmd = 'printf "%s" > wrapper_scripts/%s' % ('\\n'.join(wrapper_script.replace('\\', '\\\\\\\\').replace('"', '\\"').replace('%', '%%').splitlines()), filename)
 }@
 @(SNIPPET(
     'builder_shell',


### PR DESCRIPTION
If the `sh` shell actually some custom shell like `bash` the `echo` command doesn't expand the `\n` to newline but outputs them as-is. 

Fixes ros/rosdistro#12824.