### PR TITLE
use python-rosdistro-modules where possible

### DIFF
--- a/ros_buildfarm/templates/devel/devel_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_reconfigure_task.Dockerfile.em
@@ -32,7 +32,7 @@ RUN useradd -u @uid -m buildfarm
 # automatic invalidation once every day
 RUN echo "@today_str"
 
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-pip python3-rosdistro python3-yaml
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-pip python3-rosdistro-modules python3-yaml
 RUN pip3 install jenkinsapi
 
 USER buildfarm

--- a/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
@@ -43,7 +43,7 @@ RUN echo "@today_str"
     os_code_name=os_code_name,
 ))@
 
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-apt python3-catkin-pkg-modules python3-empy python3-rosdep python3-rosdistro wget
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-apt python3-catkin-pkg-modules python3-empy python3-rosdep python3-rosdistro-modules wget
 
 # always invalidate to actually have the latest apt and rosdep state
 RUN echo "@now_str"

--- a/ros_buildfarm/templates/doc/doc_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_create_reconfigure_task.Dockerfile.em
@@ -32,7 +32,7 @@ RUN useradd -u @uid -m buildfarm
 # automatic invalidation once every day
 RUN echo "@today_str"
 
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-pip python3-rosdistro python3-yaml
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-pip python3-rosdistro-modules python3-yaml
 RUN pip3 install jenkinsapi
 
 USER buildfarm

--- a/ros_buildfarm/templates/doc/doc_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_create_task.Dockerfile.em
@@ -38,7 +38,7 @@ RUN echo "@today_str"
     os_code_name=os_code_name,
 ))@
 
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git mercurial python3-apt python3-catkin-pkg-modules python3-empy python3-rosdep python3-rosdistro subversion
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git mercurial python3-apt python3-catkin-pkg-modules python3-empy python3-rosdep python3-rosdistro-modules subversion
 
 # always invalidate to actually have the latest apt and rosdep state
 RUN echo "@now_str"

--- a/ros_buildfarm/templates/doc/doc_metadata_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_metadata_task.Dockerfile.em
@@ -32,7 +32,7 @@ RUN useradd -u @uid -m buildfarm
 # automatic invalidation once every day
 RUN echo "@today_str"
 
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-catkin-pkg-modules python3-rosdistro python3-yaml
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-catkin-pkg-modules python3-rosdistro-modules python3-yaml
 
 USER buildfarm
 

--- a/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
@@ -58,7 +58,7 @@ RUN echo "@today_str"
     os_code_name=os_code_name,
 ))@
 
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y devscripts dpkg-dev python3-apt python3-catkin-pkg-modules python3-empy python3-rosdistro python3-yaml
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y devscripts dpkg-dev python3-apt python3-catkin-pkg-modules python3-empy python3-rosdistro-modules python3-yaml
 
 # always invalidate to actually have the latest apt repo state
 RUN echo "@now_str"

--- a/ros_buildfarm/templates/release/release_check_sync_criteria_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_check_sync_criteria_task.Dockerfile.em
@@ -32,7 +32,7 @@ RUN useradd -u @uid -m buildfarm
 # automatic invalidation once every day
 RUN echo "@today_str"
 
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-rosdistro python3-yaml
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-rosdistro-modules python3-yaml
 
 USER buildfarm
 ENTRYPOINT ["sh", "-c"]

--- a/ros_buildfarm/templates/release/release_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_create_reconfigure_task.Dockerfile.em
@@ -32,7 +32,7 @@ RUN useradd -u @uid -m buildfarm
 # automatic invalidation once every day
 RUN echo "@today_str"
 
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-pip python3-rosdistro python3-yaml
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-pip python3-rosdistro-modules python3-yaml
 RUN pip3 install jenkinsapi
 
 USER buildfarm

--- a/ros_buildfarm/templates/release/release_create_trigger_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_create_trigger_task.Dockerfile.em
@@ -32,7 +32,7 @@ RUN useradd -u @uid -m buildfarm
 # automatic invalidation once every day
 RUN echo "@today_str"
 
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-empy python3-pip python3-rosdistro python3-yaml
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-empy python3-pip python3-rosdistro-modules python3-yaml
 RUN pip3 install jenkinsapi
 
 USER buildfarm

--- a/ros_buildfarm/templates/release/sourcedeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/sourcedeb_task.Dockerfile.em
@@ -44,7 +44,7 @@ RUN echo "@today_str"
     os_code_name=os_code_name,
 ))@
 
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y debhelper dpkg dpkg-dev git git-buildpackage python3-catkin-pkg-modules python3-rosdistro python3-yaml
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y debhelper dpkg dpkg-dev git git-buildpackage python3-catkin-pkg-modules python3-rosdistro-modules python3-yaml
 @[if os_name == 'ubuntu' and os_code_name == 'yakkety']@
 @# git-buildpackage in Yakkety has a bug resulting in using the current time for
 @# the to be archived files resulting in non-deterministic checksums for the tarball

--- a/ros_buildfarm/templates/status/blocked_releases_page_task.Dockerfile.em
+++ b/ros_buildfarm/templates/status/blocked_releases_page_task.Dockerfile.em
@@ -32,7 +32,7 @@ RUN useradd -u @uid -m buildfarm
 # automatic invalidation once every day
 RUN echo "@today_str"
 
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-rosdistro python3-yaml
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-rosdistro-modules python3-yaml
 
 USER buildfarm
 ENTRYPOINT ["sh", "-c"]

--- a/ros_buildfarm/templates/status/release_compare_page_task.Dockerfile.em
+++ b/ros_buildfarm/templates/status/release_compare_page_task.Dockerfile.em
@@ -32,7 +32,7 @@ RUN useradd -u @uid -m buildfarm
 # automatic invalidation once every day
 RUN echo "@today_str"
 
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-rosdistro python3-yaml
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-rosdistro-modules python3-yaml
 
 USER buildfarm
 ENTRYPOINT ["sh", "-c"]

--- a/ros_buildfarm/templates/status/release_status_page_task.Dockerfile.em
+++ b/ros_buildfarm/templates/status/release_status_page_task.Dockerfile.em
@@ -32,7 +32,7 @@ RUN useradd -u @uid -m buildfarm
 # automatic invalidation once every day
 RUN echo "@today_str"
 
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-rosdistro python3-yaml
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-rosdistro-modules python3-yaml
 
 USER buildfarm
 ENTRYPOINT ["sh", "-c"]

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
-Depends: python-argparse, python-catkin-pkg-modules, python-configparser, python-empy, python-rosdistro (>= 0.4.0), python-yaml, python3-empy
-Depends3: python3-catkin-pkg-modules, python3-empy, python3-rosdistro (>= 0.4.0), python3-yaml
+Depends: python-argparse, python-catkin-pkg-modules, python-configparser, python-empy, python-rosdistro-modules, python-yaml, python3-empy
+Depends3: python3-catkin-pkg-modules, python3-empy, python3-rosdistro-modules, python3-yaml
 Conflicts: python3-ros-buildfarm
 Conflicts3: python-ros-buildfarm
 Suite: trusty utopic vivid wily xenial yakkety zesty


### PR DESCRIPTION
Similar to #379.

The only location requiring `python3-rosdistro` is https://github.com/ros-infrastructure/ros_buildfarm/blob/ec218740829145a27b414b66e586d42255213fae/ros_buildfarm/templates/misc/rosdistro_cache_task.Dockerfile.em#L35 since the job invokes one of the rosdistro scripts: `rosdistro_build_cache`.