### PR TITLE
Fix old releases multiverse

### DIFF
--- a/ros_buildfarm/templates/snippet/add_additional_repositories.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/add_additional_repositories.Dockerfile.em
@@ -1,10 +1,21 @@
 @[if os_name == 'ubuntu']@
+@{
+from itertools import product
+commands = []
+}@
 @[  if arch in ['amd64', 'i386']]@
-# Add multiverse
-RUN echo "deb http://archive.ubuntu.com/ubuntu/ @(os_code_name) multiverse" >> /etc/apt/sources.list && echo "deb-src http://archive.ubuntu.com/ubuntu/ @(os_code_name) multiverse" >> /etc/apt/sources.list && echo "deb-src http://archive.ubuntu.com/ubuntu/ @(os_code_name)-updates multiverse" >> /etc/apt/sources.list && echo "deb-src http://archive.ubuntu.com/ubuntu/ @(os_code_name)-updates multiverse" >> /etc/apt/sources.list && echo "deb-src http://archive.ubuntu.com/ubuntu/ @(os_code_name)-security multiverse" >> /etc/apt/sources.list && echo "deb-src http://archive.ubuntu.com/ubuntu/ @(os_code_name)-security multiverse" >> /etc/apt/sources.list
+@{
+for distribution, archive_type in product((os_code_name, os_code_name + '-updates', os_code_name + '-security'), ('deb', 'deb-src')):
+    commands.append('echo "%s http://archive.ubuntu.com/ubuntu/ %s multiverse" >> /etc/apt/sources.list' % (archive_type, distribution))
+}@
 @[  elif arch in ['armhf', 'armv8']]@
-# Add multiverse
-RUN echo "deb http://ports.ubuntu.com/ @(os_code_name) multiverse" >> /etc/apt/sources.list && echo "deb-src http://ports.ubuntu.com/ @(os_code_name) multiverse" >> /etc/apt/sources.list && echo "deb-src http://ports.ubuntu.com/ @(os_code_name)-updates multiverse" >> /etc/apt/sources.list && echo "deb-src http://ports.ubuntu.com/ @(os_code_name)-updates multiverse" >> /etc/apt/sources.list && echo "deb-src http://ports.ubuntu.com/ @(os_code_name)-security multiverse" >> /etc/apt/sources.list && echo "deb-src http://ports.ubuntu.com/ @(os_code_name)-security multiverse" >> /etc/apt/sources.list
+@{
+for distribution, archive_type in product((os_code_name, os_code_name + '-updates', os_code_name + '-security'), ('deb', 'deb-src')):
+    commands.append('echo "%s http://ports.ubuntu.com// %s multiverse" >> /etc/apt/sources.list' % (archive_type, distribution))
+}@
+@[  end if]@
+@[  if commands]@
+RUN @(' && '.join(commands))
 @[  end if]@
 @[else if os_name == 'debian']@
 # Add contrib and non-free to debian images

--- a/ros_buildfarm/templates/snippet/add_additional_repositories.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/add_additional_repositories.Dockerfile.em
@@ -1,20 +1,22 @@
 @[if os_name == 'ubuntu']@
 @{
 from itertools import product
-commands = []
 }@
 @[  if arch in ['amd64', 'i386']]@
 @{
+archive_commands = []
+old_releases_commands = []
 for distribution, archive_type in product((os_code_name, os_code_name + '-updates', os_code_name + '-security'), ('deb', 'deb-src')):
-    commands.append('echo "%s http://archive.ubuntu.com/ubuntu/ %s multiverse" >> /etc/apt/sources.list' % (archive_type, distribution))
+    archive_commands.append('echo "%s http://archive.ubuntu.com/ubuntu/ %s multiverse" >> /etc/apt/sources.list' % (archive_type, distribution))
+    old_releases_commands.append('echo "%s http://old-releases.ubuntu.com/ubuntu/ %s multiverse" >> /etc/apt/sources.list' % (archive_type, distribution))
 }@
+RUN grep -q -F -e "deb http://old-releases.ubuntu.com" /etc/apt/sources.list && (@(' && '.join(old_releases_commands))) || (@(' && '.join(archive_commands)))
 @[  elif arch in ['armhf', 'armv8']]@
 @{
+commands = []
 for distribution, archive_type in product((os_code_name, os_code_name + '-updates', os_code_name + '-security'), ('deb', 'deb-src')):
     commands.append('echo "%s http://ports.ubuntu.com// %s multiverse" >> /etc/apt/sources.list' % (archive_type, distribution))
 }@
-@[  end if]@
-@[  if commands]@
 RUN @(' && '.join(commands))
 @[  end if]@
 @[else if os_name == 'debian']@


### PR DESCRIPTION
Follow up of #363.

The first commit refactors the command generation using a loop rather than copy-n-paste (which had `deb-src` too often).

The second commit checks if the sources contains `old-releases.ubuntu.com` and either uses those or `archive.ubuntu.org` for the multiverse entries.