### PR TITLE
catch another apt hiccup

### DIFF
--- a/ros_buildfarm/wrapper/apt.py
+++ b/ros_buildfarm/wrapper/apt.py
@@ -63,6 +63,7 @@ def call_apt_update_install_clean(
                 'maybe run apt update',
                 'The following packages cannot be authenticated!',
                 'Unable to locate package',
+                'has no installation candidate',
             ]
             rc, known_error_conditions = \
                 call_apt(


### PR DESCRIPTION
Catch and retry cases where apt reports:

> E: Package '...' has no installation candidate