### PR TITLE
increase days_to_keep for some job types

### DIFF
--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -9,7 +9,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
   <properties>
 @(SNIPPET(
     'property_log-rotator',
-    days_to_keep=365,
+    days_to_keep=730,
     num_to_keep=100,
 ))@
 @[if github_url]@

--- a/ros_buildfarm/templates/release/binarydeb_job.xml.em
+++ b/ros_buildfarm/templates/release/binarydeb_job.xml.em
@@ -9,7 +9,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
   <properties>
 @(SNIPPET(
     'property_log-rotator',
-    days_to_keep=180,
+    days_to_keep=730,
     num_to_keep=30,
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/release/release_trigger-broken-with-non-broken-upstream_job.xml.em
+++ b/ros_buildfarm/templates/release/release_trigger-broken-with-non-broken-upstream_job.xml.em
@@ -5,7 +5,7 @@
   <properties>
 @(SNIPPET(
     'property_log-rotator',
-    days_to_keep=365,
+    days_to_keep=730,
     num_to_keep=30,
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/release/release_trigger-jobs_job.xml.em
+++ b/ros_buildfarm/templates/release/release_trigger-jobs_job.xml.em
@@ -5,7 +5,7 @@
   <properties>
 @(SNIPPET(
     'property_log-rotator',
-    days_to_keep=365,
+    days_to_keep=730,
     num_to_keep=100,
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/release/sourcedeb_job.xml.em
+++ b/ros_buildfarm/templates/release/sourcedeb_job.xml.em
@@ -9,7 +9,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
   <properties>
 @(SNIPPET(
     'property_log-rotator',
-    days_to_keep=180,
+    days_to_keep=730,
     num_to_keep=30,
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/snippet/trigger-jobs_job.xml.em
+++ b/ros_buildfarm/templates/snippet/trigger-jobs_job.xml.em
@@ -5,7 +5,7 @@
   <properties>
 @(SNIPPET(
     'property_log-rotator',
-    days_to_keep=365,
+    days_to_keep=730,
     num_to_keep=10,
 ))@
 @(SNIPPET(


### PR DESCRIPTION
Since some job only run rarely and a new build after e.g. nine months removes all previous entries.