### PR TITLE
fix config of created views if they have no jobs associated

### DIFF
--- a/ros_buildfarm/jenkins.py
+++ b/ros_buildfarm/jenkins.py
@@ -100,7 +100,7 @@ def configure_view(
         view = jenkins.views.create(view_name, view_type=view_type) \
             if not dry_run else None
         remote_view_config = view.get_config() \
-            if view else None
+            if view is not None else None
     else:
         print("Ensure that view '%s' exists" % view_name)
         view = jenkins.views[view_name]
@@ -114,7 +114,7 @@ def configure_view(
             view = jenkins.views.create(view_name, view_type=view_type) \
                 if not dry_run else None
             remote_view_config = view.get_config() \
-                if view else None
+                if view is not None else None
 
     if not remote_view_config:
         print(


### PR DESCRIPTION
When interpreting `view` as a bool it uses the `__len__` method which return `0` when the new view doesn't have any jobs associated with it yet.