### PR TITLE
fix mercurial config

### DIFF
--- a/ros_buildfarm/templates/snippet/scm_hg.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_hg.xml.em
@@ -1,5 +1,5 @@
   <scm class="hudson.plugins.mercurial.MercurialSCM" plugin="mercurial@@2.1">
-    <installation>(Default)</installation>
+    <installation>Default</installation>
     <source>@ESCAPE(source)</source>
     <modules/>
     <revisionType>BRANCH</revisionType>


### PR DESCRIPTION
Fixes #488.

One of the jobs which is triggered too often (e.g. http://build.ros.org/job/Idev__rbdl__ubuntu_trusty_amd64/) shows the following in the polling log which result in a triggered build even though the revision hasn't changed in the repo:

```
Started on Dec 18, 2017 8:43:01 AM
Workspace is offline.
Scheduling a new build to get a workspace. (nonexisting_workspace)
Done. Took 0 ms
Changes found
```

I modified one of the mentioned job configs as in this patch (http://build.ros.org/job/Idev__multisense_ros__ubuntu_trusty_amd64/) which result in the folllowing polling log which didn't result in a triggered build:

```
Started on Dec 18, 2017 8:08:00 AM
Acquired master cache lock.
$ /usr/bin/hg clone --noupdate https://bitbucket.org/crl/multisense_ros /var/lib/jenkins/hgcache/F9965BCA9980A99EA564137BDC3A7618C30F7819-multisense_ros
applying clone bundle from https://media-api.atlassian.io/file/90732f32-beac-4280-b1b8-34506fbf487e/binary?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIyMDNkMTc0NS1hNzk2LTRlZWEtODBjMy02ZWM4MjM0YmUyYjIiLCJhY2Nlc3MiOnsidXJuOmZpbGVzdG9yZTpmaWxlOjkwNzMyZjMyLWJlYWMtNDI4MC1iMWI4LTM0NTA2ZmJmNDg3ZSI6WyJyZWFkIl19LCJuYmYiOjE1MTM2MTMyMjIsImV4cCI6MTUxMzYxMzY0Mn0.o8rlT6gOlzP3WdIjR_KhrkIcxwluP5d_etx_qAZp6UA&client=203d1745-a796-4eea-80c3-6ec8234be2b2
adding changesets
adding manifests
adding file changes
added 117 changesets with 1542 changes to 393 files
finished applying clone bundle
searching for changes
no changes found
Master cache lock released.
[F9965BCA9980A99EA564137BDC3A7618C30F7819-multisense_ros] $ /usr/bin/hg log --rev default --template {node}
[F9965BCA9980A99EA564137BDC3A7618C30F7819-multisense_ros] $ /usr/bin/hg log --rev default --template {rev}
Done. Took 5.6 sec
No changes
```