### PR TITLE
a few prerelease improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,19 @@ matrix:
       sudo: required
       services:
         - docker
+      env: JOB_TYPE=external_prerelease
+      before_script:
+        - python setup.py install
+        - mkdir job && cd job
+      script:
+        - git clone -b dummy_package https://github.com/ros-infrastructure/ros_buildfarm catkin_workspace/src/ros_buildfarm
+        - generate_prerelease_script.py $CONFIG_URL $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH --output-dir .
+        - ./prerelease.sh -y
+    - language: python
+      python: "3.4"
+      sudo: required
+      services:
+        - docker
       env: JOB_TYPE=status_pages
       before_script:
         - python setup.py install
@@ -154,6 +167,20 @@ matrix:
         - . /opt/ros/indigo/setup.sh
         - . prerelease.sh -y
         - (exit $catkin_test_results_RC_underlay) && (exit $catkin_test_results_RC_overlay)
+    - language: python
+      python: "2.7"
+      sudo: required
+      services:
+        - docker
+      env: JOB_TYPE=external_prerelease
+      before_script:
+        - pip3 install EmPy
+        - python setup.py install
+        - mkdir job && cd job
+      script:
+        - git clone -b dummy_package https://github.com/ros-infrastructure/ros_buildfarm catkin_workspace/src/ros_buildfarm
+        - generate_prerelease_script.py $CONFIG_URL $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH --output-dir .
+        - ./prerelease.sh -y
     - language: python
       python: "2.7"
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
         - python setup.py install
         - mkdir job && cd job
       script:
-        - generate_prerelease_script.py $CONFIG_URL $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH $UNDERLAY_REPOSITORY_NAMES --level 0 --pkg $OVERLAY_PACKAGE_NAMES --output-dir .
+        - generate_prerelease_script.py $CONFIG_URL $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH $UNDERLAY_REPOSITORY_NAMES --pkg $OVERLAY_PACKAGE_NAMES --output-dir .
         - . /opt/ros/indigo/setup.sh
         - . prerelease.sh -y
         - (exit $catkin_test_results_RC_underlay) && (exit $catkin_test_results_RC_overlay)
@@ -150,7 +150,7 @@ matrix:
         - python setup.py install
         - mkdir job && cd job
       script:
-        - generate_prerelease_script.py $CONFIG_URL $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH $UNDERLAY_REPOSITORY_NAMES --level 0 --pkg $OVERLAY_PACKAGE_NAMES --output-dir .
+        - generate_prerelease_script.py $CONFIG_URL $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH $UNDERLAY_REPOSITORY_NAMES --pkg $OVERLAY_PACKAGE_NAMES --output-dir .
         - . /opt/ros/indigo/setup.sh
         - . prerelease.sh -y
         - (exit $catkin_test_results_RC_underlay) && (exit $catkin_test_results_RC_overlay)

--- a/doc/jobs/prerelease_jobs.rst
+++ b/doc/jobs/prerelease_jobs.rst
@@ -69,7 +69,7 @@ The packages defining the *overlay* workspace are: *roscpp*
 .. code:: sh
 
   mkdir /tmp/prerelease_job
-  generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml indigo default ubuntu trusty amd64 roscpp_core std_msgs --level 0 --pkg roscpp --output-dir /tmp/prerelease_job
+  generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml indigo default ubuntu trusty amd64 roscpp_core std_msgs --pkg roscpp --output-dir /tmp/prerelease_job
   cd /tmp/prerelease_job
   ./prerelease.sh
 

--- a/doc/jobs/prerelease_jobs.rst
+++ b/doc/jobs/prerelease_jobs.rst
@@ -141,3 +141,17 @@ repository type, the repository URL, the branch or tag name, e.g.:
 If the ROS packages in a repository depend on other packages not available in
 the ROS distribution the repositories containing them need to be listed too.
 The *underlay* workspace will then contain all "custom" repositories.
+
+As an alternative to specify all custom repos as command line arguments it is possible to manually populate the underlay (and/or overlay) workspace.
+The following commands are all it takes to run a prerelease job for a custom repository not mentioned in any ROS distribution:
+
+.. code:: sh
+
+  mkdir /tmp/prerelease && cd /tmp/prerelease
+  git clone -b dummy_package https://github.com/ros-infrastructure/ros_buildfarm catkin_workspace/src/ros_buildfarm
+  generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml kinetic default ubuntu xenial amd64 --output-dir .
+  # the argument -y suppresses the question if you want to continue with content already present in the workspace
+  ./prerelease.sh -y
+
+The git clone command is just an example.
+It can be substituted with any other commands to populate the workspaces (e.g. `wstool`, `vcstool`).

--- a/ros_buildfarm/prerelease.py
+++ b/ros_buildfarm/prerelease.py
@@ -44,10 +44,10 @@ def add_overlay_arguments(parser):
     group.add_argument(
         '--level',
         type=int,
-        default=2,
+        default=0,
         metavar='DEPENDENCY_LEVEL',
         help="The depth of the depends-on tree to be included in the " +
-             "overlay workspace (-1 implies unlimited, default: 2)")
+             "overlay workspace (-1 implies unlimited, default: 0)")
 
 
 def get_overlay_package_names(

--- a/ros_buildfarm/templates/prerelease/prerelease_script.sh.em
+++ b/ros_buildfarm/templates/prerelease/prerelease_script.sh.em
@@ -11,7 +11,7 @@ echo ""
 echo "By default this script will continue even if tests fail."
 echo "If you want the script to abort and return a non-zero return code"
 echo "you can set the environment variable ABORT_ON_TEST_FAILURE=1."
-echo "You can also set ABORT_ON_TEST_FAILURE_UNDERLAY=1 or "
+echo "You can also set ABORT_ON_TEST_FAILURE_UNDERLAY=1 or"
 echo "ABORT_ON_TEST_FAILURE_OVERLAY=1 to only affect a specific workspace."
 echo ""
 
@@ -53,7 +53,7 @@ echo "travis_fold:start:prerelease-build-underlay-workspace"
 @[end if]@
 echo "Build underlay workspace"
 echo ""
-. prerelease_build_underlay.sh
+. `pwd`/prerelease_build_underlay.sh
 @[if os.environ.get('TRAVIS') == 'true']@
 echo "travis_fold:end:prerelease-build-underlay-workspace"
 @[end if]@
@@ -63,9 +63,13 @@ echo ""
 @[if os.environ.get('TRAVIS') == 'true']@
 echo "travis_fold:start:prerelease-build-overlay-workspace"
 @[end if]@
-echo "Build overlay workspace"
-echo ""
-. prerelease_build_overlay.sh
+if [ "$(ls -A "$WORKSPACE/catkin_workspace_overlay/src" 2> /dev/null)" != "" ]; then
+  echo "Build overlay workspace"
+  echo ""
+  . `pwd`/prerelease_build_overlay.sh
+else
+  echo "Skipping empty overlay workspace"
+fi
 @[if os.environ.get('TRAVIS') == 'true']@
 echo "travis_fold:end:prerelease-build-overlay-workspace"
 @[end if]@

--- a/scripts/prerelease/generate_prerelease_script.py
+++ b/scripts/prerelease/generate_prerelease_script.py
@@ -176,8 +176,9 @@ def main(argv=sys.argv[1:]):
     from ros_buildfarm import templates
     templates.template_hooks = [hook]
 
-    # use random source repo to pass to devel job template
-    source_repository = deepcopy(list(repositories.values())[0])
+    # use any source repo to pass to devel job template
+    source_repository = deepcopy(
+        dist_file.repositories['catkin'].source_repository)
     if not source_repository:
         print(("The repository '%s' does not have a source entry in the distribution " +
                'file. We cannot generate a prerelease without a source entry.') % repo_name,


### PR DESCRIPTION
* Change the default of the `--level` argument to 0 since it is the most common value (2 doesn't make much sense in many cases).
* Skip processing the overlay workspace if it is empty anyway (saving quite some time).
* Fix the prerelease script when using only external repos which don't have any source entries in the distro.