### PR TITLE
set default Debian-Version

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,5 @@
 [ros_buildfarm]
+Debian-Version: 100
 Depends: python-argparse, python-catkin-pkg-modules, python-ros-buildfarm-modules, python-rosdistro-modules, python-yaml
 Depends3: python3-catkin-pkg-modules, python3-ros-buildfarm-modules, python3-rosdistro-modules, python3-yaml
 Conflicts: python3-ros-buildfarm


### PR DESCRIPTION
Requires ros-infrastructure/ros_release_python#20.