### PR TITLE
modify compare page to list packages

### DIFF
--- a/doc/jobs/miscellaneous_jobs.rst
+++ b/doc/jobs/miscellaneous_jobs.rst
@@ -27,11 +27,11 @@ Dashboard
 Status pages
 ------------
 
-The following jobs generate HTML pages to visualize the status of the package
-repositories:
+The following jobs generate HTML pages to visualize the status of the packages
+/ repositories:
 
 * The ``release-status-page`` job, generated on the farm by
-  **generate_release_status_page_job.py**, 
+  **generate_release_status_page_job.py**,
   invokes the script
   *build_release_status_page.py*.
   The generated page shows the ROS packages of a specific ROS distribution and
@@ -61,12 +61,12 @@ repositories:
   invokes the script
   *build_release_compare_page.py*.
   The generated page shows, for a specific pair of ROS distributions, how the versions of the
-  repositories released in the earlier distribution compare in the more recent distribution.
+  packages released in the earlier distribution compare in the more recent distribution.
 
 * The ``blocked-releases-page`` job, generated on the farm by
   **generate_blocked_releases_page_job.py**,
   invokes the script
   *build_blocked_releases_page.py*.
-  The generated page shows, for a specific ROS distribution, which repositories from the previous 
-  distribution have not yet been released, and which repositories they are preventing from being 
+  The generated page shows, for a specific ROS distribution, which repositories from the previous
+  distribution have not yet been released, and which repositories they are preventing from being
   released as a result.

--- a/ros_buildfarm/templates/status/css/compare_page.css
+++ b/ros_buildfarm/templates/status/css/compare_page.css
@@ -1,10 +1,11 @@
-tbody tr td:nth-child(1) div { width: 300px; }
-tbody tr td:nth-child(2) a { display: block; width: 200px; }
-tbody tr td:nth-child(3) div,
+tbody tr td:nth-child(1) div,
+tbody tr td:nth-child(2) div { width: 300px; }
+tbody tr td:nth-child(3) a { display: block; width: 200px; }
 tbody tr td:nth-child(4) div,
-tbody tr td:nth-child(5) div { width: 80px; overflow-x: hidden; }
+tbody tr td:nth-child(5) div,
+tbody tr td:nth-child(6) div { width: 80px; overflow-x: hidden; }
 
 /* Give the table more breathing room on a wider display. */
 @media (min-width: 1380px) {
-  tbody tr td:nth-child(2) { padding-right: 20px; }
+  tbody tr td:nth-child(3) { padding-right: 20px; }
 }

--- a/ros_buildfarm/templates/status/release_compare_page.html.em
+++ b/ros_buildfarm/templates/status/release_compare_page.html.em
@@ -27,7 +27,7 @@
     <form action="?">
       <input type="text" name="q" id="q" />
       <p>Quick filter:
-        <a href="?q=" title="Show all repos">*</a>,
+        <a href="?q=" title="Show all packages">*</a>,
         <a href="?q=DIFF_PATCH" title="Filter packages which are only differ in the patch version">different patch version</a>,
         <a href="?q=DOWNGRADE_VERSION" title="Filter packages which disappear by a sync from shadow-fixed to public">downgrade</a>,
         <a href="?q=DIFF_BRANCH_SAME_VERSION" title="Filter packages which are are released from different branches but have same minor version">same version from different branches</a>
@@ -42,6 +42,7 @@
     <caption></caption>
     <thead>
       <tr>
+        <th class="sortable"><div>Package</div></th>
         <th class="sortable"><div>Repo</div></th>
         <th class="sortable"><div>Maintainer</div></th>
 @[for rosdistro_name in rosdistro_names]@
@@ -51,8 +52,8 @@
     </thead>
     <tbody>
       <script type="text/javascript">window.tbody_ready();</script>
-@[for repo_name in sorted(repos_data.keys())]@
-      <tr>@[for cell in repos_data[repo_name]]<td>@(cell)</td>@[end for]</tr>
+@[for pkg_name in sorted(pkgs_data.keys())]@
+      <tr>@[for cell in pkgs_data[pkg_name]]<td>@(cell)</td>@[end for]</tr>
 @[end for]@
     </tbody>
   </table>


### PR DESCRIPTION
Currently the page lists repositories but when a package is being moved to a different repo that can't be shown. While the list of packages is longer it handles that case easily. Commonly the viewer filters the list by package / repo / maintainer name anyway.