### PR TITLE
Adding support for custom rosdep URLs in doc builds

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -315,3 +315,14 @@ The following options are valid in version ``2`` (beside the generic options):
 * ``upload_user``: The username to use to rsync the resultant files.
   This should match the config ``upload::docs::user`` in the buildfarm_deployment_config.
   The default is ``jenkins-slave``
+
+The following options are valid as keys in the ``_config`` dict under
+``targets``:
+
+* ``custom_rosdep_urls``: a list of URLs containing rosdep sources.list.d entry
+  files that are downloaded into /etc/ros/rosdep/sources.list.d at the beginning
+  of the doc job after running *rosdep init*.
+  Note that *rosdep init* will add the 20-default.list file from the public
+  rosdistro by default.
+  To override this, add an entry to this list corresponding to the
+  20-default.list file from your forked rosdistro repository.

--- a/ros_buildfarm/config/doc_build_file.py
+++ b/ros_buildfarm/config/doc_build_file.py
@@ -123,6 +123,13 @@ class DocBuildFile(BuildFile):
             self.skip_ignored_repositories = \
                 bool(data['skip_ignored_repositories'])
 
+        self.custom_rosdep_urls = []
+        if '_config' in data['targets']:
+            if 'custom_rosdep_urls' in data['targets']['_config']:
+                self.custom_rosdep_urls = \
+                    data['targets']['_config']['custom_rosdep_urls']
+                assert isinstance(self.custom_rosdep_urls, list)
+
         # repository black-/whitelist can only be used with doc type rosdoc
         assert not self.repository_blacklist or is_rosdoc_type
         assert not self.repository_whitelist or is_rosdoc_type

--- a/ros_buildfarm/templates/doc/doc_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_create_task.Dockerfile.em
@@ -45,7 +45,11 @@ RUN echo "@now_str"
 RUN python3 -u /tmp/wrapper_scripts/apt.py update
 
 ENV ROSDISTRO_INDEX_URL @rosdistro_index_url
-RUN rosdep init
+
+@(TEMPLATE(
+    'snippet/rosdep_init.Dockerfile.em',
+    custom_rosdep_urls=custom_rosdep_urls,
+))@
 
 USER buildfarm
 

--- a/scripts/doc/run_doc_job.py
+++ b/scripts/doc/run_doc_job.py
@@ -20,8 +20,8 @@ import sys
 
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_name
-from ros_buildfarm.argument import add_argument_custom_rosdep_urls
 from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_custom_rosdep_urls
 from ros_buildfarm.argument import \
     add_argument_distribution_repository_key_files
 from ros_buildfarm.argument import add_argument_distribution_repository_urls

--- a/scripts/doc/run_doc_job.py
+++ b/scripts/doc/run_doc_job.py
@@ -20,6 +20,7 @@ import sys
 
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_name
+from ros_buildfarm.argument import add_argument_custom_rosdep_urls
 from ros_buildfarm.argument import add_argument_config_url
 from ros_buildfarm.argument import \
     add_argument_distribution_repository_key_files
@@ -51,6 +52,7 @@ def main(argv=sys.argv[1:]):
     add_argument_vcs_information(parser)
     add_argument_distribution_repository_urls(parser)
     add_argument_distribution_repository_key_files(parser)
+    add_argument_custom_rosdep_urls(parser)
     add_argument_force(parser)
     add_argument_dockerfile_dir(parser)
     args = parser.parse_args(argv)
@@ -61,7 +63,7 @@ def main(argv=sys.argv[1:]):
         'distribution_repository_keys': get_distribution_repository_keys(
             args.distribution_repository_urls,
             args.distribution_repository_key_files),
-
+        'custom_rosdep_urls': args.custom_rosdep_urls,
         'uid': get_user_id(),
     })
     create_dockerfile(

--- a/scripts/doc/run_doc_job.py
+++ b/scripts/doc/run_doc_job.py
@@ -20,7 +20,6 @@ import sys
 
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_name
-from ros_buildfarm.argument import add_argument_custom_rosdep_urls
 from ros_buildfarm.argument import add_argument_config_url
 from ros_buildfarm.argument import add_argument_custom_rosdep_urls
 from ros_buildfarm.argument import \

--- a/scripts/doc/run_doc_job.py
+++ b/scripts/doc/run_doc_job.py
@@ -20,6 +20,7 @@ import sys
 
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_name
+from ros_buildfarm.argument import add_argument_custom_rosdep_urls
 from ros_buildfarm.argument import add_argument_config_url
 from ros_buildfarm.argument import add_argument_custom_rosdep_urls
 from ros_buildfarm.argument import \


### PR DESCRIPTION
This addresses #409 by adding support for custom rosdep URLs in doc jobs. I still need to try to test this against our build farm, but I want to open it up for comments in the meantime.

Note that I adapted these changes from the [PR](https://github.com/ros-infrastructure/ros_buildfarm/pull/100) that added the same functionality for devel jobs.