### PR TITLE
Add initial version of upload trigger job generators.

### DIFF
--- a/doc/jobs/release_jobs.rst
+++ b/doc/jobs/release_jobs.rst
@@ -75,6 +75,9 @@ configuration:
   same tasks as the *source* and *binary* jobs for a specific package on a
   local machine.
 
+* **generate_release_trigger_upload_jobs.py** generates a pair of jobs that
+  trigger an upload to packages.ros.org. Only needed for the official buildfarm
+  at build.ros.org.
 
 The build process in detail
 ---------------------------

--- a/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
+++ b/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
@@ -34,7 +34,7 @@
     <hudson.tasks.Shell>
       <command>#!/bin/bash
 $HOME/upload_triggers/upload_repo.bash @repo
-    </command>
+</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers/>

--- a/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
+++ b/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
@@ -16,7 +16,7 @@
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
-  <blockBuildWhenUpstreamBuilding>true</blockBuildWhenUpstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>@block_when_upstream_building</blockBuildWhenUpstreamBuilding>
   <triggers>
     <jenkins.triggers.ReverseBuildTrigger>
       <spec/>

--- a/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
+++ b/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
@@ -1,0 +1,42 @@
+<project>
+  <actions/>
+  <description/>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <jenkins.advancedqueue.priority.strategy.PriorityJobProperty plugin="PrioritySorter@@3.5.0">
+      <useJobPriority>false</useJobPriority>
+      <priority>-1</priority>
+    </jenkins.advancedqueue.priority.strategy.PriorityJobProperty>
+    <org.jenkinsci.plugins.requeuejob.RequeueJobProperty plugin="jobrequeue@@1.1">
+      <requeueJob>false</requeueJob>
+    </org.jenkinsci.plugins.requeuejob.RequeueJobProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <assignedNode>building_repository</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>true</blockBuildWhenUpstreamBuilding>
+  <triggers>
+    <jenkins.triggers.ReverseBuildTrigger>
+      <spec/>
+      <upstreamProjects>@upstream_job_names</upstreamProjects>
+      <threshold>
+        <name>SUCCESS</name>
+        <ordinal>0</ordinal>
+        <color>BLUE</color>
+        <completeBuild>true</completeBuild>
+      </threshold>
+    </jenkins.triggers.ReverseBuildTrigger>
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>#!/bin/bash
+$HOME/upload_triggers/upload_repo.bash @repo
+    </command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/scripts/release/generate_release_trigger_upload_jobs.py
+++ b/scripts/release/generate_release_trigger_upload_jobs.py
@@ -43,7 +43,7 @@ def main(argv=sys.argv[1:]):
         job_name = 'upload_%s' % repo
         upstream_job_names = ['{0}_sync-packages-to-{1}'.format(
             get_release_job_prefix(rosdistro), repo) for rosdistro in distributions]
-        upstream_job_names = ', '.join(upstream_job_names)
+        upstream_job_names = ', '.join(sorted(upstream_job_names))
         job_config = expand_template(template_name, {
             'repo': repo,
             'upstream_job_names': upstream_job_names})

--- a/scripts/release/generate_release_trigger_upload_jobs.py
+++ b/scripts/release/generate_release_trigger_upload_jobs.py
@@ -19,8 +19,10 @@ import sys
 
 from ros_buildfarm.argument import add_argument_config_url
 from ros_buildfarm.argument import add_argument_dry_run
+from ros_buildfarm.common import JobValidationError
 from ros_buildfarm.common import get_release_job_prefix
 from ros_buildfarm.config import get_index
+from ros_buildfarm.config import get_release_build_files
 from ros_buildfarm.jenkins import configure_job
 from ros_buildfarm.jenkins import connect
 from ros_buildfarm.templates import expand_template
@@ -37,22 +39,49 @@ def main(argv=sys.argv[1:]):
 
     config = get_index(args.config_url)
     jenkins = connect(config.jenkins_url)
-    distributions = config.distributions.keys()
 
     for repo in ['main', 'testing']:
         job_name = 'upload_%s' % repo
         block_when_upstream_building = 'true'
         if repo == 'testing':
             block_when_upstream_building = 'false'
-        upstream_job_names = ['{0}_sync-packages-to-{1}'.format(
-            get_release_job_prefix(rosdistro), repo) for rosdistro in distributions]
-        upstream_job_names = ', '.join(sorted(upstream_job_names))
         job_config = expand_template(template_name, {
             'block_when_upstream_building': block_when_upstream_building,
             'repo': repo,
-            'upstream_job_names': upstream_job_names})
+            'upstream_job_names': get_upstream_job_names(config, repo)})
 
         configure_job(jenkins, job_name, job_config, dry_run=args.dry_run)
+
+
+def get_upstream_job_names(config, repo):
+    distributions = config.distributions.keys()
+    if repo == 'main':
+        upstream_job_names = ['{0}_sync-packages-to-{1}'.format(
+            get_release_job_prefix(rosdistro), repo) for rosdistro in distributions]
+    elif repo == 'testing':
+        upstream_job_names = []
+        for rosdistro in distributions:
+            architectures_by_code_name = {}
+            build_files = get_release_build_files(config, rosdistro)
+            for k, build_file in build_files.items():
+                for os_name in build_file.targets.keys():
+                    for code_name, architectures in build_file.targets[os_name].items():
+                        architectures_by_code_name[code_name] = \
+                            set(architectures_by_code_name.get(code_name, set()).union(
+                                set(architectures.keys())))
+
+            for code_name, archs in architectures_by_code_name.items():
+                for arch in archs:
+                    upstream_job_names.append(
+                        '{prefix}_sync-packages-to-{repo}_{codename}_{arch}'.format(
+                            prefix=get_release_job_prefix(rosdistro),
+                            repo=repo,
+                            codename=code_name,
+                            arch=arch))
+    else:
+        raise JobValidationError("Unknown upstream jobs for job 'upload_{}'." % repo)
+    upstream_job_names = ','.join(sorted(upstream_job_names))
+    return upstream_job_names
 
 
 if __name__ == '__main__':

--- a/scripts/release/generate_release_trigger_upload_jobs.py
+++ b/scripts/release/generate_release_trigger_upload_jobs.py
@@ -67,8 +67,8 @@ def get_upstream_job_names(config, repo):
                 for os_name in build_file.targets.keys():
                     for code_name, architectures in build_file.targets[os_name].items():
                         architectures_by_code_name[code_name] = \
-                            architectures_by_code_name.get(code_name, set()) \
-                            | set(architectures.keys())
+                            architectures_by_code_name.get(code_name, set()) | \
+                            set(architectures.keys())
 
             for code_name, archs in architectures_by_code_name.items():
                 for arch in archs:

--- a/scripts/release/generate_release_trigger_upload_jobs.py
+++ b/scripts/release/generate_release_trigger_upload_jobs.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+
+from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_dry_run
+from ros_buildfarm.common import get_release_job_prefix
+from ros_buildfarm.config import get_index
+from ros_buildfarm.jenkins import configure_job
+from ros_buildfarm.jenkins import connect
+from ros_buildfarm.templates import expand_template
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Generate the 'upload_main' and 'upload_testing' jobs.")
+    add_argument_config_url(parser)
+    add_argument_dry_run(parser)
+    args = parser.parse_args(argv)
+
+    template_name = 'release/trigger_upload_repo_job.xml.em'
+
+    config = get_index(args.config_url)
+    jenkins = connect(config.jenkins_url)
+    distributions = config.distributions.keys()
+
+    for repo in ['main', 'testing']:
+        job_name = 'upload_%s' % repo
+        upstream_job_names = ['{0}_sync-packages-to-{1}'.format(
+            get_release_job_prefix(rosdistro), repo) for rosdistro in distributions]
+        upstream_job_names = ', '.join(upstream_job_names)
+        job_config = expand_template(template_name, {
+            'repo': repo,
+            'upstream_job_names': upstream_job_names})
+
+        configure_job(jenkins, job_name, job_config, dry_run=args.dry_run)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/release/generate_release_trigger_upload_jobs.py
+++ b/scripts/release/generate_release_trigger_upload_jobs.py
@@ -67,8 +67,8 @@ def get_upstream_job_names(config, repo):
                 for os_name in build_file.targets.keys():
                     for code_name, architectures in build_file.targets[os_name].items():
                         architectures_by_code_name[code_name] = \
-                            set(architectures_by_code_name.get(code_name, set()).union(
-                                set(architectures.keys())))
+                            architectures_by_code_name.get(code_name, set()) \
+                            | set(architectures.keys())
 
             for code_name, archs in architectures_by_code_name.items():
                 for arch in archs:

--- a/scripts/release/generate_release_trigger_upload_jobs.py
+++ b/scripts/release/generate_release_trigger_upload_jobs.py
@@ -73,10 +73,10 @@ def get_upstream_job_names(config, repo):
             for code_name, archs in architectures_by_code_name.items():
                 for arch in archs:
                     upstream_job_names.append(
-                        '{prefix}_sync-packages-to-{repo}_{codename}_{arch}'.format(
+                        '{prefix}_sync-packages-to-{repo}_{code_name}_{arch}'.format(
                             prefix=get_release_job_prefix(rosdistro),
                             repo=repo,
-                            codename=code_name,
+                            code_name=code_name,
                             arch=arch))
     else:
         raise JobValidationError("Unknown upstream jobs for job 'upload_{}'." % repo)

--- a/scripts/release/generate_release_trigger_upload_jobs.py
+++ b/scripts/release/generate_release_trigger_upload_jobs.py
@@ -80,8 +80,7 @@ def get_upstream_job_names(config, repo):
                             arch=arch))
     else:
         raise JobValidationError("Unknown upstream jobs for job 'upload_{}'." % repo)
-    upstream_job_names = ','.join(sorted(upstream_job_names))
-    return upstream_job_names
+    return ','.join(sorted(upstream_job_names))
 
 
 if __name__ == '__main__':

--- a/scripts/release/generate_release_trigger_upload_jobs.py
+++ b/scripts/release/generate_release_trigger_upload_jobs.py
@@ -63,7 +63,7 @@ def get_upstream_job_names(config, repo):
         for rosdistro in distributions:
             architectures_by_code_name = {}
             build_files = get_release_build_files(config, rosdistro)
-            for k, build_file in build_files.items():
+            for build_file in build_files.values():
                 for os_name in build_file.targets.keys():
                     for code_name, architectures in build_file.targets[os_name].items():
                         architectures_by_code_name[code_name] = \

--- a/scripts/release/generate_release_trigger_upload_jobs.py
+++ b/scripts/release/generate_release_trigger_upload_jobs.py
@@ -41,10 +41,14 @@ def main(argv=sys.argv[1:]):
 
     for repo in ['main', 'testing']:
         job_name = 'upload_%s' % repo
+        block_when_upstream_building = 'true'
+        if repo == 'testing':
+            block_when_upstream_building = 'false'
         upstream_job_names = ['{0}_sync-packages-to-{1}'.format(
             get_release_job_prefix(rosdistro), repo) for rosdistro in distributions]
         upstream_job_names = ', '.join(sorted(upstream_job_names))
         job_config = expand_template(template_name, {
+            'block_when_upstream_building': block_when_upstream_building,
             'repo': repo,
             'upstream_job_names': upstream_job_names})
 


### PR DESCRIPTION
This adds a template and generating script for the upload trigger jobs.
On the current farm as `upload_main` and `upload_testing`.

The first commit only creates the generating script. It doesn't add the script to `generate_all_jobs.py` or check any configuration keys for whether or not the jobs should be created. I also need to figure out the right way to check all combinations of the sync-testing jobs since they're distro+arch specific.

The scripts themselves are part of a puppet branch that is waiting to be published. I've asked @tfoote to be the second set of eyes verifying there's nothing sensitive in the script contents itself before publishing the puppet changes that will place these scripts on repo hosts.

There's some formatting of the template still to iron out but better to get the overall setup reviewed early than spend time scrutinizing something that needs fundamental changes.