### PR TITLE
update list of EOL ubuntu distributions

### DIFF
--- a/ros_buildfarm/templates/snippet/old_release_set.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/old_release_set.Dockerfile.em
@@ -1,3 +1,3 @@
-@[if os_name == 'ubuntu' and os_code_name in ['saucy', 'utopic']]@
+@[if os_name == 'ubuntu' and os_code_name in ['saucy', 'utopic', 'vivid', 'wily', 'yakkety', 'zesty']]@
 RUN find /etc/apt/ -name *.list -exec sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' {} \;
 @[end if]@


### PR DESCRIPTION
addresses https://github.com/ros-infrastructure/ros_buildfarm_config/pull/103#issuecomment-359530548

needs https://github.com/osrf/multiarch-docker-image-generation/pull/16 to be deployed to fix zesty builds