### PR TITLE
check version in a way that supports Python 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ kwargs = {
     'license': 'Apache 2.0',
 }
 
-if os.sys.version_info.major == 2:
+if os.sys.version_info[0] == 2:
     kwargs['install_requires'].append('configparser')
 
 if 'SKIP_PYTHON_MODULES' in os.environ:


### PR DESCRIPTION
Similar to this change: https://github.com/ros-infrastructure/catkin_pkg/pull/165

I ran into this because our web server is still using Python 2.6 and we cannot update it ourselves.