### PR TITLE
Fix generate release script

### DIFF
--- a/ros_buildfarm/git.py
+++ b/ros_buildfarm/git.py
@@ -48,8 +48,9 @@ def get_repository():
     if url != FALLBACK_REPOSITORY_URL:
         print(msg1 %
               ("url '%s'" % url, "fallback url '%s' defined in '%s'" %
-               (FALLBACK_REPOSITORY_URL, os.path.abspath(__file__))))
-        print(msg2 % 'fallback url')
+               (FALLBACK_REPOSITORY_URL, os.path.abspath(__file__))),
+              file=sys.stderr)
+        print(msg2 % 'fallback url', file=sys.stderr)
 
     # get repository version from git or fallback to version string
     version = _get_git_repository_version(basepath)
@@ -62,8 +63,8 @@ def get_repository():
     elif version not in [version_number, repository_version]:
         print(msg1 %
               ("version '%s'" % version,
-               "Python package version '%s'" % __version__))
-        print(msg2 % 'Python package version')
+               "Python package version '%s'" % __version__), file=sys.stderr)
+        print(msg2 % 'Python package version', file=sys.stderr)
 
     return namedtuple('Repository', 'url version')(url, version)
 

--- a/ros_buildfarm/templates/__init__.py
+++ b/ros_buildfarm/templates/__init__.py
@@ -96,7 +96,9 @@ def expand_template(template_name, data, options=None):
 
         with open(template_path, 'r') as h:
             content = h.read()
+            interpreter.invoke('beforeFile', name=template_name, file=h)
         interpreter.string(content, template_path, locals=data)
+        interpreter.invoke('afterFile')
 
         value = output.getvalue()
         return value

--- a/scripts/release/generate_release_script.py
+++ b/scripts/release/generate_release_script.py
@@ -60,6 +60,9 @@ def main(argv=sys.argv[1:]):
             template_path = kwargs['file'].name
             if template_path.endswith('/release/binarydeb_job.xml.em'):
                 self.scripts.append('--')
+
+        def beforeInclude(self, *args, **kwargs):
+            template_path = kwargs['file'].name
             if template_path.endswith('/snippet/builder_shell.xml.em'):
                 self.scripts.append(kwargs['locals']['script'])
 


### PR DESCRIPTION
Replaces #376.

This regressed in #164 which replaced the `Interpreter.file()` call with a `Interpreter.string()` call.