### PR TITLE
use 'old' Debian naming for ardent release

### DIFF
--- a/ros_buildfarm/binarydeb_job.py
+++ b/ros_buildfarm/binarydeb_job.py
@@ -104,7 +104,8 @@ def append_build_timestamp(rosdistro_name, package_name, sourcedeb_dir):
         '-v',
         '%s.%s' % (version, strftime('%Y%m%d.%H%M%S', gmtime()))
         # Backwards compatibility for #460
-        if rosdistro_name not in ('indigo', 'jade', 'kinetic', 'lunar')
+        if rosdistro_name not in (
+            'indigo', 'jade', 'kinetic', 'lunar', 'ardent')
         else '%s-%s' % (version, strftime('%Y%m%d-%H%M%S%z')),
         '-p',  # preserve directory name
         '-D', distribution,


### PR DESCRIPTION
Follow up of #460.

Since the previous packages of Ardent have been built with the "old" naming scheme (containing dashed) the patch releases should continue to do so.

Only for ROS 2 B-turtle we will switch to the "new" naming scheme (containing dots).