### PR TITLE
add support for changing upstream content

### DIFF
--- a/ros_buildfarm/sourcedeb_job.py
+++ b/ros_buildfarm/sourcedeb_job.py
@@ -117,7 +117,7 @@ def build_sourcedeb(sources_dir, os_name=None, os_code_name=None):
         # dpkg-buildpackage args
         '-us', '-uc',
         # set the option for dpkg-source to auto-commit upstream changes
-        # This is needed for debian incrments where the upstream had changed.
+        # This is needed for Debian increments where the upstream has changed.
         # It's not the best practice but we have people doing it a bunch.
         '--hook-source=\'bash -c "echo auto-commit > debian/source/options"\'',
         # debuild args for lintian

--- a/ros_buildfarm/sourcedeb_job.py
+++ b/ros_buildfarm/sourcedeb_job.py
@@ -119,7 +119,8 @@ def build_sourcedeb(sources_dir, os_name=None, os_code_name=None):
         # set the option for dpkg-source to auto-commit upstream changes
         # This is needed for Debian increments where the upstream has changed.
         # It's not the best practice but we have people doing it a bunch.
-        '--hook-source=\'bash -c "echo >> debian/source/options && echo auto-commit >> debian/source/options"\'',
+        '--hook-source=\'bash -c "echo >> debian/source/options'
+        ' && echo auto-commit >> debian/source/options"\'',
         # debuild args for lintian
         '--lintian-opts', '--suppress-tags', 'newer-standards-version']
 

--- a/ros_buildfarm/sourcedeb_job.py
+++ b/ros_buildfarm/sourcedeb_job.py
@@ -119,7 +119,7 @@ def build_sourcedeb(sources_dir, os_name=None, os_code_name=None):
         # set the option for dpkg-source to auto-commit upstream changes
         # This is needed for Debian increments where the upstream has changed.
         # It's not the best practice but we have people doing it a bunch.
-        '--hook-source=\'bash -c "echo auto-commit >> debian/source/options"\'',
+        '--hook-source=\'bash -c "echo >> debian/source/options && echo auto-commit >> debian/source/options"\'',
         # debuild args for lintian
         '--lintian-opts', '--suppress-tags', 'newer-standards-version']
 

--- a/ros_buildfarm/sourcedeb_job.py
+++ b/ros_buildfarm/sourcedeb_job.py
@@ -119,7 +119,7 @@ def build_sourcedeb(sources_dir, os_name=None, os_code_name=None):
         # set the option for dpkg-source to auto-commit upstream changes
         # This is needed for Debian increments where the upstream has changed.
         # It's not the best practice but we have people doing it a bunch.
-        '--hook-source=\'bash -c "echo auto-commit > debian/source/options"\'',
+        '--hook-source=\'bash -c "echo auto-commit >> debian/source/options"\'',
         # debuild args for lintian
         '--lintian-opts', '--suppress-tags', 'newer-standards-version']
 

--- a/ros_buildfarm/sourcedeb_job.py
+++ b/ros_buildfarm/sourcedeb_job.py
@@ -116,6 +116,10 @@ def build_sourcedeb(sources_dir, os_name=None, os_code_name=None):
     cmd += [
         # dpkg-buildpackage args
         '-us', '-uc',
+        # set the option for dpkg-source to auto-commit upstream changes
+        # This is needed for debian incrments where the upstream had changed.
+        # It's not the best practice but we have people doing it a bunch.
+        '--hook-source=\'bash -c "echo auto-commit > debian/source/options"\'',
         # debuild args for lintian
         '--lintian-opts', '--suppress-tags', 'newer-standards-version']
 


### PR DESCRIPTION
This will auto commit changes to the upstream tarball as diffs for the debian increment.
Addresses issue in #374

It's not recommended, but there are a lot of times that this comes up in our community. This will make the sourcedebs robust to that.

This fixed the build: http://build.ros.org/view/Kbin_uxhf_uXhf/job/Ksrc_uX__openhrp3__ubuntu_xenial__source/18/console