### PR TITLE
added lunar targets

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -259,11 +259,14 @@ def get_short_os_code_name(os_code_name):
     os_code_name_mappings = {
         'jessie': 'J',
         'saucy': 'S',
+        'stretch': 'S',
         'trusty': 'T',
         'utopic': 'U',
         'vivid': 'V',
         'wily': 'W',
         'xenial': 'X',
+        'yakkety': 'Y',
+        'zesty': 'Z',
     }
     return os_code_name_mappings.get(os_code_name, os_code_name)
 


### PR DESCRIPTION
I assumed it's ok to have duplicate `os_code_mapping` values because they're always associated with the `os_short_name` so it shouldn't be ambiguous. Is that correct ?