### PR TITLE
update examples to use production branch of config

### DIFF
--- a/doc/jobs/devel_jobs.rst
+++ b/doc/jobs/devel_jobs.rst
@@ -141,7 +141,7 @@ from ROS *Indigo* for Ubuntu *Trusty* *amd64*:
 .. code:: sh
 
   mkdir /tmp/devel_job
-  generate_devel_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/master/index.yaml indigo default roscpp_core ubuntu trusty amd64 > /tmp/devel_job/devel_job_indigo_roscpp_core.sh
+  generate_devel_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml indigo default roscpp_core ubuntu trusty amd64 > /tmp/devel_job/devel_job_indigo_roscpp_core.sh
   cd /tmp/devel_job
   sh devel_job_indigo_roscpp_core.sh
 

--- a/doc/jobs/doc_jobs.rst
+++ b/doc/jobs/doc_jobs.rst
@@ -130,6 +130,6 @@ ROS *Indigo* for Ubuntu *Trusty* *amd64*:
 .. code:: sh
 
   mkdir /tmp/doc_job
-  generate_doc_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/master/index.yaml indigo default roscpp_core ubuntu trusty amd64 > /tmp/doc_job/doc_job_indigo_roscpp_core.sh
+  generate_doc_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml indigo default roscpp_core ubuntu trusty amd64 > /tmp/doc_job/doc_job_indigo_roscpp_core.sh
   cd /tmp/doc_job
   sh doc_job_indigo_roscpp_core.sh

--- a/doc/jobs/prerelease_jobs.rst
+++ b/doc/jobs/prerelease_jobs.rst
@@ -68,7 +68,7 @@ The packages defining the *overlay* workspace are: *roscpp*
 .. code:: sh
 
   mkdir /tmp/prerelease_job
-  generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/master/index.yaml indigo default ubuntu trusty amd64 roscpp_core std_msgs --level 0 --pkg roscpp --output-dir /tmp/prerelease_job
+  generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml indigo default ubuntu trusty amd64 roscpp_core std_msgs --level 0 --pkg roscpp --output-dir /tmp/prerelease_job
   cd /tmp/prerelease_job
   ./prerelease.sh
 

--- a/doc/jobs/release_jobs.rst
+++ b/doc/jobs/release_jobs.rst
@@ -151,6 +151,6 @@ from ROS *Indigo* for Ubuntu *Trusty* *amd64*:
 .. code:: sh
 
   mkdir /tmp/release_job
-  generate_release_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/master/index.yaml indigo default roscpp ubuntu trusty amd64 > /tmp/release_job/release_job_indigo_roscpp.sh
+  generate_release_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml indigo default roscpp ubuntu trusty amd64 > /tmp/release_job/release_job_indigo_roscpp.sh
   cd /tmp/release_job
   sh release_job_indigo_roscpp.sh


### PR DESCRIPTION
Change examples to use production branch of config.

Based on this question: https://discourse.ros.org/t/error-during-running-the-devel-job-locally-unable-to-connect-to-54-183-65-232/1425