### PR TITLE
Move all jobs that are at priority 40 down to 35.

### DIFF
--- a/ros_buildfarm/templates/release/release_trigger-broken-with-non-broken-upstream_job.xml.em
+++ b/ros_buildfarm/templates/release/release_trigger-broken-with-non-broken-upstream_job.xml.em
@@ -10,7 +10,7 @@
 ))@
 @(SNIPPET(
     'property_job-priority',
-    priority=40,
+    priority=35,
 ))@
 @(SNIPPET(
     'property_requeue-job',

--- a/ros_buildfarm/templates/release/release_trigger-jobs_job.xml.em
+++ b/ros_buildfarm/templates/release/release_trigger-jobs_job.xml.em
@@ -10,7 +10,7 @@
 ))@
 @(SNIPPET(
     'property_job-priority',
-    priority=40,
+    priority=35,
 ))@
 @(SNIPPET(
     'property_requeue-job',

--- a/ros_buildfarm/templates/snippet/trigger-jobs_job.xml.em
+++ b/ros_buildfarm/templates/snippet/trigger-jobs_job.xml.em
@@ -10,7 +10,7 @@
 ))@
 @(SNIPPET(
     'property_job-priority',
-    priority=40,
+    priority=35,
 ))@
 @(SNIPPET(
     'property_requeue-job',


### PR DESCRIPTION
This is to clear up a bit of space in the priority scheme
for the individual ROS distro builds.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>