### PR TITLE
explicitly reschedule aborted builds

### DIFF
--- a/ros_buildfarm/templates/snippet/builder_check-docker.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_check-docker.xml.em
@@ -17,6 +17,7 @@ else:
     'builder_system-groovy',
     command=
 """// DISABLE SLAVE IF OUTPUT INDICATES DOCKER RUN PROBLEMS
+import hudson.model.ParametersAction
 import hudson.slaves.OfflineCause.UserCause
 import java.io.BufferedReader
 import java.util.regex.Pattern
@@ -37,7 +38,9 @@ while ((line = br.readLine()) != null) {
         def computer = node.toComputer()
         computer.setTemporarilyOffline(true, new UserCause(null, "'docker run' failed"))
 
-        // the job will be rescheduled automatically if it has corresponding flag set in the project configuration
+        // rescheduled a build with the same parameters
+        // the requeue flag in the project configuration seems to not be sufficient anymore
+        build.getProject().scheduleBuild(1, new UserIdCause(), *build.getActions(ParametersAction))
 
         // add badge to build
         build.getActions().add(GroovyPostbuildAction.createInfoBadge("'docker run' failed, disabled slave '" + computer.name + "', rescheduled job"))

--- a/ros_buildfarm/templates/snippet/builder_system-groovy_check-free-disk-space.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy_check-free-disk-space.xml.em
@@ -3,6 +3,7 @@
     command=
 """// VERFIY THAT FREE DISK SPACE THRESHOLD IS NOT VIOLATED
 import hudson.model.Cause.UserIdCause
+import hudson.model.ParametersAction
 import hudson.node_monitors.AbstractDiskSpaceMonitor
 import hudson.node_monitors.DiskSpaceMonitor
 import hudson.node_monitors.DiskSpaceMonitorDescriptor.DiskSpace
@@ -37,7 +38,9 @@ try {
         logger.warning(Messages.DiskSpaceMonitor_MarkedOffline(computer.getName()))
       }
 
-      // the job will be rescheduled automatically if it has corresponding flag set in the project configuration
+      // rescheduled a build with the same parameters
+      // the requeue flag in the project configuration seems to not be sufficient anymore
+      build.getProject().scheduleBuild(1, new UserIdCause(), *build.getActions(ParametersAction))
 
       // add badge to build
       build.getActions().add(GroovyPostbuildAction.createInfoBadge("Free disk space is too low, disabled slave '" + computer.name + "', rescheduled job"))


### PR DESCRIPTION
The implicit rescheduling done by the `requeue` plugin seems to not happen anymore (see e.g. http://build.ros.org/view/Lbin_uX64/job/Lbin_uX64__rostime__ubuntu_xenial_amd64__binary/2/). Might be a change within Jenkins since the plugin hasn't changed.