### PR TITLE
remove MAINTAINER command

### DIFF
--- a/ros_buildfarm/templates/devel/devel_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_reconfigure_task.Dockerfile.em
@@ -1,7 +1,6 @@
 # generated from @template_name
 
 FROM ubuntu:trusty
-MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
@@ -6,7 +6,6 @@
     os_code_name=os_code_name,
     arch=arch,
 ))@
-MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -6,7 +6,6 @@
     os_code_name=os_code_name,
     arch=arch,
 ))@
-MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/doc/doc_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_create_reconfigure_task.Dockerfile.em
@@ -1,7 +1,6 @@
 # generated from @template_name
 
 FROM ubuntu:trusty
-MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/doc/doc_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_create_task.Dockerfile.em
@@ -1,7 +1,6 @@
 # generated from @template_name
 
 FROM ubuntu:@os_code_name
-MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/doc/doc_independent_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_independent_task.Dockerfile.em
@@ -1,7 +1,6 @@
 # generated from @template_name
 
 FROM ubuntu:trusty
-MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/doc/doc_metadata_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_metadata_task.Dockerfile.em
@@ -1,7 +1,6 @@
 # generated from @template_name
 
 FROM ubuntu:trusty
-MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/doc/doc_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_task.Dockerfile.em
@@ -6,7 +6,6 @@
     os_code_name=os_code_name,
     arch=arch,
 ))@
-MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/misc/rosdistro_cache_task.Dockerfile.em
+++ b/ros_buildfarm/templates/misc/rosdistro_cache_task.Dockerfile.em
@@ -1,7 +1,6 @@
 # generated from @template_name
 
 FROM ubuntu:trusty
-MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
@@ -6,7 +6,6 @@
     os_code_name=os_code_name,
     arch=arch,
 ))@
-MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/release/binarydeb_install_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_install_task.Dockerfile.em
@@ -7,7 +7,6 @@
     os_code_name=os_code_name,
     arch=arch,
 ))@
-MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
@@ -7,7 +7,6 @@
     os_code_name=os_code_name,
     arch=arch,
 ))@
-MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/release/release_check_sync_criteria_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_check_sync_criteria_task.Dockerfile.em
@@ -1,7 +1,6 @@
 # generated from @template_name
 
 FROM ubuntu:trusty
-MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/release/release_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_create_reconfigure_task.Dockerfile.em
@@ -1,7 +1,6 @@
 # generated from @template_name
 
 FROM ubuntu:trusty
-MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/release/release_create_trigger_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_create_trigger_task.Dockerfile.em
@@ -1,7 +1,6 @@
 # generated from @template_name
 
 FROM ubuntu:trusty
-MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/release/sourcedeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/sourcedeb_task.Dockerfile.em
@@ -1,7 +1,6 @@
 # generated from @template_name
 
 FROM @os_name:@os_code_name
-MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/status/release_compare_page_task.Dockerfile.em
+++ b/ros_buildfarm/templates/status/release_compare_page_task.Dockerfile.em
@@ -1,7 +1,6 @@
 # generated from @template_name
 
 FROM ubuntu:trusty
-MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/status/release_status_page_task.Dockerfile.em
+++ b/ros_buildfarm/templates/status/release_status_page_task.Dockerfile.em
@@ -1,7 +1,6 @@
 # generated from @template_name
 
 FROM ubuntu:trusty
-MAINTAINER Dirk Thomas dthomas+buildfarm@@osrfoundation.org
 
 VOLUME ["/var/cache/apt/archives"]
 


### PR DESCRIPTION
Remove usage of `MAINTAINER` command. It will be deprecated as of [Docker 1.13](https://blog.nimbleci.com/2016/11/17/whats-coming-in-docker-1-13/#other-noteworthy-improvements). Since the generated images are never shared I don't see a reason to add a label instead.