### PR TITLE
[prerelease] Add arg example for --custom-repo option.

### DIFF
--- a/scripts/prerelease/generate_prerelease_script.py
+++ b/scripts/prerelease/generate_prerelease_script.py
@@ -79,7 +79,8 @@ def main(argv=sys.argv[1:]):
         type=_repository_name_and_type_and_url_and_branch,
         default=[],
         metavar='REPO_NAME:REPO_TYPE:REPO_URL:BRANCH_OR_TAG_NAME',
-        help='The name, type, url and branch / tag name of a repository')
+        help='The name, type, url and branch / tag name of a repository, '
+             'e.g. "common_tutorials:git:https://github.com/ros/common_tutorials:pullrequest-1"')
 
     add_overlay_arguments(parser)
 


### PR DESCRIPTION
Argument value for `--custom-repo` option of `generate_prerelease_script.py` isn't very clear to me so adding a concrete example.
I'm not sure if the example here is correct, but on my computer it seems the script is able to fetch the specified branch and commit.