### PR TITLE
Two more job template changes.

### DIFF
--- a/ros_buildfarm/templates/snippet/publisher_extended-email.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_extended-email.xml.em
@@ -36,6 +36,7 @@
       <defaultContent>$DEFAULT_CONTENT</defaultContent>
       <attachmentsPattern/>
       <presendScript>$DEFAULT_PRESEND_SCRIPT</presendScript>
+      <postsendScript/>
       <attachBuildLog>false</attachBuildLog>
       <compressBuildLog>false</compressBuildLog>
       <replyTo>$DEFAULT_REPLYTO</replyTo>

--- a/ros_buildfarm/templates/snippet/trigger_github-pull-request-builder.xml.em
+++ b/ros_buildfarm/templates/snippet/trigger_github-pull-request-builder.xml.em
@@ -18,11 +18,11 @@
           <branch>@ESCAPE(branch_name)</branch>
         </org.jenkinsci.plugins.ghprb.GhprbBranch>
       </whiteListTargetBranches>
-      <blacklistTargetBranches>
+      <blackListTargetBranches>
         <org.jenkinsci.plugins.ghprb.GhprbBranch>
           <branch></branch>
         </org.jenkinsci.plugins.ghprb.GhprbBranch>
-      </blacklistTargetBranches>
+      </blackListTargetBranches>
       <triggerPhrase/>
       <skipBuildPhrase>.*\[skip\W+ci\].*</skipBuildPhrase>
       <blackListCommitAuthor/>


### PR DESCRIPTION
Having swept the different job types again I turned up two changes I hadn't previous spotted.

In the future going to have to look at a way to do this programatically with an xml differ because the quote and apostrophe escaping litters the builtin diff with false positives making it hard to scan and thus a huge time sink.