### PR TITLE
ubuntu doesn't ship with locales anymore

### DIFF
--- a/ros_buildfarm/templates/devel/devel_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_reconfigure_task.Dockerfile.em
@@ -8,8 +8,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name='ubuntu',
-    os_code_name='trusty',
     timezone=timezone,
 ))@
 

--- a/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
@@ -13,8 +13,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name=os_name,
-    os_code_name=os_code_name,
     timezone=timezone,
 ))@
 

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -13,8 +13,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name=os_name,
-    os_code_name=os_code_name,
     timezone=timezone,
 ))@
 

--- a/ros_buildfarm/templates/doc/doc_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_create_reconfigure_task.Dockerfile.em
@@ -8,8 +8,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name='ubuntu',
-    os_code_name='trusty',
     timezone=timezone,
 ))@
 

--- a/ros_buildfarm/templates/doc/doc_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_create_task.Dockerfile.em
@@ -8,8 +8,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name='ubuntu',
-    os_code_name=os_code_name,
     timezone=timezone,
 ))@
 

--- a/ros_buildfarm/templates/doc/doc_independent_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_independent_task.Dockerfile.em
@@ -8,8 +8,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name='ubuntu',
-    os_code_name='trusty',
     timezone=timezone,
 ))@
 

--- a/ros_buildfarm/templates/doc/doc_metadata_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_metadata_task.Dockerfile.em
@@ -8,8 +8,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name='ubuntu',
-    os_code_name='trusty',
     timezone=timezone,
 ))@
 

--- a/ros_buildfarm/templates/doc/doc_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_task.Dockerfile.em
@@ -13,8 +13,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name=os_name,
-    os_code_name=os_code_name,
     timezone=timezone,
 ))@
 

--- a/ros_buildfarm/templates/misc/rosdistro_cache_task.Dockerfile.em
+++ b/ros_buildfarm/templates/misc/rosdistro_cache_task.Dockerfile.em
@@ -8,8 +8,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name='ubuntu',
-    os_code_name='trusty',
     timezone=timezone,
 ))@
 

--- a/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
@@ -13,8 +13,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name=os_name,
-    os_code_name=os_code_name,
     timezone=timezone,
 ))@
 

--- a/ros_buildfarm/templates/release/binarydeb_install_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_install_task.Dockerfile.em
@@ -14,8 +14,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name=os_name,
-    os_code_name=os_code_name,
     timezone=timezone,
 ))@
 

--- a/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
@@ -14,8 +14,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name=os_name,
-    os_code_name=os_code_name,
     timezone=timezone,
 ))@
 

--- a/ros_buildfarm/templates/release/release_check_sync_criteria_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_check_sync_criteria_task.Dockerfile.em
@@ -8,8 +8,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name='ubuntu',
-    os_code_name='trusty',
     timezone=timezone,
 ))@
 

--- a/ros_buildfarm/templates/release/release_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_create_reconfigure_task.Dockerfile.em
@@ -8,8 +8,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name='ubuntu',
-    os_code_name='trusty',
     timezone=timezone,
 ))@
 

--- a/ros_buildfarm/templates/release/release_create_trigger_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_create_trigger_task.Dockerfile.em
@@ -8,8 +8,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name='ubuntu',
-    os_code_name='trusty',
     timezone=timezone,
 ))@
 

--- a/ros_buildfarm/templates/release/sourcedeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/sourcedeb_task.Dockerfile.em
@@ -8,8 +8,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name=os_name,
-    os_code_name=os_code_name,
     timezone=timezone,
 ))@
 

--- a/ros_buildfarm/templates/snippet/setup_locale.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/setup_locale.Dockerfile.em
@@ -1,8 +1,5 @@
-@[if os_name == 'debian']@
-@# Debian does not have locales installed by default but ubuntu does
 RUN for i in 1 2 3; do apt-get update && apt-get install -q -y locales && apt-get clean && break || if [[ $i < 3 ]]; then sleep 5; else false; fi; done
 RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
-@[end if]@
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV TZ @timezone

--- a/ros_buildfarm/templates/status/blocked_releases_page_task.Dockerfile.em
+++ b/ros_buildfarm/templates/status/blocked_releases_page_task.Dockerfile.em
@@ -8,8 +8,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name='ubuntu',
-    os_code_name='trusty',
     timezone=timezone,
 ))@
 

--- a/ros_buildfarm/templates/status/release_compare_page_task.Dockerfile.em
+++ b/ros_buildfarm/templates/status/release_compare_page_task.Dockerfile.em
@@ -8,8 +8,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name='ubuntu',
-    os_code_name='trusty',
     timezone=timezone,
 ))@
 

--- a/ros_buildfarm/templates/status/release_status_page_task.Dockerfile.em
+++ b/ros_buildfarm/templates/status/release_status_page_task.Dockerfile.em
@@ -8,8 +8,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
-    os_name='ubuntu',
-    os_code_name='trusty',
     timezone=timezone,
 ))@
 


### PR DESCRIPTION
As of today, `xenial` and `zesty` don't ship with locales anymore.
This PR installs it for all ubuntu platforms because I'm expecting the new `yakkety` and `trusty` image to not have it either in the next image.

Addresses https://github.com/ros-infrastructure/ros_buildfarm/issues/414