### PR TITLE
add_corrupted_package_archive_error

### DIFF
--- a/ros_buildfarm/wrapper/apt.py
+++ b/ros_buildfarm/wrapper/apt.py
@@ -27,7 +27,6 @@ def main(argv=sys.argv[1:]):
         'Hash Sum mismatch',
         'Unable to locate package',
         'is not what the server reported',
-        'corrupted package archive'
     ]
 
     command = argv[0]
@@ -66,6 +65,7 @@ def call_apt_update_install_clean(
                 'The following packages cannot be authenticated!',
                 'Unable to locate package',
                 'has no installation candidate',
+                'corrupted package archive',
             ]
             rc, known_error_conditions = \
                 call_apt(

--- a/ros_buildfarm/wrapper/apt.py
+++ b/ros_buildfarm/wrapper/apt.py
@@ -27,6 +27,7 @@ def main(argv=sys.argv[1:]):
         'Hash Sum mismatch',
         'Unable to locate package',
         'is not what the server reported',
+        'corrupted package archive'
     ]
 
     command = argv[0]


### PR DESCRIPTION
addresses https://github.com/ros-infrastructure/ros_buildfarm/issues/455#issuecomment-320013474 somehow.

Job failing before:
http://build.ros.org/view/Lbin_dsv8_dSv8/job/Lbin_dsv8_dSv8__image_cb_detector__debian_stretch_arm64__binary/9/
Job passing with retry:
http://build.ros.org/view/Lbin_dsv8_dSv8/job/Lbin_dsv8_dSv8__image_cb_detector__debian_stretch_arm64__binary/10/

Note: the retry doesnt go through the download + unpack phase because the failing package is a recommended package and not a required dependency.  I don't have any job in lunar failing because of a corrupted required package to see if the retry logic works in that use case