### PR TITLE
readme: point to the Buildfarm Discourse instead of the old SIG.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,8 @@ the process.
 It is based on the ROS distro specification
 [REP 143](http://www.ros.org/reps/rep-0143.html) and uses a separate repository
 to configure the jobs being generated (e.g.
-[https://github.com/ros-infrastructure/ros_buildfarm_config](https://github.com/ros-infrastructure/ros_buildfarm_config)
-).
+[ros-infrastructure/ros_buildfarm_config](https://github.com/ros-infrastructure/ros_buildfarm_config)).
 
 If you are going to use any of the provided infrastructure please consider
-signing up for the build farm mailing list
-(https://groups.google.com/d/forum/ros-sig-buildfarm) in order to receive
-notifications e.g. about any upcoming changes.
+watching the [buildfarm Discourse category](https://discourse.ros.org/c/buildfarm)
+in order to receive notifications e.g. about any upcoming changes.


### PR DESCRIPTION
As per subject.

Seems more in-line with `buildfarm_deployment` and other related readmes.
