### PR TITLE
pass -d to skip check for build dependencies, do not sign the .buildinfo file

### DIFF
--- a/ros_buildfarm/sourcedeb_job.py
+++ b/ros_buildfarm/sourcedeb_job.py
@@ -89,9 +89,10 @@ def build_sourcedeb(sources_dir, os_name=None, os_code_name=None):
         # dpkg-buildpackage args
         '-S']
     if os_name == 'debian' and os_code_name == 'stretch':
-        # without this dpkg-genbuildinfo assumes a full build
-        # which will check if the build deps are installed
-        cmd.append('--buildinfo-option=source')
+        # don't fail for not installed build dependencies
+        cmd.append('-d')
+        # do not sign the .buildinfo file, since dpkg 1.18.19
+        cmd.append('-ui')
     cmd += [
         # dpkg-buildpackage args
         '-us', '-uc',


### PR DESCRIPTION
Follow up of #380.

Fixes #382.

http://build.ros.org:8080/view/Lsrc_dS/job/Lsrc_dS__catkin__debian_stretch__source/35/console#console-section-12