### PR TITLE
various improvements to the status pages

### DIFF
--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -112,7 +112,7 @@ def build_release_status_page(
 
     template_name = 'status/release_status_page.html.em'
     data = {
-        'title': 'ROS %s - release status' % rosdistro_name.capitalize(),
+        'title': 'ROS packages for %s' % rosdistro_name.capitalize(),
         'start_time': start_time,
         'start_time_local_str': time.strftime('%Y-%m-%d %H:%M:%S %z', time.localtime(start_time)),
 
@@ -149,7 +149,7 @@ def build_release_status_page(
 
 
 def build_debian_repos_status_page(
-        repo_urls, os_code_name_and_arch_tuples,
+        rosdistro_name, repo_urls, os_code_name_and_arch_tuples,
         cache_dir, output_name, output_dir):
     start_time = time.time()
 
@@ -200,7 +200,7 @@ def build_debian_repos_status_page(
 
     template_name = 'status/release_status_page.html.em'
     data = {
-        'title': 'ROS repository status',
+        'title': 'All packages for %s targets' % rosdistro_name.capitalize(),
         'start_time': start_time,
         'start_time_local_str': time.strftime('%Y-%m-%d %H:%M:%S %z', time.localtime(start_time)),
 
@@ -572,8 +572,7 @@ def build_release_compare_page(
 
     template_name = 'status/release_compare_page.html.em'
     data = {
-        'title':
-            'ROS %s - version compare' % ' '.join([x.capitalize() for x in rosdistro_names]),
+        'title': 'ROS packages in %s' % ' '.join([x.capitalize() for x in rosdistro_names]),
 
         'start_time': start_time,
         'start_time_local_str': time.strftime('%Y-%m-%d %H:%M:%S %z', time.localtime(start_time)),

--- a/ros_buildfarm/templates/status/css/status_page.css
+++ b/ros_buildfarm/templates/status/css/status_page.css
@@ -22,6 +22,7 @@ div.search input { width: 300px; font-size: 1.0em }
 div.search #search-count { color: #444; font-style: italic; }
 div.top.legend ul { list-style: none; }
 div.top.legend li a { margin: 0; position: relative; top: 3px; left: -5px; }
+div.top.legend li a.w { top: 3px; }
 
 /* Styles for the non-scrolling table header. */
 table {

--- a/ros_buildfarm/templates/status/release_compare_page.html.em
+++ b/ros_buildfarm/templates/status/release_compare_page.html.em
@@ -20,7 +20,7 @@
   </script>
   <div class="top logo">
     <h1><img src="http://wiki.ros.org/custom/images/ros_org.png" alt="ROS.org" width="150" height="32" /></h1>
-    <h2>Version compare<br />@(' '.join([d.capitalize() for d in rosdistro_names]))@</h2>
+    <h2>@title</h2>
   </div>
   <div class="top search">
     <form action="?">

--- a/ros_buildfarm/templates/status/release_status_page.html.em
+++ b/ros_buildfarm/templates/status/release_status_page.html.em
@@ -70,7 +70,7 @@
     <ul class="squares">
       <li>
 @[for repo_name, repo_url in zip(repo_names, repo_urls)]@
-        <a class="w" href="@repo_url" title="@repo_name"></a>
+        <a class="w" href="@repo_url" title="@repo_name">@(repo_name[0].upper())</a>
 @[end for]@
         the repositories
       </li>
@@ -101,7 +101,7 @@
         <th class="sortable"><div>Maintainer</div></th>
 @[end if]@
 @[for target in targets]@
-        <th><div>@(target.os_code_name[0].upper())@(short_arches[target.arch])</div>@
+        <th><div title="@(target.os_name.capitalize()) @(target.os_code_name.capitalize()) @(target.arch)">@(target.os_code_name[0].upper())@(short_arches[target.arch])</div>@
 @[for count in package_counts[target]]@
 <span class="sum">@count</span>@
 @[end for]@

--- a/ros_buildfarm/templates/status/repos_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/repos_status_page_job.xml.em
@@ -58,6 +58,7 @@ os_code_name_and_arch_tuples = status_page['os_code_name_and_arch_tuples']
         'echo "# BEGIN SECTION: generate repos status page: %s"' % status_page_name,
         'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/status/build_repos_status_page.py' +
+        ' ' + rosdistro_name +
         ' ' + ' '.join(debian_repository_urls) +
         ' --os-code-name-and-arch-tuples ' +
         ' '.join(os_code_name_and_arch_tuples) +

--- a/scripts/status/build_repos_status_page.py
+++ b/scripts/status/build_repos_status_page.py
@@ -22,12 +22,14 @@ from ros_buildfarm.argument import add_argument_debian_repository_urls
 from ros_buildfarm.argument import add_argument_os_code_name_and_arch_tuples
 from ros_buildfarm.argument import add_argument_output_dir
 from ros_buildfarm.argument import add_argument_output_name
+from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.status_page import build_debian_repos_status_page
 
 
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
         description="Run the 'repos_status_page' job")
+    add_argument_rosdistro_name(parser)
     add_argument_debian_repository_urls(parser)
     add_argument_os_code_name_and_arch_tuples(parser)
     add_argument_cache_dir(parser, '/tmp/debian_repo_cache')
@@ -36,8 +38,9 @@ def main(argv=sys.argv[1:]):
     args = parser.parse_args(argv)
 
     return build_debian_repos_status_page(
-        args.debian_repository_urls, args.os_code_name_and_arch_tuples,
-        args.cache_dir, args.output_name, args.output_dir)
+        args.rosdistro_name, args.debian_repository_urls,
+        args.os_code_name_and_arch_tuples, args.cache_dir, args.output_name,
+        args.output_dir)
 
 
 if __name__ == '__main__':

--- a/scripts/status/generate_repos_status_page_job.py
+++ b/scripts/status/generate_repos_status_page_job.py
@@ -102,12 +102,11 @@ def get_targets_by_repo(config, ros_distro_name):
         targets_by_repo[target_repository] = []
         targets = target_dicts_by_repo[target_repository]
         # TODO support other OS names
-        if 'ubuntu' in targets:
-            ubuntu_targets = targets['ubuntu']
-            for os_code_name in sorted(ubuntu_targets.keys()):
+        for os_name in ['debian', 'ubuntu']:
+            for os_code_name in sorted(targets[os_name].keys()):
                 target = '%s:source' % os_code_name
                 targets_by_repo[target_repository].append(target)
-                for arch in sorted(ubuntu_targets[os_code_name].keys()):
+                for arch in sorted(targets[os_name][os_code_name].keys()):
                     target = '%s:%s' % (os_code_name, arch)
                     targets_by_repo[target_repository].append(target)
     return targets_by_repo


### PR DESCRIPTION
* Update title to clarify what is being shown (all packages vs. ROS packages)
* Add first letter of the three repos to the squares in the legend
* Add verbose title to the column labels
* Consider Debian targets for repos page

Fixes #353.