### PR TITLE
Fix builds using pip3 alongside Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -164,6 +164,7 @@ matrix:
         - docker
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="roscpp_core" OVERLAY_PACKAGE_NAMES=roscpp
       before_script:
+        - pip3 install EmPy
         # install catkin for test results
         - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
         - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
@@ -184,6 +185,7 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
+        - pip3 install EmPy
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm

--- a/.travis.yml
+++ b/.travis.yml
@@ -164,7 +164,6 @@ matrix:
         - docker
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="roscpp_core" OVERLAY_PACKAGE_NAMES=roscpp
       before_script:
-        - pip3 install EmPy
         # install catkin for test results
         - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
         - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
@@ -185,7 +184,6 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
-        - pip3 install EmPy
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm

--- a/.travis.yml
+++ b/.travis.yml
@@ -164,6 +164,7 @@ matrix:
         - docker
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="roscpp_core" OVERLAY_PACKAGE_NAMES=roscpp
       before_script:
+        - sudo apt-get update
         - sudo apt-get install -y python3-pip
         - sudo pip3 install EmPy
         # install catkin for test results
@@ -186,6 +187,7 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
+        - sudo apt-get update
         - sudo apt-get install -y python3-pip
         - sudo pip3 install EmPy
         - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -165,7 +165,7 @@ matrix:
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="roscpp_core" OVERLAY_PACKAGE_NAMES=roscpp
       before_script:
         - sudo apt-get install -y python3-pip
-        - pip3 install EmPy
+        - sudo pip3 install EmPy
         # install catkin for test results
         - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
         - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
@@ -187,7 +187,7 @@ matrix:
       env: JOB_TYPE=external_prerelease
       before_script:
         - sudo apt-get install -y python3-pip
-        - pip3 install EmPy
+        - sudo pip3 install EmPy
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm

--- a/.travis.yml
+++ b/.travis.yml
@@ -164,6 +164,7 @@ matrix:
         - docker
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="roscpp_core" OVERLAY_PACKAGE_NAMES=roscpp
       before_script:
+        - sudo apt-get install -y python3-pip
         - pip3 install EmPy
         # install catkin for test results
         - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
@@ -185,6 +186,7 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
+        - sudo apt-get install -y python3-pip
         - pip3 install EmPy
         - python setup.py install
         - mkdir job && cd job


### PR DESCRIPTION
Two builds on Travis started failing with a recent platform update. To get the build working again I've set it to install the system pip3 and use sudo when installing the python3 version of EmPy.

We could also just install python3-empy from apt. I don't have a preference either way.

I was testing these configuration changes with custom builds. Here's a link to the [most recent one](https://travis-ci.org/ros-infrastructure/ros_buildfarm/builds/282492141) and another will be part of this PR. Hopefully it too succeeds.