### PR TITLE
Fix Debian revision (replace - by .)

### DIFF
--- a/ros_buildfarm/binarydeb_job.py
+++ b/ros_buildfarm/binarydeb_job.py
@@ -108,6 +108,11 @@ def append_build_timestamp(rosdistro_name, package_name, sourcedeb_dir):
         '-m',  # keep maintainer details
         'Append timestamp when binarydeb was built.',
     ]
+    # Backwards compatibility for #460
+    # TODO(tfoote) remove when kinetic EOL
+    if rosdistro_name in ['indigo', 'kinetic', 'lunar']:
+        cmd[2] = '%s-%s' % (version, strftime('%Y%m%d-%H%M%S%z'))
+    # End backwards compatibility removal section
     print("Invoking '%s' in '%s'" % (' '.join(cmd), source_dir))
     subprocess.check_call(cmd, cwd=source_dir)
 

--- a/ros_buildfarm/binarydeb_job.py
+++ b/ros_buildfarm/binarydeb_job.py
@@ -15,7 +15,7 @@
 import os
 import subprocess
 import sys
-from time import strftime
+from time import gmtime, strftime
 import traceback
 
 from ros_buildfarm.common import get_debian_package_name
@@ -101,7 +101,7 @@ def append_build_timestamp(rosdistro_name, package_name, sourcedeb_dir):
         source_dir, ['Source', 'Version', 'Distribution', 'Urgency'])
     cmd = [
         'debchange',
-        '-v', '%s-%s' % (version, strftime('%Y%m%d-%H%M%S%z')),
+        '-v', '%s.%s' % (version, strftime('%Y%m%d.%H%M%S', gmtime())),
         '-p',  # preserve directory name
         '-D', distribution,
         '-u', urgency,

--- a/ros_buildfarm/binarydeb_job.py
+++ b/ros_buildfarm/binarydeb_job.py
@@ -104,7 +104,7 @@ def append_build_timestamp(rosdistro_name, package_name, sourcedeb_dir):
         '-v',
         '%s.%s' % (version, strftime('%Y%m%d.%H%M%S', gmtime()))
         # Backwards compatibility for #460
-        if rosdistro_name not in ('indigo', 'kinetic', 'lunar')
+        if rosdistro_name not in ('indigo', 'jade', 'kinetic', 'lunar')
         else '%s-%s' % (version, strftime('%Y%m%d-%H%M%S%z')),
         '-p',  # preserve directory name
         '-D', distribution,
@@ -112,7 +112,6 @@ def append_build_timestamp(rosdistro_name, package_name, sourcedeb_dir):
         '-m',  # keep maintainer details
         'Append timestamp when binarydeb was built.',
     ]
-    # End backwards compatibility removal section
     print("Invoking '%s' in '%s'" % (' '.join(cmd), source_dir))
     subprocess.check_call(cmd, cwd=source_dir)
 

--- a/ros_buildfarm/binarydeb_job.py
+++ b/ros_buildfarm/binarydeb_job.py
@@ -101,17 +101,17 @@ def append_build_timestamp(rosdistro_name, package_name, sourcedeb_dir):
         source_dir, ['Source', 'Version', 'Distribution', 'Urgency'])
     cmd = [
         'debchange',
-        '-v', '%s.%s' % (version, strftime('%Y%m%d.%H%M%S', gmtime())),
+        '-v',
+        '%s.%s' % (version, strftime('%Y%m%d.%H%M%S', gmtime()))
+        # Backwards compatibility for #460
+        if rosdistro_name not in ('indigo', 'kinetic', 'lunar')
+        else '%s-%s' % (version, strftime('%Y%m%d-%H%M%S%z')),
         '-p',  # preserve directory name
         '-D', distribution,
         '-u', urgency,
         '-m',  # keep maintainer details
         'Append timestamp when binarydeb was built.',
     ]
-    # Backwards compatibility for #460
-    # TODO(tfoote) remove when kinetic EOL
-    if rosdistro_name in ['indigo', 'kinetic', 'lunar']:
-        cmd[2] = '%s-%s' % (version, strftime('%Y%m%d-%H%M%S%z'))
     # End backwards compatibility removal section
     print("Invoking '%s' in '%s'" % (' '.join(cmd), source_dir))
     subprocess.check_call(cmd, cwd=source_dir)


### PR DESCRIPTION
Debian policy doesn't allow hyphens in the revision:

https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version
https://manpages.debian.org/stretch/dpkg-dev/deb-version.5.html

As %z in strftime could convert to a -0800, replace it with UTC time
instead.