### PR TITLE
resolve catkin instead of assuming current rosdistro.

### DIFF
--- a/scripts/devel/create_devel_task_generator.py
+++ b/scripts/devel/create_devel_task_generator.py
@@ -98,8 +98,7 @@ def main(argv=sys.argv[1:]):
         'python3',
     ]
     if 'catkin' not in pkg_names:
-        debian_pkg_names.append(
-            get_debian_package_name(args.rosdistro_name, 'catkin'))
+        debian_pkg_names += resolve_names(['catkin'], **context)
     print('Always install the following generic dependencies:')
     for debian_pkg_name in sorted(debian_pkg_names):
         print('  -', debian_pkg_name)


### PR DESCRIPTION
This is necessary for addon rosdistros.

Re: https://answers.ros.org/question/269152/buildfarm-addon-fork-requires-ros-my_distribution-catkin/

I also considered deferring it to after the dependency checks and looking if 'catkin' was in `pkg_names + build_depends` but wanted to keep the change minimal.