### PR TITLE
avoid switching between dst and non-dst timezone

### DIFF
--- a/ros_buildfarm/templates/__init__.py
+++ b/ros_buildfarm/templates/__init__.py
@@ -86,10 +86,9 @@ def expand_template(template_name, data, options=None):
             '%Y-%m-%d %H:%M:%S %z', now)
         data['today_str'] = time.strftime(
             '%Y-%m-%d (%z)', now)
-        tz_name = time.strftime('%Z', now)
-        tz_offset = time.strftime('%z', now)
-        data['timezone'] = '%s%s%s' % \
-            (tz_name, '+' if tz_offset[0] == '-' else '-', tz_offset[1:3])
+        data['timezone'] = '%s%s%02d' % (
+            time.tzname[0], '-' if time.timezone < 0 else '+',
+            time.timezone / 60 / 60)
         data['wrapper_scripts'] = get_wrapper_scripts()
 
         _add_helper_functions(data)


### PR DESCRIPTION
Instead of using DST or non-DST when generating the jobs (which flip flops twice a year) always use the non-DST timezone. While this will result in the same local time it keeps the jobs configuration stable.