### PR TITLE
fix triggering of doc job for released packages

### DIFF
--- a/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
@@ -28,7 +28,7 @@
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <triggers>
 @(SNIPPET(
-    'trigger_poll',
+    'trigger_timer',
     spec='H 3 H/3 * *',
 ))@
   </triggers>


### PR DESCRIPTION
Polling without an scm doesn't make sense. It only triggered the job when the workspace was unavailable (when the previous slave went offline).