### PR TITLE
print blank lines around error message

### DIFF
--- a/ros_buildfarm/wrapper/apt.py
+++ b/ros_buildfarm/wrapper/apt.py
@@ -92,8 +92,10 @@ def call_apt_update_install_clean(
                 # retry with update command
                 continue
 
+            print('')
             print('Invocation failed due to the following known error '
                   'conditions: ' + ', '.join(known_error_conditions))
+            print('')
             if tries < max_tries:
                 sleep_time = 5
                 print("Reinvoke 'apt install' after sleeping %s seconds" %


### PR DESCRIPTION
To match the print behavior of other wrappers (and this wrapper in [other places](https://github.com/ros-infrastructure/ros_buildfarm/compare/blank_lines_around_msg?expand=1#diff-943c6ed2c6f830b08cb10542d040aab1R128)) and make log more readable