### PR TITLE
move old_releases sources before installing locales

### DIFF
--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -12,17 +12,17 @@ VOLUME ["/var/cache/apt/archives"]
 ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
+    'snippet/old_release_set.Dockerfile.em',
+    os_name=os_name,
+    os_code_name=os_code_name,
+))@
+
+@(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
     timezone=timezone,
 ))@
 
 RUN useradd -u @uid -m buildfarm
-
-@(TEMPLATE(
-    'snippet/old_release_set.Dockerfile.em',
-    os_name=os_name,
-    os_code_name=os_code_name,
-))@
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/doc/doc_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_task.Dockerfile.em
@@ -12,17 +12,17 @@ VOLUME ["/var/cache/apt/archives"]
 ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
+    'snippet/old_release_set.Dockerfile.em',
+    os_name=os_name,
+    os_code_name=os_code_name,
+))@
+
+@(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
     timezone=timezone,
 ))@
 
 RUN useradd -u @uid -m buildfarm
-
-@(TEMPLATE(
-    'snippet/old_release_set.Dockerfile.em',
-    os_name=os_name,
-    os_code_name=os_code_name,
-))@
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
@@ -12,18 +12,18 @@ VOLUME ["/var/cache/apt/archives"]
 ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
+    'snippet/old_release_set.Dockerfile.em',
+    os_name=os_name,
+    os_code_name=os_code_name,
+))@
+
+@(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
     timezone=timezone,
 ))@
 
 
 RUN useradd -u @uid -m buildfarm
-
-@(TEMPLATE(
-    'snippet/old_release_set.Dockerfile.em',
-    os_name=os_name,
-    os_code_name=os_code_name,
-))@
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/release/binarydeb_install_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_install_task.Dockerfile.em
@@ -13,14 +13,14 @@ VOLUME ["/var/cache/apt/archives"]
 ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
-    'snippet/setup_locale.Dockerfile.em',
-    timezone=timezone,
-))@
-
-@(TEMPLATE(
     'snippet/old_release_set.Dockerfile.em',
     os_name=os_name,
     os_code_name=os_code_name,
+))@
+
+@(TEMPLATE(
+    'snippet/setup_locale.Dockerfile.em',
+    timezone=timezone,
 ))@
 
 @(TEMPLATE(

--- a/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
@@ -13,17 +13,17 @@ VOLUME ["/var/cache/apt/archives"]
 ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
+    'snippet/old_release_set.Dockerfile.em',
+    os_name=os_name,
+    os_code_name=os_code_name,
+))@
+
+@(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
     timezone=timezone,
 ))@
 
 RUN useradd -u @uid -m buildfarm
-
-@(TEMPLATE(
-    'snippet/old_release_set.Dockerfile.em',
-    os_name=os_name,
-    os_code_name=os_code_name,
-))@
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/release/sourcedeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/sourcedeb_task.Dockerfile.em
@@ -7,17 +7,17 @@ VOLUME ["/var/cache/apt/archives"]
 ENV DEBIAN_FRONTEND noninteractive
 
 @(TEMPLATE(
+    'snippet/old_release_set.Dockerfile.em',
+    os_name=os_name,
+    os_code_name=os_code_name,
+))@
+
+@(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
     timezone=timezone,
 ))@
 
 RUN useradd -u @uid -m buildfarm
-
-@(TEMPLATE(
-    'snippet/old_release_set.Dockerfile.em',
-    os_name=os_name,
-    os_code_name=os_code_name,
-))@
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',


### PR DESCRIPTION
Without this all ubuntu source and binary jobs fail for EOL distros. Follow-up of https://github.com/ros-infrastructure/ros_buildfarm/pull/503

Currently being tested on http://build.ros.org/view/Lsrc_uZ/job/Lsrc_uZ__trac_ik_lib__ubuntu_zesty__source