### PR TITLE
fix return code of retry loop

### DIFF
--- a/ros_buildfarm/templates/snippet/install_python3.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/install_python3.Dockerfile.em
@@ -1,4 +1,4 @@
 @[if os_name == 'debian' or os_name == 'ubuntu' and os_code_name in ['saucy', 'vivid', 'wily', 'xenial']]@
 @# Ubuntu Saucy, Vivid and newer have neither Python 2 nor 3 installed by default
-RUN for i in 1 2 3; do apt-get update && apt-get install -q -y python3 && apt-get clean && break || sleep 5; done
+RUN for i in 1 2 3; do apt-get update && apt-get install -q -y python3 && apt-get clean && break || if [[ $i < 3 ]]; then sleep 5; else false; fi; done
 @[end if]@

--- a/ros_buildfarm/templates/snippet/setup_locale.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/setup_locale.Dockerfile.em
@@ -1,6 +1,6 @@
 @[if os_name == 'debian']@
 @# Debian does not have locales installed by default but ubuntu does
-RUN for i in 1 2 3; do apt-get update && apt-get install -q -y locales && apt-get clean && break || sleep 5; done
+RUN for i in 1 2 3; do apt-get update && apt-get install -q -y locales && apt-get clean && break || if [[ $i < 3 ]]; then sleep 5; else false; fi; done
 RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
 @[end if]@
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
Instead of failing on a following step since the step actually failed all 3 times (http://build.ros.org/job/Ibin_uS64__qt_gui__ubuntu_saucy_amd64__binary/8/) the line should return with an error code so that this step actually fails (http://build.ros.org/job/Ibin_uS64__qt_gui__ubuntu_saucy_amd64__binary/9/).