### PR TITLE
switch doc_independent_task to xenial

### DIFF
--- a/ros_buildfarm/templates/doc/doc_independent_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_independent_task.Dockerfile.em
@@ -1,6 +1,6 @@
 # generated from @template_name
 
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 
 VOLUME ["/var/cache/apt/archives"]
 
@@ -18,7 +18,7 @@ RUN useradd -u @uid -m buildfarm
     distribution_repository_keys=distribution_repository_keys,
     distribution_repository_urls=distribution_repository_urls,
     os_name='ubuntu',
-    os_code_name='trusty',
+    os_code_name='xenial',
     add_source=False,
 ))@
 
@@ -29,6 +29,12 @@ RUN useradd -u @uid -m buildfarm
 
 # automatic invalidation once every day
 RUN echo "@today_str"
+
+@(TEMPLATE(
+    'snippet/install_python3.Dockerfile.em',
+    os_name='ubuntu',
+    os_code_name='xenial',
+))@
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y make python-catkin-pkg-modules python-dateutil python-pip python-wstool python-yaml
 RUN pip install -U catkin-sphinx sphinx


### PR DESCRIPTION
Fix [failing job](http://build.ros.org/job/doc_independent-packages/510/) after new release of Sphinx (1.6.1): http://build.ros.org/job/doc_independent-packages/520/