### PR TITLE
check for test dependencies as well

### DIFF
--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -768,7 +768,7 @@ def _get_blocked_releases_info(
             # Accumulate all dependencies for those packages
             for package in packages:
                 recursive_dependencies = dependency_walker.get_recursive_depends(
-                    package, ['build', 'run', 'buildtool'], ros_packages_only=True,
+                    package, ['build', 'buildtool', 'run', 'test'], ros_packages_only=True,
                     limit_depth=depth)
                 package_dependencies = package_dependencies.union(
                     recursive_dependencies)


### PR DESCRIPTION
Devel jobs fail because packages marked as `releasable` don't have all test dependencies satisfied. e.g. http://build.ros.org/job/Ldev__angles__ubuntu_xenial_amd64/1/

This adds test dependencies to the deps to check