### PR TITLE
add multiverse to source.list for amd64

### DIFF
--- a/ros_buildfarm/templates/snippet/add_distribution_repositories.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/add_distribution_repositories.Dockerfile.em
@@ -8,3 +8,10 @@ RUN echo deb @url @os_code_name main | tee -a /etc/apt/sources.list.d/buildfarm.
 RUN echo deb-src @url @os_code_name main | tee -a /etc/apt/sources.list.d/buildfarm.list
 @[end if]@
 @[end for]@
+@[if os_name == 'ubuntu']@
+# Enable multiverse
+RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list
+@[else if os_name == 'debian']@
+# Add contrib and non-free to debian images
+RUN echo deb http://http.debian.net/debian @os_code_name contrib non-free | tee -a /etc/apt/sources.list
+@[end if]@


### PR DESCRIPTION
I have trouble on buidling package at http://build.ros.org/job/Isrc_uT__darknet__ubuntu_trusty__source/,
whcih it can compile on i386, but not on amd64. The problem is it fail to find `nvidia-cuda-toolkit` as

```
23:13:21 Invoking 'debchange -v 2016.11.27-1trusty-20170119-231321-0800 -p -D trusty -u high -m Append timestamp when binarydeb was built.' in '/tmp/binarydeb/ros-indigo-darknet-2016.11.27'
23:13:21 # END SUBSECTION
23:13:24 Looking for the '.dsc' file of package 'ros-indigo-darknet' with version '2016.11.27-1'
23:13:27 Traceback (most recent call last):
23:13:27   File "/usr/lib/python3/dist-packages/apt/cache.py", line 198, in __getitem__
23:13:27     return self._weakref[key]
23:13:27   File "/usr/lib/python3.4/weakref.py", line 125, in __getitem__
23:13:27     o = self.data[key]()
23:13:27 KeyError: 'nvidia-cuda-toolkit'
23:13:27 
23:13:27 During handling of the above exception, another exception occurred:
23:13:27 
23:13:27 Traceback (most recent call last):
23:13:27   File "/tmp/ros_buildfarm/scripts/release/create_binarydeb_task_generator.py", line 162, in <module>
23:13:27     main()
23:13:27   File "/tmp/ros_buildfarm/scripts/release/create_binarydeb_task_generator.py", line 84, in main
23:13:27     apt_cache, debian_pkg_names)
23:13:27   File "/tmp/ros_buildfarm/ros_buildfarm/common.py", line 134, in get_binary_package_versions
23:13:27     pkg = apt_cache[debian_pkg_name]
23:13:27   File "/usr/lib/python3/dist-packages/apt/cache.py", line 205, in __getitem__
23:13:27     raise KeyError('The cache has no package named %r' % key)
23:13:27 KeyError: "The cache has no package named 'nvidia-cuda-toolkit'"
23:13:27 Build step 'Execute shell' marked build as failure
23:13:27 [ssh-agent] Stopped.
23:13:27 [description-setter] Could not determine descri
```

What I found is amd64 was build on `ubuntu:trusty` Docker but i386 was using `osrf/ubuntu_i386:trusty`.
And on amd64, are we forget to enable multiverse https://github.com/ros-infrastructure/ros_buildfarm/blob/17a5f253b431342dfcd9a2a657722360b4febce7/ros_buildfarm/templates/doc/doc_task.Dockerfile.em#L37-L43


```
root@3040eddc8424:/# uname -a                  
Linux 3040eddc8424 4.4.0-59-generic #80~14.04.1-Ubuntu SMP Fri Jan 6 18:02:02 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
root@3040eddc8424:/# cat /etc/apt/sources.list
# See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
# newer versions of the distribution.

deb http://archive.ubuntu.com/ubuntu/ trusty main restricted
deb-src http://archive.ubuntu.com/ubuntu/ trusty main restricted

## Major bug fix updates produced after the final release of the
## distribution.
deb http://archive.ubuntu.com/ubuntu/ trusty-updates main restricted
deb-src http://archive.ubuntu.com/ubuntu/ trusty-updates main restricted

## Uncomment the following two lines to add software from the 'universe'
## repository.
## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
## team. Also, please note that software in universe WILL NOT receive any
## review or updates from the Ubuntu security team.
deb http://archive.ubuntu.com/ubuntu/ trusty universe
deb-src http://archive.ubuntu.com/ubuntu/ trusty universe
deb http://archive.ubuntu.com/ubuntu/ trusty-updates universe
deb-src http://archive.ubuntu.com/ubuntu/ trusty-updates universe

## N.B. software from this repository may not have been tested as
## extensively as that contained in the main release, although it includes
## newer versions of some applications which may provide useful features.
## Also, please note that software in backports WILL NOT receive any review
## or updates from the Ubuntu security team.
# deb http://archive.ubuntu.com/ubuntu/ trusty-backports main restricted
# deb-src http://archive.ubuntu.com/ubuntu/ trusty-backports main restricted

deb http://archive.ubuntu.com/ubuntu/ trusty-security main restricted
deb-src http://archive.ubuntu.com/ubuntu/ trusty-security main restricted
deb http://archive.ubuntu.com/ubuntu/ trusty-security universe
deb-src http://archive.ubuntu.com/ubuntu/ trusty-security universe
# deb http://archive.ubuntu.com/ubuntu/ trusty-security multiverse
# deb-src http://archive.ubuntu.com/ubuntu/ trusty-security multiverse
```
root@fe60d1b58a90:/# uname -a
Linux fe60d1b58a90 4.4.0-59-generic #80~14.04.1-Ubuntu SMP Fri Jan 6 18:02:02 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
root@fe60d1b58a90:/# cat /etc/apt/sources.list
deb http://archive.ubuntu.com/ubuntu trusty main restricted universe multiverse
deb http://archive.ubuntu.com/ubuntu trusty-updates main restricted universe multiverse
deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse
```