### PR TITLE
add 'Failed to stat' to the list of apt known errors

### DIFF
--- a/ros_buildfarm/wrapper/apt.py
+++ b/ros_buildfarm/wrapper/apt.py
@@ -23,10 +23,10 @@ def main(argv=sys.argv[1:]):
     max_tries = 10
     known_error_strings = [
         'Failed to fetch',
+        'Failed to stat',
         'Hash Sum mismatch',
         'Unable to locate package',
         'is not what the server reported',
-        'Failed to stat',
     ]
 
     command = argv[0]

--- a/ros_buildfarm/wrapper/apt.py
+++ b/ros_buildfarm/wrapper/apt.py
@@ -26,6 +26,7 @@ def main(argv=sys.argv[1:]):
         'Hash Sum mismatch',
         'Unable to locate package',
         'is not what the server reported',
+        'Failed to stat',
     ]
 
     command = argv[0]


### PR DESCRIPTION
Not sure if this swill fix all the stretch failures we'e seen in the last two weeks but it seem to solve most of them.
Example of job that this fix allowed to run apt-update successfully after facing this error: http://build.ros.org/view/Lbin_dsv8_dSv8/job/Lbin_dsv8_dSv8__katana__debian_stretch_arm64__binary/11/console