### PR TITLE
Fix sourcedeb stretch

### DIFF
--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -570,6 +570,7 @@ def _get_sourcedeb_job_config(
         'sourcedeb/*.debian.tar.xz',
         'sourcedeb/*.dsc',
         'sourcedeb/*.orig.tar.gz',
+        'sourcedeb/*_source.buildinfo',
         'sourcedeb/*_source.changes',
     ]
 

--- a/ros_buildfarm/sourcedeb_job.py
+++ b/ros_buildfarm/sourcedeb_job.py
@@ -87,7 +87,14 @@ def build_sourcedeb(sources_dir, os_name=None, os_code_name=None):
         '--git-ignore-new',
         '--git-ignore-branch',
         # dpkg-buildpackage args
-        '-S', '-us', '-uc',
+        '-S']
+    if os_name == 'debian' and os_code_name == 'stretch':
+        # without this dpkg-genbuildinfo assumes a full build
+        # which will check if the build deps are installed
+        cmd.append('--buildinfo-option=source')
+    cmd += [
+        # dpkg-buildpackage args
+        '-us', '-uc',
         # debuild args for lintian
         '--lintian-opts', '--suppress-tags', 'newer-standards-version']
 


### PR DESCRIPTION
~~The first commit adds `-d` to the invocation since at least on Debian Stretch it otherwise checks if the build dependencies are installed. Since they are not necessary to create the sourcedeb I don't think changing the job to install them makes sense (it would make them much slower). I haven't found any reference when this behavior has changed since it is not the case on Ubuntu (but Stretch is using a newer version so it might become the same on Ubuntu at some point).~~

The first commit now passes an option to the new tool `dpkg-genbuildinfo` to only perform a `source` build (new in `dpkg` 1.18.11). This avoids that the tool checks if the build dependencies are installed.

The second commit adds uploading the new `.buildinfo` file to the repo. This file has recently been added (see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=138409).

The job can now successfully build the sourcedeb (http://build.ros.org/view/Lsrc_dS/job/Lsrc_dS__catkin__debian_stretch__source/17/console) and the import only fails since the orig tarballs have different hashes (http://build.ros.org/job/Lrel_import-package/66/console). #374 tries to address this but with this difference in behavior on Stretch compared to the current Ubuntu distros they both just disagree how the sourcedeb should look like (Stretch has the `.buildinfo` file, the others don't).

I think this PR can be reviewed and merged though.