### PR TITLE
add config option to enable / disable sending notification emails for pull request jobs

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -228,6 +228,8 @@ The following options are valid in version ``2`` (beside the generic options):
   * ``committers``: a boolean flag if the committers should be notified.
   * ``emails``: a list of static email addresses.
   * ``maintainers``: a boolean flag if the maintainers should be notified.
+  * ``pull_requests``: boolean flag if notifications should be sent for pull
+    request jobs (default: ``false``)
 
 * ``repository_whitelist``: a list of repository names to whitelist.
 * ``repository_blacklist``: a list of repository names to blacklist.

--- a/ros_buildfarm/config/source_build_file.py
+++ b/ros_buildfarm/config/source_build_file.py
@@ -56,13 +56,17 @@ class SourceBuildFile(BuildFile):
 
         self.notify_committers = None
         self.notify_compiler_warnings = False
+        self.notify_pull_requests = False
         if 'notifications' in data:
             if 'committers' in data['notifications']:
                 self.notify_committers = \
                     bool(data['notifications']['committers'])
-            if 'compiler_warnings' in data['notifications'] and \
-                    data['notifications']['compiler_warnings']:
-                self.notify_compiler_warnings = True
+            if 'compiler_warnings' in data['notifications']:
+                self.notify_compiler_warnings = \
+                    bool(data['notifications']['compiler_warnings'])
+            if 'pull_requests' in data['notifications']:
+                self.notify_pull_requests = \
+                    bool(data['notifications']['pull_requests'])
 
         self.repository_blacklist = []
         if 'repository_blacklist' in data:

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -386,6 +386,7 @@ def _get_devel_job_config(
         'maintainer_emails': maintainer_emails,
         'notify_maintainers': build_file.notify_maintainers,
         'notify_committers': build_file.notify_committers,
+        'notify_pull_requests': build_file.notify_pull_requests,
 
         'timeout_minutes': build_file.jenkins_job_timeout,
 

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -245,17 +245,19 @@ if pull_request:
     'publisher_xunit',
     pattern='catkin_workspace/test_results/**/*.xml',
 ))@
-@[if notify_maintainers]@
+@[if not pull_request or notify_pull_requests]@
+@[ if notify_maintainers]@
 @(SNIPPET(
     'publisher_groovy-postbuild_maintainer-notification',
 ))@
-@[end if]@
+@[ end if]@
 @(SNIPPET(
     'publisher_mailer',
     recipients=notify_emails,
     dynamic_recipients=maintainer_emails,
     send_to_individuals=notify_committers,
 ))@
+@[end if]@
   </publishers>
   <buildWrappers>
 @[if timeout_minutes is not None]@


### PR DESCRIPTION
I chose `False` as the default since I assume that is what we want to use for all ROS distros?

@tfoote @wjwwood @mikaelarguedas 