### PR TITLE
update plugin versions and fix groovy failures

### DIFF
--- a/ros_buildfarm/templates/dashboard_view_all_jobs.xml.em
+++ b/ros_buildfarm/templates/dashboard_view_all_jobs.xml.em
@@ -15,7 +15,7 @@
     <hudson.views.LastSuccessColumn/>
     <hudson.views.LastFailureColumn/>
     <hudson.views.LastDurationColumn/>
-    <jenkins.plugins.extracolumns.BuildDescriptionColumn plugin="extra-columns@@1.17">
+    <jenkins.plugins.extracolumns.BuildDescriptionColumn plugin="extra-columns@@1.18">
       <columnWidth>80</columnWidth>
       <forceWidth>true</forceWidth>
     </jenkins.plugins.extracolumns.BuildDescriptionColumn>

--- a/ros_buildfarm/templates/dashboard_view_devel_jobs.xml.em
+++ b/ros_buildfarm/templates/dashboard_view_devel_jobs.xml.em
@@ -23,7 +23,7 @@
     <jenkins.plugins.extracolumns.TestResultColumn plugin="extra-columns@@1.17">
       <testResultFormat>1</testResultFormat>
     </jenkins.plugins.extracolumns.TestResultColumn>
-    <hudson.plugins.warnings.WarningsColumn plugin="warnings@@4.59"/>
+    <hudson.plugins.warnings.WarningsColumn plugin="warnings@@4.62"/>
   </columns>
 @[if include_regex]@
   <includeRegex>@include_regex</includeRegex>

--- a/ros_buildfarm/templates/devel/devel_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_reconfigure-jobs_job.xml.em
@@ -61,13 +61,6 @@
 ))@
 @(SNIPPET(
     'builder_shell',
-    script="""rm -fr $WORKSPACE/classpath
-mkdir -p $WORKSPACE/classpath
-cd $WORKSPACE/classpath
-wget --no-verbose https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/java-diff-utils/diffutils-1.2.1.jar""",
-))@
-@(SNIPPET(
-    'builder_shell',
     script='\n'.join([
         'rm -fr $WORKSPACE/docker_generate_devel_jobs',
         'rm -fr $WORKSPACE/reconfigure_jobs',
@@ -120,7 +113,6 @@ wget --no-verbose https://storage.googleapis.com/google-code-archive-downloads/v
     'builder_system-groovy',
     command=None,
     script_file='$WORKSPACE/reconfigure_jobs/reconfigure_jobs.groovy',
-    classpath='$WORKSPACE/classpath/diffutils-1.2.1.jar',
 ))@
   </builders>
   <publishers>

--- a/ros_buildfarm/templates/doc/doc_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_reconfigure-jobs_job.xml.em
@@ -61,13 +61,6 @@
 ))@
 @(SNIPPET(
     'builder_shell',
-    script="""rm -fr $WORKSPACE/classpath
-mkdir -p $WORKSPACE/classpath
-cd $WORKSPACE/classpath
-wget --no-verbose https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/java-diff-utils/diffutils-1.2.1.jar""",
-))@
-@(SNIPPET(
-    'builder_shell',
     script='\n'.join([
         'rm -fr $WORKSPACE/docker_generate_doc_jobs',
         'rm -fr $WORKSPACE/reconfigure_jobs',
@@ -120,7 +113,6 @@ wget --no-verbose https://storage.googleapis.com/google-code-archive-downloads/v
     'builder_system-groovy',
     command=None,
     script_file='$WORKSPACE/reconfigure_jobs/reconfigure_jobs.groovy',
-    classpath='$WORKSPACE/classpath/diffutils-1.2.1.jar',
 ))@
   </builders>
   <publishers>

--- a/ros_buildfarm/templates/release/release_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/release/release_reconfigure-jobs_job.xml.em
@@ -61,13 +61,6 @@
 ))@
 @(SNIPPET(
     'builder_shell',
-    script="""rm -fr $WORKSPACE/classpath
-mkdir -p $WORKSPACE/classpath
-cd $WORKSPACE/classpath
-wget --no-verbose https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/java-diff-utils/diffutils-1.2.1.jar""",
-))@
-@(SNIPPET(
-    'builder_shell',
     script='\n'.join([
         'rm -fr $WORKSPACE/docker_generate_release_jobs',
         'rm -fr $WORKSPACE/reconfigure_jobs',
@@ -120,7 +113,6 @@ wget --no-verbose https://storage.googleapis.com/google-code-archive-downloads/v
     'builder_system-groovy',
     command=None,
     script_file='$WORKSPACE/reconfigure_jobs/reconfigure_jobs.groovy',
-    classpath='$WORKSPACE/classpath/diffutils-1.2.1.jar',
 ))@
   </builders>
   <publishers>

--- a/ros_buildfarm/templates/release/release_trigger-broken-with-non-broken-upstream_job.xml.em
+++ b/ros_buildfarm/templates/release/release_trigger-broken-with-non-broken-upstream_job.xml.em
@@ -106,7 +106,6 @@ for (p in hudson.model.Hudson.instance.projects) {
 }
 """ % (source_project_name_prefix, binary_project_name_prefix),
     script_file=None,
-    classpath='',
 ))@
   </builders>
   <publishers>

--- a/ros_buildfarm/templates/release/release_trigger-jobs_job.xml.em
+++ b/ros_buildfarm/templates/release/release_trigger-jobs_job.xml.em
@@ -113,7 +113,6 @@
     'builder_system-groovy',
     command=None,
     script_file='$WORKSPACE/trigger_jobs/trigger_jobs.groovy',
-    classpath='',
 ))@
   </builders>
   <publishers>

--- a/ros_buildfarm/templates/snippet/build-wrapper_ssh-agent.xml.em
+++ b/ros_buildfarm/templates/snippet/build-wrapper_ssh-agent.xml.em
@@ -1,4 +1,4 @@
-    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.14">
+    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.15">
       <credentialIds>
 @[for credential_id in credential_ids]@
         <string>@credential_id</string>

--- a/ros_buildfarm/templates/snippet/builder_check-docker.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_check-docker.xml.em
@@ -49,7 +49,6 @@ while ((line = br.readLine()) != null) {
 println "docker seems operational, continuing"
 """,
     script_file=None,
-    classpath='',
 ))@
 @(SNIPPET(
     'builder_shell',

--- a/ros_buildfarm/templates/snippet/builder_parameterized-trigger.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_parameterized-trigger.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.parameterizedtrigger.TriggerBuilder plugin="parameterized-trigger@@2.32">
+    <hudson.plugins.parameterizedtrigger.TriggerBuilder plugin="parameterized-trigger@@2.33">
       <configs>
         <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
 @[if parameters]@

--- a/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
@@ -1,14 +1,15 @@
     <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.0">
 @[if command]@
-      <scriptSource class="hudson.plugins.groovy.StringScriptSource">
-        <command>@ESCAPE(command)</command>
-      </scriptSource>
+      <source class="hudson.plugins.groovy.StringSystemScriptSource">
+        <script plugin="script-security@@1.27">
+          <script>@ESCAPE(command)</script>
+          <sandbox>false</sandbox>
+        </script>
+      </source>
 @[end if]@
 @[if script_file]@
-      <scriptSource class="hudson.plugins.groovy.FileScriptSource">
+      <source class="hudson.plugins.groovy.FileSystemScriptSource">
         <scriptFile>@ESCAPE(script_file)</scriptFile>
-      </scriptSource>
+      </source>
 @[end if]@
-      <bindings/>
-      <classpath>@classpath</classpath>
     </hudson.plugins.groovy.SystemGroovy>

--- a/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.groovy.SystemGroovy plugin="groovy@@1.30">
+    <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.0">
 @[if command]@
       <scriptSource class="hudson.plugins.groovy.StringScriptSource">
         <command>@ESCAPE(command)</command>

--- a/ros_buildfarm/templates/snippet/builder_system-groovy_check-free-disk-space-disabled-slaves.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy_check-free-disk-space-disabled-slaves.xml.em
@@ -29,5 +29,4 @@ for (computer in Jenkins.instance.getComputers()) {
 }
 """,
     script_file=None,
-    classpath='',
 ))@

--- a/ros_buildfarm/templates/snippet/builder_system-groovy_check-free-disk-space.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy_check-free-disk-space.xml.em
@@ -52,5 +52,4 @@ try {
 }
 """,
     script_file=None,
-    classpath='',
 ))@

--- a/ros_buildfarm/templates/snippet/builder_system-groovy_check-triggered-build.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy_check-triggered-build.xml.em
@@ -54,5 +54,4 @@ try {
 }
 """,
     script_file=None,
-    classpath='',
 ))@

--- a/ros_buildfarm/templates/snippet/builder_system-groovy_dashboard.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy_dashboard.xml.em
@@ -142,5 +142,4 @@ for (v in view_stats) {
 }
 """,
     script_file=None,
-    classpath='',
 ))@

--- a/ros_buildfarm/templates/snippet/builder_system-groovy_extract-warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy_extract-warnings.xml.em
@@ -43,5 +43,4 @@ try {
 }
 """,
     script_file=None,
-    classpath='',
 ))@

--- a/ros_buildfarm/templates/snippet/builder_system-groovy_verify-upstream.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy_verify-upstream.xml.em
@@ -82,5 +82,4 @@ try {
 }
 """,
     script_file=None,
-    classpath='',
 ))@

--- a/ros_buildfarm/templates/snippet/property_github-project.xml.em
+++ b/ros_buildfarm/templates/snippet/property_github-project.xml.em
@@ -1,4 +1,4 @@
-    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.26.0">
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.26.2">
       <projectUrl>@ESCAPE(project_url)</projectUrl>
       <displayName/>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>

--- a/ros_buildfarm/templates/snippet/publisher_extended-email.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_extended-email.xml.em
@@ -1,5 +1,5 @@
 @[if recipients]@
-    <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@@2.55">
+    <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@@2.57.2">
       <recipientList>@ESCAPE(' '.join(sorted(recipients)))</recipientList>
       <configuredTriggers>
         <hudson.plugins.emailext.plugins.trigger.FailureTrigger>

--- a/ros_buildfarm/templates/snippet/publisher_groovy-postbuild.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_groovy-postbuild.xml.em
@@ -1,5 +1,5 @@
     <org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder plugin="groovy-postbuild@@2.3.1">
-      <script plugin="script-security@@1.26">
+      <script plugin="script-security@@1.27">
         <script>@ESCAPE(script)</script>
         <sandbox>false</sandbox>
       </script>

--- a/ros_buildfarm/templates/snippet/publisher_mailer.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_mailer.xml.em
@@ -1,5 +1,5 @@
 @[if recipients or dynamic_recipients or send_to_individuals]@
-    <hudson.tasks.Mailer plugin="mailer@@1.19">
+    <hudson.tasks.Mailer plugin="mailer@@1.20">
       <recipients>@ESCAPE(' '.join(sorted(recipients)))@ESCAPE(('\t' + ' '.join(sorted(dynamic_recipients))) if dynamic_recipients else '')</recipients>
       <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
       <sendToIndividuals>@(send_to_individuals ? 'true' ! 'false')</sendToIndividuals>

--- a/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.warnings.WarningsPublisher plugin="warnings@@4.59">
+    <hudson.plugins.warnings.WarningsPublisher plugin="warnings@@4.62">
       <healthy/>
       <unHealthy/>
       <thresholdLimit>low</thresholdLimit>
@@ -8,7 +8,7 @@
       <usePreviousBuildAsReference>false</usePreviousBuildAsReference>
       <useStableBuildAsReference>false</useStableBuildAsReference>
       <useDeltaValues>false</useDeltaValues>
-      <thresholds plugin="analysis-core@@1.82">
+      <thresholds plugin="analysis-core@@1.86">
 @[if unstable_threshold != '']@
         <unstableTotalAll>@unstable_threshold</unstableTotalAll>
 @[else]@

--- a/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
+++ b/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
@@ -61,7 +61,7 @@ if (views.size() != @(expected_num_views)) {
     throw new AbortException("Wrong number of view configs")
 }
 
-views.each{
+for (it in views) {
     found_view = false
     view_name = it.getName()
     view_config = new File(it.path).getText('UTF-8')
@@ -165,7 +165,7 @@ def mergePullRequestData(job_name, current_file, job_config) {
     return format_xml(document2)
 }
 
-jobs.each{
+for (it in jobs) {
     found_project = false
     job_name = it.getName()
     // remove leading serial number

--- a/ros_buildfarm/templates/snippet/scm_git.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_git.xml.em
@@ -1,4 +1,4 @@
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@@3.0.5">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@@3.2.0">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>

--- a/ros_buildfarm/templates/snippet/scm_svn.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_svn.xml.em
@@ -1,4 +1,4 @@
-<scm class="hudson.scm.SubversionSCM" plugin="subversion@@2.7.1">
+<scm class="hudson.scm.SubversionSCM" plugin="subversion@@2.7.2">
   <locations>
     <hudson.scm.SubversionSCM_-ModuleLocation>
       <remote>@ESCAPE(remote)</remote>

--- a/ros_buildfarm/templates/snippet/trigger-jobs_job.xml.em
+++ b/ros_buildfarm/templates/snippet/trigger-jobs_job.xml.em
@@ -130,7 +130,6 @@ for (p in hudson.model.Hudson.instance.getAllItems(AbstractProject)) {
 }
 """ % ('true' if has_force_parameter else 'false', project_name_pattern),
     script_file=None,
-    classpath='',
 ))@
   </builders>
   <publishers>

--- a/ros_buildfarm/templates/snippet/trigger_github-pull-request-builder.xml.em
+++ b/ros_buildfarm/templates/snippet/trigger_github-pull-request-builder.xml.em
@@ -1,4 +1,4 @@
-    <org.jenkinsci.plugins.ghprb.GhprbTrigger plugin="ghprb@@1.35.0">
+    <org.jenkinsci.plugins.ghprb.GhprbTrigger plugin="ghprb@@1.36.1">
       <spec/>
       <triggerPhrase/>
       <adminlist/>


### PR DESCRIPTION
For now this patch only updates the plugin version.

**But** the plugin configurations still need to be reviewed and updated (especially for `groovy`) in order to be parsable with the new plugin versions.

Fixes #417.