### PR TITLE
Git credentials

### DIFF
--- a/ros_buildfarm/config/index.py
+++ b/ros_buildfarm/config/index.py
@@ -99,6 +99,12 @@ class Index(object):
             self.git_ssh_credential_id = data['git_ssh_credential_id']
             assert isinstance(self.git_ssh_credential_id, str)
 
+        # find any URL->credential mappings to set credentials for repos
+        self.git_credentials = {}
+        if 'git_credentials' in data:
+            self.git_credentials = data['git_credentials']
+            assert isinstance(self.git_credentials, dict)
+
         self.jenkins_url = data['jenkins_url']
 
         self.notify_emails = []

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -320,6 +320,16 @@ def configure_devel_view(jenkins, view_name, dry_run=False):
         template_name='dashboard_view_devel_jobs.xml.em', dry_run=dry_run)
 
 
+def _get_credential(config, repo_url):
+    from re import match, IGNORECASE
+    print('matching repo_url %s against config' % repo_url)
+    for regex in config.git_credentials:
+        print('  matching repo_url %s against config %s' % (repo_url, regex))
+        if match(regex, repo_url, IGNORECASE) is not None:
+            return config.git_credentials[regex]
+    return ''
+
+
 def _get_devel_job_config(
         config, rosdistro_name, source_build_name,
         build_file, os_name, os_code_name, arch, source_repo_spec,
@@ -391,6 +401,8 @@ def _get_devel_job_config(
         'timeout_minutes': build_file.jenkins_job_timeout,
 
         'git_ssh_credential_id': config.git_ssh_credential_id,
+
+        'git_credential': _get_credential(config, source_repo_spec.url)
     }
     job_config = expand_template(template_name, job_data)
     return job_config

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -321,13 +321,25 @@ def configure_devel_view(jenkins, view_name, dry_run=False):
 
 
 def _get_credential(config, repo_url):
+    """
+    assign credentials for a git base repository using the dictionary
+    `git_credentials` in `index.yaml` of the buildfarm configuration. E.g.:
+
+    ```
+    git_credentials:
+      "https://github.com/.*": global_github_strands_jenkins
+      "https://gitsvn-nt.oru.se/.*": iliad_user
+    ```
+
+    The key in this dictionary is a regular expression (test case-insensitive)
+    and the value is the respective credential ID in jenkins which needs to
+    be available in the jenkins credential store.
+    """
     from re import match, IGNORECASE
-    print('matching repo_url %s against config' % repo_url)
+    # matching repo_url against config
     for regex in config.git_credentials:
-        print('  matching repo_url %s against config %s' % (repo_url, regex))
+        # matching regular expression
         if match(regex, repo_url, IGNORECASE) is not None:
-            print ('found this credential id: %s' %
-                   config.git_credentials[regex])
             return config.git_credentials[regex]
     return ''
 

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -326,6 +326,8 @@ def _get_credential(config, repo_url):
     for regex in config.git_credentials:
         print('  matching repo_url %s against config %s' % (repo_url, regex))
         if match(regex, repo_url, IGNORECASE) is not None:
+            print ('found this credential id: %s' %
+                   config.git_credentials[regex])
             return config.git_credentials[regex]
     return ''
 

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -54,6 +54,7 @@ if pull_request:
     repo_spec=source_repo_spec,
     path='catkin_workspace/src/%s' % source_repo_spec.name,
     git_ssh_credential_id=git_ssh_credential_id,
+    git_credential=git_credential,
 ))@
 @[else]@
 @(SNIPPET(
@@ -63,6 +64,7 @@ if pull_request:
     branch_name='${sha1}',
     relative_target_dir='catkin_workspace/src/%s' % source_repo_spec.name,
     git_ssh_credential_id=git_ssh_credential_id,
+    git_credential=git_credential,
     merge_branch=source_repo_spec.version,
 ))@
 @[end if]@

--- a/ros_buildfarm/templates/snippet/scm.xml.em
+++ b/ros_buildfarm/templates/snippet/scm.xml.em
@@ -6,6 +6,7 @@
     relative_target_dir=path,
     refspec=None,
     git_ssh_credential_id=git_ssh_credential_id,
+    git_credential=git_credential,
 ))@
 @[elif repo_spec.type == 'hg']@
 @(SNIPPET(

--- a/ros_buildfarm/templates/snippet/scm_git.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_git.xml.em
@@ -9,6 +9,9 @@
 @[if vars().get('git_ssh_credential_id')]@
         <credentialsId>@git_ssh_credential_id</credentialsId>
 @[end if]@
+@[if vars().get('git_credential')]@
+        <credentialsId>@git_credential</credentialsId>
+@[end if]@
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>


### PR DESCRIPTION
In order to facilitate builds for private repositories (on github or gitlab), suitable credentials need to be passed on to jenkins for the devel jobs. As I couldn't find a suitable solution in the current build farm I implemented this. Not sure if this is useful for others, but it might well be. Also happy for pointers to other solutions.

This assigns credentials for a git-based repository using the dictionary `git_credentials` in `index.yaml` of the buildfarm configuration. E.g.:
   ```
   git_credentials:
     "https://github.com/.*": credential_id_1
     "https://gitlab.oru.se/.*": credential_id_1
   ```
The key in this dictionary is a regular expression (test case-insensitive) and the value is the respective credential ID in jenkins which needs to be available in the jenkins credential store.
