### PR TITLE
use higher prio for import_upstream job

### DIFF
--- a/ros_buildfarm/templates/release/import_upstream_job.xml.em
+++ b/ros_buildfarm/templates/release/import_upstream_job.xml.em
@@ -10,7 +10,7 @@
 ))@
 @(SNIPPET(
     'property_job-priority',
-    priority=-1,
+    priority=20,
 ))@
 @(SNIPPET(
     'property_requeue-job',


### PR DESCRIPTION
Allow running `import_upstream` job as early as possible if the queue is not empty.