### PR TITLE
add warning to import_upstream job

### DIFF
--- a/ros_buildfarm/templates/release/import_upstream_job.xml.em
+++ b/ros_buildfarm/templates/release/import_upstream_job.xml.em
@@ -1,6 +1,10 @@
 <project>
   <actions/>
-  <description>Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'</description>
+  <description>
+    &lt;p&gt;
+      &lt;b&gt;This job should not be aborted since reprepro will likely leave lockfile behind!&lt;/b&gt;
+    &lt;/p&gt;
+Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'</description>
   <keepDependencies>false</keepDependencies>
   <properties>
 @(SNIPPET(


### PR DESCRIPTION
Due to recent problems.

ros-infrastructure/reprepro-updater#49 will make sure that eventual problems are visible.