### PR TITLE
gbp buildpackage hooks argument escaping is platform specific

### DIFF
--- a/ros_buildfarm/sourcedeb_job.py
+++ b/ros_buildfarm/sourcedeb_job.py
@@ -113,14 +113,23 @@ def build_sourcedeb(sources_dir, os_name=None, os_code_name=None):
         cmd.append('-d')
         # do not sign the .buildinfo file, since dpkg 1.18.19
         cmd.append('-ui')
+
+    def older_gbp():
+        yield ('debian', 'jessie')
+        for distro_name in ['saucy', 'trusty', 'utopic', 'vivid',
+                            'wily', 'xenial', 'yakkety']:
+            yield ('ubuntu', distro_name)
+
+    hook_quote = "'" if (os_name, os_code_name) in older_gbp() else ''
     cmd += [
         # dpkg-buildpackage args
         '-us', '-uc',
         # set the option for dpkg-source to auto-commit upstream changes
         # This is needed for Debian increments where the upstream has changed.
         # It's not the best practice but we have people doing it a bunch.
-        '--hook-source=\'bash -c "echo >> debian/source/options'
-        ' && echo auto-commit >> debian/source/options"\'',
+        '--hook-source=%(quote)sbash -c "mkdir -p debian/source'
+        ' && echo >> debian/source/options'
+        ' && echo auto-commit >> debian/source/options"%(quote)s' % {'quote': hook_quote},
         # debuild args for lintian
         '--lintian-opts', '--suppress-tags', 'newer-standards-version']
 


### PR DESCRIPTION
The fixes in #395  work on all platforms up to Yakkety, However they break on Zesty and Stretch. 

This patch fixes Zesty and stretch
http://build.ros.org/job/Lsrc_uZ__genpy__ubuntu_zesty__source/11/console


but breaks Xenial and presumably earlier.

http://build.ros.org/view/Lsrc_uX/job/Lsrc_uX__genpy__ubuntu_xenial__source/4/console

It seems that gbp has changed how it escapes/passes through the command line arguments. 

@dirk-thomas do you have any thoughts on how to best conditionalize this? I'm trying to see if there's a config file that could be used. DEBUILD_DPKG_BUILDPACKAGE_OPTS looks promising. http://manpages.ubuntu.com/manpages/precise/man1/debuild.1.html

The change to sh and mkdir aren't necessary, I just didn't know what the error was exactly.