### PR TITLE
Update plugin versions for current buildfarm.

### DIFF
--- a/ros_buildfarm/templates/dashboard_view_all_jobs.xml.em
+++ b/ros_buildfarm/templates/dashboard_view_all_jobs.xml.em
@@ -1,4 +1,4 @@
-<hudson.plugins.view.dashboard.Dashboard plugin="dashboard-view@@2.9.10">
+<hudson.plugins.view.dashboard.Dashboard plugin="dashboard-view@@2.9.11">
   <name>@view_name</name>
   <description>Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'</description>
   <filterExecutors>false</filterExecutors>

--- a/ros_buildfarm/templates/dashboard_view_devel_jobs.xml.em
+++ b/ros_buildfarm/templates/dashboard_view_devel_jobs.xml.em
@@ -1,4 +1,4 @@
-<hudson.plugins.view.dashboard.Dashboard plugin="dashboard-view@@2.9.10">
+<hudson.plugins.view.dashboard.Dashboard plugin="dashboard-view@@2.9.11">
   <name>@view_name</name>
   <description>Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'</description>
   <filterExecutors>false</filterExecutors>
@@ -23,7 +23,7 @@
     <jenkins.plugins.extracolumns.TestResultColumn plugin="extra-columns@@1.18">
       <testResultFormat>1</testResultFormat>
     </jenkins.plugins.extracolumns.TestResultColumn>
-    <hudson.plugins.warnings.WarningsColumn plugin="warnings@@4.62"/>
+    <hudson.plugins.warnings.WarningsColumn plugin="warnings@@4.63"/>
   </columns>
 @[if include_regex]@
   <includeRegex>@include_regex</includeRegex>

--- a/ros_buildfarm/templates/misc/check_failing_jobs.xml.em
+++ b/ros_buildfarm/templates/misc/check_failing_jobs.xml.em
@@ -37,6 +37,7 @@
     ros_distribution=ros_distro
 ))@
   </builders>
+  <publishers/>
   <buildWrappers>
 @(SNIPPET(
     'build-wrapper_timestamper',

--- a/ros_buildfarm/templates/snippet/builder_parameterized-trigger.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_parameterized-trigger.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.parameterizedtrigger.TriggerBuilder plugin="parameterized-trigger@@2.33">
+    <hudson.plugins.parameterizedtrigger.TriggerBuilder plugin="parameterized-trigger@@2.35.1">
       <configs>
         <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
 @[if parameters]@

--- a/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
@@ -1,7 +1,7 @@
     <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.0">
 @[if command]@
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
-        <script plugin="script-security@@1.27">
+        <script plugin="script-security@@1.34">
           <script>@ESCAPE(command)</script>
           <sandbox>false</sandbox>
         </script>

--- a/ros_buildfarm/templates/snippet/property_github-project.xml.em
+++ b/ros_buildfarm/templates/snippet/property_github-project.xml.em
@@ -1,4 +1,4 @@
-    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.26.2">
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.28.0">
       <projectUrl>@ESCAPE(project_url)</projectUrl>
       <displayName/>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>

--- a/ros_buildfarm/templates/snippet/property_job-priority.xml.em
+++ b/ros_buildfarm/templates/snippet/property_job-priority.xml.em
@@ -1,4 +1,4 @@
-    <jenkins.advancedqueue.priority.strategy.PriorityJobProperty plugin="PrioritySorter@@3.5.0">
+    <jenkins.advancedqueue.priority.strategy.PriorityJobProperty plugin="PrioritySorter@@3.5.1">
       <useJobPriority>@('true' if priority != -1 else 'false')</useJobPriority>
       <priority>@int(priority)</priority>
     </jenkins.advancedqueue.priority.strategy.PriorityJobProperty>

--- a/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.warnings.WarningsPublisher plugin="warnings@@4.62">
+    <hudson.plugins.warnings.WarningsPublisher plugin="warnings@@4.63">
       <healthy/>
       <unHealthy/>
       <thresholdLimit>low</thresholdLimit>
@@ -8,7 +8,7 @@
       <usePreviousBuildAsReference>false</usePreviousBuildAsReference>
       <useStableBuildAsReference>false</useStableBuildAsReference>
       <useDeltaValues>false</useDeltaValues>
-      <thresholds plugin="analysis-core@@1.86">
+      <thresholds plugin="analysis-core@@1.92">
 @[if unstable_threshold != '']@
         <unstableTotalAll>@unstable_threshold</unstableTotalAll>
 @[else]@

--- a/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
@@ -36,6 +36,7 @@
       <includePattern/>
       <excludePattern/>
       <messagesPattern/>
+      <categoriesPattern/>
       <parserConfigurations/>
       <consoleParsers>
         <hudson.plugins.warnings.ConsoleParser>

--- a/ros_buildfarm/templates/snippet/scm_git.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_git.xml.em
@@ -1,4 +1,4 @@
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@@3.2.0">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@@3.5.1">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>

--- a/ros_buildfarm/templates/snippet/scm_hg.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_hg.xml.em
@@ -1,4 +1,4 @@
-  <scm class="hudson.plugins.mercurial.MercurialSCM" plugin="mercurial@@1.59">
+  <scm class="hudson.plugins.mercurial.MercurialSCM" plugin="mercurial@@2.1">
     <installation>(Default)</installation>
     <source>@ESCAPE(source)</source>
     <modules/>

--- a/ros_buildfarm/templates/snippet/trigger_github-pull-request-builder.xml.em
+++ b/ros_buildfarm/templates/snippet/trigger_github-pull-request-builder.xml.em
@@ -1,4 +1,4 @@
-    <org.jenkinsci.plugins.ghprb.GhprbTrigger plugin="ghprb@@1.36.1">
+    <org.jenkinsci.plugins.ghprb.GhprbTrigger plugin="ghprb@@1.39.0">
       <spec/>
       <latestVersion>3</latestVersion>
       <configVersion>3</configVersion>
@@ -18,10 +18,18 @@
           <branch>@ESCAPE(branch_name)</branch>
         </org.jenkinsci.plugins.ghprb.GhprbBranch>
       </whiteListTargetBranches>
+      <blacklistTargetBranches>
+        <org.jenkinsci.plugins.ghprb.GhprbBranch>
+          <branch></branch>
+        </org.jenkinsci.plugins.ghprb.GhprbBranch>
+      </blacklistTargetBranches>
       <triggerPhrase/>
       <skipBuildPhrase>.*\[skip\W+ci\].*</skipBuildPhrase>
+      <blackListCommitAuthor/>
       <blackListLabels/>
       <whiteListLabels/>
+      <includedRegions/>
+      <excludedRegions/>
       <extensions>
         <org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus>
           <commitStatusContext>@ESCAPE(job_name)</commitStatusContext>


### PR DESCRIPTION
PrioritySorter  -> 3.5.1
analysis-core   -> 1.92
dashboard-view  -> 2.9.11
git             -> 3.5.1
github          -> 1.28.0
mercurial       -> 2.1
script-security -> 1.34
warnings        -> 4.63

Using log output from a sampling of reconfigure jobs. I have the beginnings of some shell scripts to make this easier. They're not quite working yet.