### PR TITLE
Fix blocking repos script

### DIFF
--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -605,7 +605,7 @@ def _format_repo_table_row(name, data):
 
     # tags for filtering
     tags = ''
-    if data['released']:
+    if data.get('released', False):
         tags += _filter_tag_wrap('RELEASED')
     else:
         tags += _filter_tag_wrap('UNRELEASED')

--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -750,98 +750,108 @@ def _get_blocked_releases_info(
             rosdistro_name))
 
     repos_info = {}
-    for repo_name in prev_repo_names:
-        if repo_name not in repos_info:
-            repos_info[repo_name] = {}
-        repos_info[repo_name]['released'] = repo_name in released_repos
+    unprocessed_repos = prev_repo_names
+    while unprocessed_repos:
+        print('Processing repos:\n{0}\n'.format('\n'.join([str(r) for r in unprocessed_repos])))
+        new_repos_to_process = set()  # set containing repos that come up while processing others
 
-        if repo_name in released_repos:
-            repo = distro_file.repositories[repo_name]
-            version = repo.release_repository.version
-            repos_info[repo_name]['version'] = version
+        for repo_name in unprocessed_repos:
+            if repo_name not in repos_info:
+                repos_info[repo_name] = {}
+            repos_info[repo_name]['released'] = repo_name in released_repos
 
-        else:
-            # Gather info on which required repos have not been released yet
-            # Assume dependencies will be the same as in the previous distribution and find
-            # which ones have been released
-            repo = prev_distro_file.repositories[repo_name]
-            release_repo = repo.release_repository
-            package_dependencies = set()
-            packages = release_repo.package_names
-            # Accumulate all dependencies for those packages
-            for package in packages:
-                recursive_dependencies = dependency_walker.get_recursive_depends(
-                    package, ['build', 'buildtool', 'run', 'test'], ros_packages_only=True,
-                    limit_depth=depth)
-                package_dependencies = package_dependencies.union(
-                    recursive_dependencies)
+            if repo_name in released_repos:
+                repo = distro_file.repositories[repo_name]
+                version = repo.release_repository.version
+                repos_info[repo_name]['version'] = version
 
-            # For all package dependencies, check if they are released yet
-            unreleased_pkgs = package_dependencies.difference(
-                current_package_names)
-            # Remove the packages which this repo provides
-            unreleased_pkgs = unreleased_pkgs.difference(packages)
+            else:
+                # Gather info on which required repos have not been released yet
+                # Assume dependencies will be the same as in the previous distribution and find
+                # which ones have been released
+                repo = prev_distro_file.repositories[repo_name]
+                release_repo = repo.release_repository
+                package_dependencies = set()
+                packages = release_repo.package_names
+                # Accumulate all dependencies for those packages
+                for package in packages:
+                    recursive_dependencies = dependency_walker.get_recursive_depends(
+                        package, ['build', 'buildtool', 'run', 'test'], ros_packages_only=True,
+                        limit_depth=depth)
+                    package_dependencies = package_dependencies.union(
+                        recursive_dependencies)
 
-            # Get maintainer info and repo of unreleased packages
-            maintainers = {}
-            repos_blocked_by = set()
-            for pkg_name in unreleased_pkgs:
-                unreleased_repo_name = prev_distro_file.release_packages[pkg_name].repository_name
-                repos_blocked_by.add(unreleased_repo_name)
-                pkg_xml = prev_distribution.get_release_package_xml(pkg_name)
-                if pkg_xml is not None:
-                    try:
-                        pkg = parse_package_string(pkg_xml)
-                        pkg_maintainers = {m.name: m.email for m in pkg.maintainers}
+                # For all package dependencies, check if they are released yet
+                unreleased_pkgs = package_dependencies.difference(
+                    current_package_names)
+                # Remove the packages which this repo provides
+                unreleased_pkgs = unreleased_pkgs.difference(packages)
+
+                # Get maintainer info and repo of unreleased packages
+                maintainers = {}
+                repos_blocked_by = set()
+                for pkg_name in unreleased_pkgs:
+                    unreleased_repo_name = prev_distro_file.release_packages[pkg_name].repository_name
+                    repos_blocked_by.add(unreleased_repo_name)
+                    pkg_xml = prev_distribution.get_release_package_xml(pkg_name)
+                    if pkg_xml is not None:
                         try:
-                            maintainers[unreleased_repo_name].update(pkg_maintainers)
-                        except KeyError:
-                            maintainers[unreleased_repo_name] = pkg_maintainers
-                    except InvalidPackage:
-                        pkg_maintainers = None
-            if maintainers:
-                repos_info[repo_name]['maintainers'] = maintainers
+                            pkg = parse_package_string(pkg_xml)
+                            pkg_maintainers = {m.name: m.email for m in pkg.maintainers}
+                            try:
+                                maintainers[unreleased_repo_name].update(pkg_maintainers)
+                            except KeyError:
+                                maintainers[unreleased_repo_name] = pkg_maintainers
+                        except InvalidPackage:
+                            pkg_maintainers = None
+                if maintainers:
+                    repos_info[repo_name]['maintainers'] = maintainers
 
-            repos_info[repo_name]['repos_blocked_by'] = {}
-            for blocking_repo_name in repos_blocked_by:
-                # Get url of blocking repos
-                repo_url = None
-                blocking_repo = prev_distro_file.repositories[blocking_repo_name]
-                if blocking_repo.source_repository:
-                    repo_url = blocking_repo.source_repository.url
-                elif blocking_repo.doc_repository:
-                    repo_url = blocking_repo.doc_repository.url
-                repos_info[repo_name]['repos_blocked_by'].update({blocking_repo_name: repo_url})
+                repos_info[repo_name]['repos_blocked_by'] = {}
+                for blocking_repo_name in repos_blocked_by:
+                    # Get url of blocking repos
+                    repo_url = None
+                    blocking_repo = prev_distro_file.repositories[blocking_repo_name]
+                    if blocking_repo.source_repository:
+                        repo_url = blocking_repo.source_repository.url
+                    elif blocking_repo.doc_repository:
+                        repo_url = blocking_repo.doc_repository.url
+                    repos_info[repo_name]['repos_blocked_by'].update({blocking_repo_name: repo_url})
 
-                # Mark blocking relationship in other direction
-                if blocking_repo_name not in repos_info:
-                    repos_info[blocking_repo_name] = {}
-                try:
-                    repos_info[blocking_repo_name]['repos_blocking'].add(repo_name)
-                except KeyError:
-                    repos_info[blocking_repo_name]['repos_blocking'] = set([repo_name])
+                    # Mark blocking relationship in other direction
+                    if blocking_repo_name not in repos_info:
+                        new_repos_to_process.add(blocking_repo_name)
+                        repos_info[blocking_repo_name] = {}
+                    try:
+                        repos_info[blocking_repo_name]['repos_blocking'].add(repo_name)
+                    except KeyError:
+                        repos_info[blocking_repo_name]['repos_blocking'] = set([repo_name])
 
-        # Get url of repo
-        repo_url = None
-        if repo.source_repository:
-            repo_url = repo.source_repository.url
-        elif repo.doc_repository:
-            repo_url = repo.doc_repository.url
-        if repo_url:
-            repos_info[repo_name]['url'] = repo_url
+            # Get url of repo
+            repo_url = None
+            if repo.source_repository:
+                repo_url = repo.source_repository.url
+            elif repo.doc_repository:
+                repo_url = repo.doc_repository.url
+            if repo_url:
+                repos_info[repo_name]['url'] = repo_url
 
-    for repo_name in repos_info.keys():
-        # Recursively get all repos being blocked by this repo
-        recursive_blocks = set([])
-        repos_to_check = set([repo_name])
-        while repos_to_check:
-            next_repo_to_check = repos_to_check.pop()
-            blocks = repos_info[next_repo_to_check].get('repos_blocking', set([]))
-            new_blocks = blocks - recursive_blocks
-            repos_to_check |= new_blocks
-            recursive_blocks |= new_blocks
-        if recursive_blocks:
-            repos_info[repo_name]['recursive_repos_blocking'] = recursive_blocks
+            new_repos_to_process.discard(repo_name)  # this repo has been fully processed now
+
+        for repo_name in repos_info.keys():
+            # Recursively get all repos being blocked by this repo
+            recursive_blocks = set([])
+            repos_to_check = set([repo_name])
+            while repos_to_check:
+                next_repo_to_check = repos_to_check.pop()
+                blocks = repos_info[next_repo_to_check].get('repos_blocking', set([]))
+                new_blocks = blocks - recursive_blocks
+                repos_to_check |= new_blocks
+                recursive_blocks |= new_blocks
+            if recursive_blocks:
+                repos_info[repo_name]['recursive_repos_blocking'] = recursive_blocks
+        known_repos = set(repos_info.keys())
+        unprocessed_repos = new_repos_to_process
 
     return repos_info
 

--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -794,7 +794,8 @@ def _get_blocked_releases_info(
                 maintainers = {}
                 repos_blocked_by = set()
                 for pkg_name in unreleased_pkgs:
-                    unreleased_repo_name = prev_distro_file.release_packages[pkg_name].repository_name
+                    unreleased_repo_name = \
+                        prev_distro_file.release_packages[pkg_name].repository_name
                     repos_blocked_by.add(unreleased_repo_name)
                     pkg_xml = prev_distribution.get_release_package_xml(pkg_name)
                     if pkg_xml is not None:
@@ -819,7 +820,8 @@ def _get_blocked_releases_info(
                         repo_url = blocking_repo.source_repository.url
                     elif blocking_repo.doc_repository:
                         repo_url = blocking_repo.doc_repository.url
-                    repos_info[repo_name]['repos_blocked_by'].update({blocking_repo_name: repo_url})
+                    repos_info[repo_name]['repos_blocked_by'].update(
+                        {blocking_repo_name: repo_url})
 
                     # Mark blocking relationship in other direction
                     if blocking_repo_name not in repos_info:
@@ -853,7 +855,6 @@ def _get_blocked_releases_info(
                 recursive_blocks |= new_blocks
             if recursive_blocks:
                 repos_info[repo_name]['recursive_repos_blocking'] = recursive_blocks
-        known_repos = set(repos_info.keys())
         unprocessed_repos = new_repos_to_process
 
     return repos_info

--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -775,11 +775,14 @@ def _get_blocked_releases_info(
                 packages = release_repo.package_names
                 # Accumulate all dependencies for those packages
                 for package in packages:
-                    recursive_dependencies = dependency_walker.get_recursive_depends(
-                        package, ['build', 'buildtool', 'run', 'test'], ros_packages_only=True,
-                        limit_depth=depth)
-                    package_dependencies = package_dependencies.union(
-                        recursive_dependencies)
+                    try:
+                        recursive_dependencies = dependency_walker.get_recursive_depends(
+                            package, ['build', 'buildtool', 'run', 'test'], ros_packages_only=True,
+                            limit_depth=depth)
+                        package_dependencies = package_dependencies.union(
+                            recursive_dependencies)
+                    except AssertionError as e:
+                        print(e, file=sys.stderr)
 
                 # For all package dependencies, check if they are released yet
                 unreleased_pkgs = package_dependencies.difference(


### PR DESCRIPTION
fixes https://github.com/ros-infrastructure/ros_buildfarm/issues/406

Situation was: `roch` is blocked by `roch_robot` but since that wasn't released into kinetic, `roch_robot` wasn't being fully processed by the script. Now these new repos are being fully processed.

---

Some `roch_*` packages cause errors [here in get_recursive_depends](https://github.com/ros-infrastructure/rosdistro/blob/2bd2c05413b22a36ba136a3779f3575524db7d3b/src/rosdistro/dependency_walker.py#L46):
```
Package 'roch_base' in repository 'roch_robot' has no version set
Package 'roch_bringup' in repository 'roch_robot' has no version set
Package 'roch_capabilities' in repository 'roch_robot' has no version set
Package 'roch_control' in repository 'roch_robot' has no version set
Package 'roch_description' in repository 'roch_robot' has no version set
Package 'roch_ftdi' in repository 'roch_robot' has no version set
Package 'roch_msgs' in repository 'roch_robot' has no version set
Package 'roch_robot' in repository 'roch_robot' has no version set
Package 'roch_safety_controller' in repository 'roch_robot' has no version set
Package 'roch_sensorpc' in repository 'roch_robot' has no version set
```
for now I just ignored those errors with https://github.com/ros-infrastructure/ros_buildfarm/commit/5e3b9b167be184c33261ca252b0424bf6d35a291