### PR TITLE
Customizable age threshold

### DIFF
--- a/ros_buildfarm/templates/status/blocked_releases_page.html.em
+++ b/ros_buildfarm/templates/status/blocked_releases_page.html.em
@@ -29,6 +29,7 @@
 import time
 }@
   <script type="text/javascript">
+    window.age_threshold_green = moment.duration(7, 'hours');
     window.body_ready_with_age(moment.duration(moment() - moment("@(time.time())", "X")));
   </script>
   <div class="top logo">

--- a/ros_buildfarm/templates/status/blocked_releases_page_job.xml.em
+++ b/ros_buildfarm/templates/status/blocked_releases_page_job.xml.em
@@ -32,7 +32,7 @@
   <triggers>
 @(SNIPPET(
     'trigger_timer',
-    spec='*/15 * * * *',
+    spec='5 */6 * * *',
 ))@
   </triggers>
   <concurrentBuild>false</concurrentBuild>

--- a/ros_buildfarm/templates/status/js/setup.js
+++ b/ros_buildfarm/templates/status/js/setup.js
@@ -25,7 +25,7 @@ window.body_ready = function() {
   }
 };
 
-window.age_threshold_green = moment.duration(20, 'minutes');
+window.age_threshold_green = moment.duration(30, 'minutes');
 window.age_threshold_yellow = moment.duration(1, 'days');
 
 window.body_ready_with_age = function(age) {

--- a/ros_buildfarm/templates/status/js/setup.js
+++ b/ros_buildfarm/templates/status/js/setup.js
@@ -25,16 +25,18 @@ window.body_ready = function() {
   }
 };
 
+window.age_threshold_green = moment.duration(20, 'minutes');
+window.age_threshold_yellow = moment.duration(1, 'days');
+
 window.body_ready_with_age = function(age) {
   // Do age stuff
   $(document).ready(function() {
     $('.age p').replaceWith("<p>Page was generated: <br/>" + age.humanize() + " ago</p>");
-    if (age < moment.duration(20, 'minutes')) {
+    if (age < window.age_threshold_green) {
       $('.age p').css('color', '#3c763d');
       $('.age').css('background-color', '#dff0d8');
       $('.age').css('border-color', '#d6e9c6');
-    }
-    else if (age < moment.duration(1, 'days')) {
+    } else if (age < window.age_threshold_yellow) {
       $('.age p').css('color', '#8a6d3b');
       $('.age').css('background-color', '#fcf8e3');
       $('.age').css('border-color', '#faebcc');

--- a/ros_buildfarm/templates/status/release_compare_page.html.em
+++ b/ros_buildfarm/templates/status/release_compare_page.html.em
@@ -16,6 +16,7 @@
 </head>
 <body>
   <script type="text/javascript">
+    window.age_threshold_green = moment.duration(7, 'hours');
     window.body_ready_with_age(moment.duration(moment() - moment("@start_time", "X")));
   </script>
   <div class="top logo">

--- a/ros_buildfarm/templates/status/release_compare_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_compare_page_job.xml.em
@@ -32,7 +32,7 @@
   <triggers>
 @(SNIPPET(
     'trigger_timer',
-    spec='*/15 * * * *',
+    spec='35 */6 * * *',
 ))@
   </triggers>
   <concurrentBuild>false</concurrentBuild>

--- a/ros_buildfarm/templates/status/release_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_status_page_job.xml.em
@@ -32,7 +32,7 @@
   <triggers>
 @(SNIPPET(
     'trigger_timer',
-    spec='*/15 * * * *',
+    spec='*/20 * * * *',
 ))@
   </triggers>
   <concurrentBuild>false</concurrentBuild>


### PR DESCRIPTION
Regenerate the blocked and compare pages only every six hours (16 pages). The other status pages every 20 minutes (14 pages). This should reduce the load by more than half. Hopefully other management jobs won't starve anymore.

Update the age threshold logic to be configurable per page and match the new schedule.