### PR TITLE
Add in artful and bionic to the short os names.

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -275,9 +275,9 @@ def get_short_os_code_name(os_code_name):
         'xenial': 'X',
         'yakkety': 'Y',
         'zesty': 'Z',
-        'artful', : 'A',
-        'bionic', : 'B',
-        'wheezy', : 'W',
+        'artful': 'A',
+        'bionic': 'B',
+        'wheezy': 'W',
         'jessie': 'J',
         'stretch': 'S',
     }

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -267,9 +267,7 @@ def get_short_os_name(os_name):
 
 def get_short_os_code_name(os_code_name):
     os_code_name_mappings = {
-        'jessie': 'J',
         'saucy': 'S',
-        'stretch': 'S',
         'trusty': 'T',
         'utopic': 'U',
         'vivid': 'V',
@@ -277,6 +275,11 @@ def get_short_os_code_name(os_code_name):
         'xenial': 'X',
         'yakkety': 'Y',
         'zesty': 'Z',
+        'artful', : 'A',
+        'bionic', : 'B',
+        'wheezy', : 'W',
+        'jessie': 'J',
+        'stretch': 'S',
     }
     return os_code_name_mappings.get(os_code_name, os_code_name)
 

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -267,7 +267,11 @@ def get_short_os_name(os_name):
 
 def get_short_os_code_name(os_code_name):
     os_code_name_mappings = {
+        'artful': 'A',
+        'bionic': 'B',
+        'jessie': 'J',
         'saucy': 'S',
+        'stretch': 'S',
         'trusty': 'T',
         'utopic': 'U',
         'vivid': 'V',
@@ -275,11 +279,6 @@ def get_short_os_code_name(os_code_name):
         'xenial': 'X',
         'yakkety': 'Y',
         'zesty': 'Z',
-        'artful': 'A',
-        'bionic': 'B',
-        'wheezy': 'W',
-        'jessie': 'J',
-        'stretch': 'S',
     }
     return os_code_name_mappings.get(os_code_name, os_code_name)
 


### PR DESCRIPTION
While we are here, change the order of the listing so it is Ubuntu chronological, followed by Debian chronological.  This matches what we do in other repositories (like https://github.com/ros-infrastructure/buildfarm_deployment_config/blob/master/hiera/hieradata/buildfarm_role/repo.yaml#L100)

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>