### PR TITLE
use forked code in Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
         - sudo apt-get install ros-indigo-catkin -y
         - python setup.py install
         - mkdir job && cd job
+        - ln -s .. ros_buildfarm
       script:
         - generate_devel_script.py $CONFIG_URL $ROS_DISTRO_NAME default $REPOSITORY_NAME $OS_NAME $OS_CODE_NAME $ARCH > job.sh
         - . /opt/ros/indigo/setup.sh
@@ -40,9 +41,10 @@ matrix:
       before_script:
         - python setup.py install
         - mkdir job && cd job
+        - ln -s .. ros_buildfarm
       script:
         - generate_doc_script.py $CONFIG_URL $ROS_DISTRO_NAME default $REPOSITORY_NAME $OS_NAME $OS_CODE_NAME $ARCH > job.sh
-        - sh job.sh
+        - sh job.sh -y
         - ls -alR generated_documentation/api_rosdoc
     - language: python
       python: "3.4"
@@ -53,9 +55,11 @@ matrix:
       before_script:
         - python setup.py install
         - mkdir job && cd job
+        - mkdir source && cd source && ln -s ../.. ros_buildfarm && cd ..
+        - mkdir binary && cd binary && ln -s ../.. ros_buildfarm && cd ..
       script:
         - generate_release_script.py $CONFIG_URL $ROS_DISTRO_NAME default $PACKAGE_NAME $OS_NAME $OS_CODE_NAME $ARCH > job.sh
-        - sh job.sh
+        - sh job.sh -y
     - language: python
       python: "3.4"
       sudo: required
@@ -70,6 +74,7 @@ matrix:
         - sudo apt-get install ros-indigo-catkin -y
         - python setup.py install
         - mkdir job && cd job
+        - ln -s .. ros_buildfarm
       script:
         - generate_prerelease_script.py $CONFIG_URL $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH $UNDERLAY_REPOSITORY_NAMES --pkg $OVERLAY_PACKAGE_NAMES --output-dir .
         - . /opt/ros/indigo/setup.sh
@@ -84,6 +89,7 @@ matrix:
       before_script:
         - python setup.py install
         - mkdir job && cd job
+        - ln -s .. ros_buildfarm
       script:
         - git clone -b dummy_package https://github.com/ros-infrastructure/ros_buildfarm catkin_workspace/src/ros_buildfarm
         - generate_prerelease_script.py $CONFIG_URL $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH --output-dir .
@@ -117,6 +123,7 @@ matrix:
         - sudo apt-get install ros-indigo-catkin -y
         - python setup.py install
         - mkdir job && cd job
+        - ln -s .. ros_buildfarm
       script:
         - generate_devel_script.py $CONFIG_URL $ROS_DISTRO_NAME default $REPOSITORY_NAME $OS_NAME $OS_CODE_NAME $ARCH > job.sh
         - . /opt/ros/indigo/setup.sh
@@ -131,9 +138,10 @@ matrix:
       before_script:
         - python setup.py install
         - mkdir job && cd job
+        - ln -s .. ros_buildfarm
       script:
         - generate_doc_script.py $CONFIG_URL $ROS_DISTRO_NAME default $REPOSITORY_NAME $OS_NAME $OS_CODE_NAME $ARCH > job.sh
-        - sh job.sh
+        - sh job.sh -y
         - ls -alR generated_documentation/api_rosdoc
     - language: python
       python: "2.7"
@@ -144,9 +152,11 @@ matrix:
       before_script:
         - python setup.py install
         - mkdir job && cd job
+        - mkdir source && cd source && ln -s ../.. ros_buildfarm && cd ..
+        - mkdir binary && cd binary && ln -s ../.. ros_buildfarm && cd ..
       script:
         - generate_release_script.py $CONFIG_URL $ROS_DISTRO_NAME default $PACKAGE_NAME $OS_NAME $OS_CODE_NAME $ARCH > job.sh
-        - sh job.sh
+        - sh job.sh -y
     - language: python
       python: "2.7"
       sudo: required
@@ -162,6 +172,7 @@ matrix:
         - sudo apt-get install ros-indigo-catkin -y
         - python setup.py install
         - mkdir job && cd job
+        - ln -s .. ros_buildfarm
       script:
         - generate_prerelease_script.py $CONFIG_URL $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH $UNDERLAY_REPOSITORY_NAMES --pkg $OVERLAY_PACKAGE_NAMES --output-dir .
         - . /opt/ros/indigo/setup.sh
@@ -177,6 +188,7 @@ matrix:
         - pip3 install EmPy
         - python setup.py install
         - mkdir job && cd job
+        - ln -s .. ros_buildfarm
       script:
         - git clone -b dummy_package https://github.com/ros-infrastructure/ros_buildfarm catkin_workspace/src/ros_buildfarm
         - generate_prerelease_script.py $CONFIG_URL $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH --output-dir .

--- a/scripts/devel/generate_devel_script.py
+++ b/scripts/devel/generate_devel_script.py
@@ -58,7 +58,18 @@ def main(argv=sys.argv[1:]):
                 self.scms.append(
                     (kwargs['locals']['repo_spec'], kwargs['locals']['path']))
             if template_path.endswith('/snippet/builder_shell.xml.em'):
-                self.scripts.append(kwargs['locals']['script'])
+                script = kwargs['locals']['script']
+                # reuse existing ros_buildfarm folder if it exists
+                if 'Clone ros_buildfarm' in script:
+                    lines = script.splitlines()
+                    lines.insert(0, 'if [ ! -d "ros_buildfarm" ]; then')
+                    lines += [
+                        'else',
+                        'echo "Using existing ros_buildfarm folder"',
+                        'fi',
+                    ]
+                    script = '\n'.join(lines)
+                self.scripts.append(script)
 
     hook = IncludeHook()
     from ros_buildfarm import templates

--- a/scripts/doc/generate_doc_script.py
+++ b/scripts/doc/generate_doc_script.py
@@ -60,7 +60,18 @@ def main(argv=sys.argv[1:]):
                 self.scms.append(
                     (kwargs['locals']['repo_spec'], kwargs['locals']['path']))
             if template_path.endswith('/snippet/builder_shell.xml.em'):
-                self.scripts.append(kwargs['locals']['script'])
+                script = kwargs['locals']['script']
+                # reuse existing ros_buildfarm folder if it exists
+                if 'Clone ros_buildfarm' in script:
+                    lines = script.splitlines()
+                    lines.insert(0, 'if [ ! -d "ros_buildfarm" ]; then')
+                    lines += [
+                        'else',
+                        'echo "Using existing ros_buildfarm folder"',
+                        'fi',
+                    ]
+                    script = '\n'.join(lines)
+                self.scripts.append(script)
 
     hook = IncludeHook()
     from ros_buildfarm import templates

--- a/scripts/prerelease/generate_prerelease_script.py
+++ b/scripts/prerelease/generate_prerelease_script.py
@@ -170,7 +170,18 @@ def main(argv=sys.argv[1:]):
         def beforeInclude(self, *args, **kwargs):
             template_path = kwargs['file'].name
             if template_path.endswith('/snippet/builder_shell.xml.em'):
-                self.scripts.append(kwargs['locals']['script'])
+                script = kwargs['locals']['script']
+                # reuse existing ros_buildfarm folder if it exists
+                if 'Clone ros_buildfarm' in script:
+                    lines = script.splitlines()
+                    lines.insert(0, 'if [ ! -d "ros_buildfarm" ]; then')
+                    lines += [
+                        'else',
+                        'echo "Using existing ros_buildfarm folder"',
+                        'fi',
+                    ]
+                    script = '\n'.join(lines)
+                self.scripts.append(script)
 
     hook = IncludeHook()
     from ros_buildfarm import templates

--- a/scripts/release/generate_release_script.py
+++ b/scripts/release/generate_release_script.py
@@ -64,7 +64,18 @@ def main(argv=sys.argv[1:]):
         def beforeInclude(self, *args, **kwargs):
             template_path = kwargs['file'].name
             if template_path.endswith('/snippet/builder_shell.xml.em'):
-                self.scripts.append(kwargs['locals']['script'])
+                script = kwargs['locals']['script']
+                # reuse existing ros_buildfarm folder if it exists
+                if 'Clone ros_buildfarm' in script:
+                    lines = script.splitlines()
+                    lines.insert(0, 'if [ ! -d "ros_buildfarm" ]; then')
+                    lines += [
+                        'else',
+                        'echo "Using existing ros_buildfarm folder"',
+                        'fi',
+                    ]
+                    script = '\n'.join(lines)
+                self.scripts.append(script)
 
     hook = IncludeHook()
     from ros_buildfarm import templates


### PR DESCRIPTION
The [recently added tests](https://github.com/ros-infrastructure/ros_buildfarm/pull/396) don't do the right thing when the PR branch is in a forked repo (rather than within this repo as it was the case for the PRs since these tests have been added). This patch will make the tests use the `ros_buildfarm` code already cloned in Travis.