### PR TITLE
run local jobs during tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,77 @@ language: python
 python:
   - "3.4"
 sudo: false
+env:
+  global:
+    - ROS_DISTRO_NAME=kinetic
+    - OS_NAME=ubuntu
+    - OS_CODE_NAME=xenial
+    - ARCH=amd64
+matrix:
+  include:
+    - language: python
+      python: "3.4"
+      sudo: required
+      services:
+        - docker
+      env: JOB_TYPE=devel REPOSITORY_NAME=roscpp_core
+      before_script:
+        # install catkin for test results
+        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
+        - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+        - sudo apt-get update -qq
+        - sudo apt-get install ros-indigo-catkin -y
+        - python setup.py install
+        - mkdir job && cd job
+      script:
+        - generate_devel_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml $ROS_DISTRO_NAME default $REPOSITORY_NAME $OS_NAME $OS_CODE_NAME $ARCH > job.sh
+        - . /opt/ros/indigo/setup.sh
+        - . job.sh -y
+        - (exit $catkin_test_results_RC)
+    - language: python
+      python: "3.4"
+      sudo: required
+      services:
+        - docker
+      env: JOB_TYPE=doc REPOSITORY_NAME=roscpp_core
+      before_script:
+        - python setup.py install
+        - mkdir job && cd job
+      script:
+        - generate_doc_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml $ROS_DISTRO_NAME default $REPOSITORY_NAME $OS_NAME $OS_CODE_NAME $ARCH > job.sh
+        - sh job.sh
+        - ls -alR generated_documentation/api_rosdoc
+    - language: python
+      python: "3.4"
+      sudo: required
+      services:
+        - docker
+      env: JOB_TYPE=release PACKAGE_NAME=rostime
+      before_script:
+        - python setup.py install
+        - mkdir job && cd job
+      script:
+        - generate_release_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml $ROS_DISTRO_NAME default $PACKAGE_NAME $OS_NAME $OS_CODE_NAME $ARCH > job.sh
+        - sh job.sh
+    - language: python
+      python: "3.4"
+      sudo: required
+      services:
+        - docker
+      env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="roscpp_core" OVERLAY_PACKAGE_NAMES=roscpp
+      before_script:
+        # install catkin for test results
+        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
+        - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+        - sudo apt-get update -qq
+        - sudo apt-get install ros-indigo-catkin -y
+        - python setup.py install
+        - mkdir job && cd job
+      script:
+        - generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH $UNDERLAY_REPOSITORY_NAMES --level 0 --pkg $OVERLAY_PACKAGE_NAMES --output-dir .
+        - . /opt/ros/indigo/setup.sh
+        - . prerelease.sh -y
+        - (exit $catkin_test_results_RC_underlay) && (exit $catkin_test_results_RC_overlay)
 install:
   - pip install catkin-pkg EmPy PyYAML rosdistro
   - pip install coverage flake8 flake8-docstrings flake8-import-order nose pep8 pyflakes

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - OS_NAME=ubuntu
     - OS_CODE_NAME=xenial
     - ARCH=amd64
+    - ROS_BUILDFARM_PULL_REQUEST_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
 matrix:
   include:
     - language: python

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -34,17 +34,27 @@ class JobValidationError(Exception):
         self.message = message
 
 
+next_scope_id = 1
+
+
 class Scope(object):
 
     def __init__(self, scope_name, description):
+        global next_scope_id
         self.scope_name = scope_name
         self.description = description
+        self.scope_id = next_scope_id
+        next_scope_id += 1
 
     def __enter__(self):
+        if os.environ.get('TRAVIS') == 'true':
+            print('travis_fold:start:scope%d' % self.scope_id)
         print('# BEGIN %s: %s' % (self.scope_name, self.description))
 
     def __exit__(self, type, value, traceback):
         print('# END %s' % self.scope_name)
+        if os.environ.get('TRAVIS') == 'true':
+            print('travis_fold:end:scope%d' % self.scope_id)
 
 
 Target = namedtuple('Target', 'os_name os_code_name arch')

--- a/ros_buildfarm/git.py
+++ b/ros_buildfarm/git.py
@@ -52,14 +52,17 @@ def get_repository():
               file=sys.stderr)
         print(msg2 % 'fallback url', file=sys.stderr)
 
-    # get repository version from git or fallback to version string
+    # get repository version from git, PR branch or fallback to version string
     version = _get_git_repository_version(basepath)
     version_number, repository_version = _get_version_parts()
+    pr_branch = os.environ.get('ROS_BUILDFARM_PULL_REQUEST_BRANCH')
     if version is None:
-        if repository_version is None:
-            version = version_number
-        else:
+        if pr_branch is not None:
+            version = pr_branch
+        elif repository_version is not None:
             version = repository_version
+        else:
+            version = version_number
     elif version not in [version_number, repository_version]:
         print(msg1 %
               ("version '%s'" % version,

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -36,10 +36,6 @@ from ros_buildfarm.config import get_distribution_file
 from ros_buildfarm.config import get_index as get_config_index
 from ros_buildfarm.config import get_release_build_files
 from ros_buildfarm.git import get_repository
-from ros_buildfarm.jenkins import configure_job
-from ros_buildfarm.jenkins import configure_view
-from ros_buildfarm.jenkins import connect
-from ros_buildfarm.jenkins import remove_jobs
 from ros_buildfarm.templates import expand_template
 
 from rosdistro import get_distribution_cache
@@ -121,7 +117,10 @@ def configure_release_jobs(
 
     # all further configuration will be handled by either the Jenkins API
     # or by a generated groovy script
-    jenkins = connect(config.jenkins_url) if groovy_script is None else False
+    jenkins = False
+    if groovy_script is None:
+        from ros_buildfarm.jenkins import connect
+        jenkins = connect(config.jenkins_url)
 
     all_view_configs = {}
     all_job_configs = OrderedDict()
@@ -260,6 +259,7 @@ def configure_release_jobs(
                 if groovy_script is None:
                     print("Removing obsolete binary jobs with prefix '%s'" %
                           binary_job_prefix)
+                    from ros_buildfarm.jenkins import remove_jobs
                     remove_jobs(
                         jenkins, binary_job_prefix, excluded_job_names,
                         dry_run=dry_run)
@@ -314,6 +314,7 @@ def configure_release_jobs(
             if groovy_script is None:
                 print("Removing obsolete source jobs with prefix '%s'" %
                       source_job_prefix)
+                from ros_buildfarm.jenkins import remove_jobs
                 remove_jobs(
                     jenkins, source_job_prefix, excluded_job_names,
                     dry_run=dry_run)
@@ -413,6 +414,7 @@ def configure_release_job(
              build_file.abi_incompatibility_assumed):
         dist_cache = get_distribution_cache(index, rosdistro_name)
     if jenkins is None:
+        from ros_buildfarm.jenkins import connect
         jenkins = connect(config.jenkins_url)
     if views is None:
         targets = []
@@ -471,6 +473,7 @@ def configure_release_job(
         other_build_files_same_platform=other_build_files_same_platform)
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
     if isinstance(jenkins, object) and jenkins is not False:
+        from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, source_job_name, job_config, dry_run=dry_run)
     source_job_names.append(source_job_name)
     job_configs[source_job_name] = job_config
@@ -518,6 +521,7 @@ def configure_release_job(
 
 def configure_release_views(
         jenkins, rosdistro_name, release_build_name, targets, dry_run=False):
+    from ros_buildfarm.jenkins import configure_view
     views = {}
 
     for os_name, os_code_name, arch in targets:
@@ -719,6 +723,7 @@ def configure_import_package_job(
         build_files = get_release_build_files(config, rosdistro_name)
         build_file = build_files[release_build_name]
     if jenkins is None:
+        from ros_buildfarm.jenkins import connect
         jenkins = connect(config.jenkins_url)
 
     job_name = get_import_package_job_name(rosdistro_name)
@@ -726,6 +731,7 @@ def configure_import_package_job(
 
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
     if isinstance(jenkins, object) and jenkins is not False:
+        from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, job_name, job_config, dry_run=dry_run)
     return (job_name, job_config)
 
@@ -755,6 +761,7 @@ def configure_sync_packages_to_testing_job(
         build_files = get_release_build_files(config, rosdistro_name)
         build_file = build_files[release_build_name]
     if jenkins is None:
+        from ros_buildfarm.jenkins import connect
         jenkins = connect(config.jenkins_url)
 
     job_name = get_sync_packages_to_testing_job_name(
@@ -765,6 +772,7 @@ def configure_sync_packages_to_testing_job(
 
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
     if isinstance(jenkins, object) and jenkins is not False:
+        from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, job_name, job_config, dry_run=dry_run)
     return (job_name, job_config)
 
@@ -811,6 +819,7 @@ def configure_sync_packages_to_main_job(
         build_files = get_release_build_files(config, rosdistro_name)
         build_file = build_files[release_build_name]
     if jenkins is None:
+        from ros_buildfarm.jenkins import connect
         jenkins = connect(config.jenkins_url)
 
     job_name = get_sync_packages_to_main_job_name(
@@ -820,6 +829,7 @@ def configure_sync_packages_to_main_job(
 
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
     if isinstance(jenkins, object) and jenkins is not False:
+        from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, job_name, job_config, dry_run=dry_run)
     return (job_name, job_config)
 

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -164,6 +164,7 @@ if pull_request:
          ' -v $SSH_AUTH_SOCK:/tmp/ssh_auth_sock' +
          ' -e SSH_AUTH_SOCK=/tmp/ssh_auth_sock' if git_ssh_credential_id else '') +
         ' devel_task_generation.%s_%s' % (rosdistro_name, source_repo_spec.name.lower()),
+        'cd -',  # restore pwd when used in scripts
         'echo "# END SECTION"',
     ]),
 ))@
@@ -190,6 +191,7 @@ if pull_request:
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/catkin_workspace:/tmp/catkin_workspace' +
         ' devel_build_and_install.%s_%s' % (rosdistro_name, source_repo_spec.name.lower()),
+        'cd -',  # restore pwd when used in scripts
         'echo "# END SECTION"',
     ]),
 ))@
@@ -216,6 +218,7 @@ if pull_request:
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/catkin_workspace:/tmp/catkin_workspace' +
         ' devel_build_and_test.%s_%s' % (rosdistro_name, source_repo_spec.name.lower()),
+        'cd -',  # restore pwd when used in scripts
         'echo "# END SECTION"',
     ]),
 ))@

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -154,6 +154,7 @@ if pull_request:
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_generating_dockers/docker.cid' +
         ' -e=HOME=/home/buildfarm' +
+        ' -e=TRAVIS=$TRAVIS' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/catkin_workspace:/tmp/catkin_workspace:ro' +
         ' -v $WORKSPACE/docker_build_and_install:/tmp/docker_build_and_install' +
@@ -185,6 +186,7 @@ if pull_request:
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_build_and_install/docker.cid' +
+        ' -e=TRAVIS=$TRAVIS' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/catkin_workspace:/tmp/catkin_workspace' +
         ' devel_build_and_install.%s_%s' % (rosdistro_name, source_repo_spec.name.lower()),
@@ -210,6 +212,7 @@ if pull_request:
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_build_and_test/docker.cid' +
+        ' -e=TRAVIS=$TRAVIS' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/catkin_workspace:/tmp/catkin_workspace' +
         ' devel_build_and_test.%s_%s' % (rosdistro_name, source_repo_spec.name.lower()),

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -155,6 +155,7 @@ if pull_request:
         ' --cidfile=$WORKSPACE/docker_generating_dockers/docker.cid' +
         ' -e=HOME=/home/buildfarm' +
         ' -e=TRAVIS=$TRAVIS' +
+        ' -e=ROS_BUILDFARM_PULL_REQUEST_BRANCH=$ROS_BUILDFARM_PULL_REQUEST_BRANCH' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/catkin_workspace:/tmp/catkin_workspace:ro' +
         ' -v $WORKSPACE/docker_build_and_install:/tmp/docker_build_and_install' +

--- a/ros_buildfarm/templates/devel/devel_script.sh.em
+++ b/ros_buildfarm/templates/devel/devel_script.sh.em
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+@{
+import os
+}@
 
 # fail script if any single command fails
 set -e
@@ -15,6 +18,9 @@ echo ""
 ))@
 
 echo ""
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:start:devel-clone-source-repos"
+@[end if]@
 echo "Clone source repositories"
 echo ""
 
@@ -23,8 +29,14 @@ echo ""
     workspace_path='catkin_workspace',
     scms=scms,
 ))@
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:end:devel-clone-source-repos"
+@[end if]@
 
 echo ""
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:start:devel-build-workspace"
+@[end if]@
 echo "Build workspace"
 echo ""
 
@@ -32,8 +44,14 @@ echo ""
     'devel/devel_script_build.sh.em',
     scripts=scripts,
 ))@
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:end:devel-build-workspace"
+@[end if]@
 
 echo ""
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:start:devel-test-results"
+@[end if]@
 echo "Test results"
 echo ""
 
@@ -41,3 +59,6 @@ echo ""
     'devel/devel_script_test_results.sh.em',
     workspace_path='catkin_workspace',
 ))@
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:end:devel-test-results"
+@[end if]@

--- a/ros_buildfarm/templates/devel/devel_script_build.sh.em
+++ b/ros_buildfarm/templates/devel/devel_script_build.sh.em
@@ -1,8 +1,25 @@
 # run all build steps
+@{
+import os
+import re
+section_id = 0
+}@
 @[for i, script in enumerate(scripts)]@
 echo "Build step @(i + 1)"
-# output the commands executed in this block
-(set -x; @script)
+@[  for j, line in enumerate(script.splitlines())]@
+@[    if os.environ.get('TRAVIS') == 'true']@
+@[      if line.startswith('echo "# BEGIN SECTION: ')]@
+@{section_id += 1}@
+echo "travis_fold:start:devel-build-section@(section_id)"
+@[      end if]@
+@[    end if]@
+@line
+@[    if os.environ.get('TRAVIS') == 'true']@
+@[      if line == 'echo "# END SECTION"']@
+echo "travis_fold:end:devel-build-section@(section_id)"
+@[      end if]@
+@[    end if]@
+@[  end for]@
 echo ""
 
 @[end for]@

--- a/ros_buildfarm/templates/devel/devel_script_test_results.sh.em
+++ b/ros_buildfarm/templates/devel/devel_script_test_results.sh.em
@@ -4,6 +4,7 @@ echo ""
 if type "catkin_test_results" > /dev/null; then
   set +e
   $catkin_test_results_CMD
+  catkin_test_results_RC=$?
   set -e
 else
   echo "'catkin_test_results' not found on the PATH. Please install catkin and source the environment to output the test result summary."

--- a/ros_buildfarm/templates/doc/doc_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_job.xml.em
@@ -174,6 +174,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_generating_docker/docker.cid' +
         ' -e=HOME=/home/buildfarm' +
+        ' -e=TRAVIS=$TRAVIS' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/rosdoc_lite:/tmp/rosdoc_lite:ro' +
         ' -v $WORKSPACE/catkin-sphinx:/tmp/catkin-sphinx:ro' +
@@ -208,6 +209,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_doc/docker.cid' +
+        ' -e=TRAVIS=$TRAVIS' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/rosdoc_lite:/tmp/rosdoc_lite:ro' +
         ' -v $WORKSPACE/catkin-sphinx:/tmp/catkin-sphinx:ro' +

--- a/ros_buildfarm/templates/doc/doc_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_job.xml.em
@@ -175,6 +175,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' --cidfile=$WORKSPACE/docker_generating_docker/docker.cid' +
         ' -e=HOME=/home/buildfarm' +
         ' -e=TRAVIS=$TRAVIS' +
+        ' -e=ROS_BUILDFARM_PULL_REQUEST_BRANCH=$ROS_BUILDFARM_PULL_REQUEST_BRANCH' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/rosdoc_lite:/tmp/rosdoc_lite:ro' +
         ' -v $WORKSPACE/catkin-sphinx:/tmp/catkin-sphinx:ro' +

--- a/ros_buildfarm/templates/doc/doc_script.sh.em
+++ b/ros_buildfarm/templates/doc/doc_script.sh.em
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+@{
+import os
+}@
 
 # fail script if any single command fails
 set -e
@@ -15,6 +18,9 @@ echo ""
 ))@
 
 echo ""
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:start:doc-clone-source-repos"
+@[end if]@
 echo "Clone source repositories"
 echo ""
 
@@ -23,8 +29,14 @@ echo ""
     workspace_path='catkin_workspace',
     scms=scms,
 ))@
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:end:doc-clone-source-repos"
+@[end if]@
 
 echo ""
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:start:doc-build-workspace"
+@[end if]@
 echo "Build workspace"
 echo ""
 
@@ -32,6 +44,9 @@ echo ""
     'devel/devel_script_build.sh.em',
     scripts=scripts,
 ))@
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:end:doc-build-workspace"
+@[end if]@
 
 echo ""
 echo "Generated documentation: $WORKSPACE/generated_documentation/api_rosdoc"

--- a/ros_buildfarm/templates/prerelease/prerelease_build_overlay_script.sh.em
+++ b/ros_buildfarm/templates/prerelease/prerelease_build_overlay_script.sh.em
@@ -23,6 +23,7 @@ if [ -d "$WORKSPACE/catkin_workspace_overlay/test_results" ]; then
         'devel/devel_script_test_results.sh.em',
         workspace_path='catkin_workspace_overlay',
     ))@
+    catkin_test_results_RC_overlay=$catkin_test_results_RC
 else
     echo ""
     echo "No test results in overlay workspace"

--- a/ros_buildfarm/templates/prerelease/prerelease_build_underlay_script.sh.em
+++ b/ros_buildfarm/templates/prerelease/prerelease_build_underlay_script.sh.em
@@ -22,3 +22,4 @@ echo ""
     'devel/devel_script_test_results.sh.em',
     workspace_path='catkin_workspace',
 ))@
+catkin_test_results_RC_underlay=$catkin_test_results_RC

--- a/ros_buildfarm/templates/prerelease/prerelease_script.sh.em
+++ b/ros_buildfarm/templates/prerelease/prerelease_script.sh.em
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+@{
+import os
+}@
 
 # fail script if any single command fails
 set -e
@@ -15,25 +18,49 @@ echo ""
 ))@
 
 echo ""
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:start:prerelease-clone-underlay-repos"
+@[end if]@
 echo "Clone source repositories for underlay workspace"
 echo ""
 ./prerelease_clone_underlay.sh
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:end:prerelease-clone-underlay-repos"
+@[end if]@
 echo ""
 
 echo ""
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:start:prerelease-clone-overlay-repos"
+@[end if]@
 echo "Clone release repositories for overlay workspace"
 echo ""
 ./prerelease_clone_overlay.sh
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:end:prerelease-clone-overlay-repos"
+@[end if]@
 echo ""
 
 echo ""
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:start:prerelease-build-underlay-workspace"
+@[end if]@
 echo "Build underlay workspace"
 echo ""
-./prerelease_build_underlay.sh
+. prerelease_build_underlay.sh
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:end:prerelease-build-underlay-workspace"
+@[end if]@
 echo ""
 
 echo ""
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:start:prerelease-build-overlay-workspace"
+@[end if]@
 echo "Build overlay workspace"
 echo ""
-./prerelease_build_overlay.sh
+. prerelease_build_overlay.sh
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:end:prerelease-build-overlay-workspace"
+@[end if]@
 echo ""

--- a/ros_buildfarm/templates/release/binarydeb_job.xml.em
+++ b/ros_buildfarm/templates/release/binarydeb_job.xml.em
@@ -123,6 +123,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_generating_docker/docker.cid' +
+        ' -e=TRAVIS=$TRAVIS' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/binarydeb:/tmp/binarydeb' +
         ' -v $WORKSPACE/docker_build_binarydeb:/tmp/docker_build_binarydeb' +
@@ -153,6 +154,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_build_binarydeb/docker.cid' +
         ' -e=HOME=' +
+        ' -e=TRAVIS=$TRAVIS' +
         ' --net=host' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/binarydeb:/tmp/binarydeb' +
@@ -209,6 +211,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 @#         'docker run' +
 @#         ' --rm ' +
 @#         ' --cidfile=$WORKSPACE/docker_install_binarydeb/docker.cid' +
+@#         ' -e=TRAVIS=$TRAVIS' +
 @#         ' -v $WORKSPACE/binarydeb:/tmp/binarydeb:ro' +
 @#         ' binarydeb_install.%s_%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
 @#         'echo "# END SECTION"',

--- a/ros_buildfarm/templates/release/binarydeb_job.xml.em
+++ b/ros_buildfarm/templates/release/binarydeb_job.xml.em
@@ -124,6 +124,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_generating_docker/docker.cid' +
         ' -e=TRAVIS=$TRAVIS' +
+        ' -e=ROS_BUILDFARM_PULL_REQUEST_BRANCH=$ROS_BUILDFARM_PULL_REQUEST_BRANCH' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/binarydeb:/tmp/binarydeb' +
         ' -v $WORKSPACE/docker_build_binarydeb:/tmp/docker_build_binarydeb' +

--- a/ros_buildfarm/templates/release/release_script.sh.em
+++ b/ros_buildfarm/templates/release/release_script.sh.em
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+@{
+import os
+}@
 
 # fail script if any single command fails
 set -e
@@ -9,35 +12,34 @@ echo "Binary job: @binary_job_name"
 BASEPATH=`pwd`
 echo "Using BASEPATH: $BASEPATH"
 
-if [ "`ls`" != "" -a "`ls`" != "`basename $0`" ]; then
-  echo "This script should be executed either in an empty folder or in a folder only containing the script itself" 1>&2
-  if [ "$1" != "-y" ]; then
-    read -p "Do you wish to continue anyway, this might overwrite existing files and folders? (y/N) " answer
-    case $answer in
-      [yY]* ) ;;
-      * ) exit 1;;
-    esac
-  fi
-fi
+@(TEMPLATE(
+    'devel/devel_script_check.sh.em',
+))@
 
 WORKSPACE=$BASEPATH/source
 echo ""
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:start:source-build-workspace"
+@[end if]@
 echo "Using workspace for source: $WORKSPACE"
 
 mkdir -p $WORKSPACE
 cd $WORKSPACE
 
 # run all source build steps
-@[for i, script in enumerate(source_scripts)]@
-echo ""
-echo "Build step @(i + 1)"
-# output the commands executed in this block
-(set -x; @script)
-
-@[end for]@
+@(TEMPLATE(
+    'devel/devel_script_build.sh.em',
+    scripts=source_scripts,
+))@
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:end:source-build-workspace"
+@[end if]@
 
 WORKSPACE=$BASEPATH/binary
 echo ""
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:start:binary-build-workspace"
+@[end if]@
 echo "Using workspace for binary: $WORKSPACE"
 
 mkdir -p $WORKSPACE
@@ -48,11 +50,10 @@ echo "Get artifacts from source job"
 mkdir -p $WORKSPACE/binarydeb
 (set -x; cp $BASEPATH/source/sourcedeb/*.debian.tar.[gx]z $BASEPATH/source/sourcedeb/*.dsc $BASEPATH/source/sourcedeb/*.orig.tar.gz $WORKSPACE/binarydeb/)
 
-# run all binary build steps
-@[for i, script in enumerate(binary_scripts)]@
-echo ""
-echo "Build step @(i + 1)"
-# output the commands executed in this block
-(set -x; @script)
-
-@[end for]@
+@(TEMPLATE(
+    'devel/devel_script_build.sh.em',
+    scripts=binary_scripts,
+))@
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:end:binary-build-workspace"
+@[end if]@

--- a/ros_buildfarm/templates/release/sourcedeb_job.xml.em
+++ b/ros_buildfarm/templates/release/sourcedeb_job.xml.em
@@ -107,6 +107,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_sourcedeb/docker.cid' +
+        ' -e=TRAVIS=$TRAVIS' +
         ' --net=host' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/sourcedeb:/tmp/sourcedeb' +

--- a/ros_buildfarm/templates/snippet/builder_check-docker.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_check-docker.xml.em
@@ -47,9 +47,13 @@ while ((line = br.readLine()) != null) {
     }
 }
 println "docker seems operational, continuing"
-
-println "# END SECTION"
 """,
     script_file=None,
     classpath='',
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'echo "# END SECTION"',
+    ]),
 ))@


### PR DESCRIPTION
With this patch Travis runs:
* nosetests to check style
* run a devel job for `roscpp_core`
* run a doc job for `roscpp_core`
* run a release job for `rostime`
* run a prerelease job for the underlay `cpp_common` and `roscpp_core` and the overlay `roscpp`

That should at least catch some future regressions before trying the changes on Jenkins.