### PR TITLE
always use constructed base image name

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -14,6 +14,7 @@
 
 from collections import namedtuple
 import os
+import platform
 try:
     from urllib.parse import urlparse
 except ImportError:
@@ -487,3 +488,16 @@ def get_default_node_label(additional_label=None):
     if additional_label:
         label += ' || ' + additional_label
     return label
+
+
+def get_system_architecture():
+    # this is used to determine the arch for the Docker image for source jobs
+    # which don't explicitly specify an architecture
+    machine = platform.machine()
+    if machine == 'x86_64':
+        return 'amd64'
+    if machine == 'i386':
+        return 'i386'
+    if machine == 'aarch64':
+        return 'armv8'
+    raise RuntimeError('Unable to determine architecture')

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -32,6 +32,7 @@ from ros_buildfarm.common import get_release_view_name
 from ros_buildfarm.common \
     import get_repositories_and_script_generating_key_files
 from ros_buildfarm.common import get_sourcedeb_job_name
+from ros_buildfarm.common import get_system_architecture
 from ros_buildfarm.common import JobValidationError
 from ros_buildfarm.common import write_groovy_script_and_configs
 from ros_buildfarm.config import get_distribution_file
@@ -612,6 +613,7 @@ def _get_sourcedeb_job_config(
         'pkg_name': pkg_name,
         'os_name': os_name,
         'os_code_name': os_code_name,
+        'arch': get_system_architecture(),
         'repository_args': repository_args,
 
         'sourcedeb_files': sourcedeb_files,

--- a/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
@@ -1,6 +1,11 @@
 # generated from @template_name
 
-FROM @os_name:@os_code_name
+@(TEMPLATE(
+    'snippet/from_base_image.Dockerfile.em',
+    os_name=os_name,
+    os_code_name=os_code_name,
+    arch=arch,
+))@
 MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -98,6 +98,9 @@ if pull_request:
 ))@
 @(SNIPPET(
     'builder_check-docker',
+    os_name=os_name,
+    os_code_name=os_code_name,
+    arch=arch,
 ))@
 @(SNIPPET(
     'builder_shell_clone-ros-buildfarm',

--- a/ros_buildfarm/templates/doc/doc_independent_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_job.xml.em
@@ -42,6 +42,9 @@
 ))@
 @(SNIPPET(
     'builder_check-docker',
+    os_name='ubuntu',
+    os_code_name='trusty',
+    arch='amd64',
 ))@
 @(SNIPPET(
     'builder_shell_clone-ros-buildfarm',

--- a/ros_buildfarm/templates/doc/doc_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_job.xml.em
@@ -72,6 +72,9 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 ))@
 @(SNIPPET(
     'builder_check-docker',
+    os_name=os_name,
+    os_code_name=os_code_name,
+    arch=arch,
 ))@
 @(SNIPPET(
     'builder_shell_clone-ros-buildfarm',

--- a/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
@@ -42,6 +42,9 @@
 ))@
 @(SNIPPET(
     'builder_check-docker',
+    os_name='ubuntu',
+    os_code_name='trusty',
+    arch='amd64',
 ))@
 @(SNIPPET(
     'builder_shell_clone-ros-buildfarm',

--- a/ros_buildfarm/templates/release/binarydeb_job.xml.em
+++ b/ros_buildfarm/templates/release/binarydeb_job.xml.em
@@ -65,6 +65,9 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 ))@
 @(SNIPPET(
     'builder_check-docker',
+    os_name=os_name,
+    os_code_name=os_code_name,
+    arch=arch,
 ))@
 @(SNIPPET(
     'builder_shell_clone-ros-buildfarm',

--- a/ros_buildfarm/templates/release/sourcedeb_job.xml.em
+++ b/ros_buildfarm/templates/release/sourcedeb_job.xml.em
@@ -55,6 +55,9 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 ))@
 @(SNIPPET(
     'builder_check-docker',
+    os_name=os_name,
+    os_code_name=os_code_name,
+    arch=arch,
 ))@
 @(SNIPPET(
     'builder_shell_clone-ros-buildfarm',

--- a/ros_buildfarm/templates/snippet/builder_check-docker.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_check-docker.xml.em
@@ -1,9 +1,16 @@
+@{
+# same logic as in from_base_image.Dockerfile.em
+if arch in ['i386', 'armhf', 'arm64']:
+    base_image = 'osrf/%s_%s:%s' % (os_name, arch, os_code_name)
+else:
+    base_image = '%s:%s' % (os_name, os_code_name)
+}@
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
         'echo "# BEGIN SECTION: Check docker status"',
         'echo "Testing trivial docker invocation..."',
-        'docker run --rm ubuntu:trusty true ; echo "\'docker run\' returned $?"',
+        'docker run --rm %s true ; echo "\'docker run\' returned $?"' % base_image,
     ]),
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/snippet/from_base_image.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/from_base_image.Dockerfile.em
@@ -1,3 +1,4 @@
+@# same logic as in builder_check-docker.xml.em
 @[if arch in ['i386', 'armhf', 'arm64']]@
 FROM osrf/@(os_name)_@arch:@os_code_name
 @[else]@

--- a/scripts/release/run_sourcedeb_job.py
+++ b/scripts/release/run_sourcedeb_job.py
@@ -29,6 +29,7 @@ from ros_buildfarm.argument import add_argument_rosdistro_index_url
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.common import get_distribution_repository_keys
 from ros_buildfarm.common import get_user_id
+from ros_buildfarm.common import get_system_architecture
 from ros_buildfarm.templates import create_dockerfile
 
 
@@ -51,6 +52,8 @@ def main(argv=sys.argv[1:]):
 
     data = copy.deepcopy(args.__dict__)
     data.update({
+        'arch': get_system_architecture(),
+
         'distribution_repository_urls': args.distribution_repository_urls,
         'distribution_repository_keys': get_distribution_repository_keys(
             args.distribution_repository_urls,


### PR DESCRIPTION
Support native arm64 jobs on a TX1.

Example builds:
* Devel http://build.ros.org/view/Kdev_uxv8/job/Kdev_uxv8__rospack__ubuntu_xenial_arm64/12/
* Binarydeb http://build.ros.org/view/Kbin_uxv8_uXv8/job/Kbin_uxv8_uXv8__desktop_full__ubuntu_xenial_arm64__binary/7/