### PR TITLE
fix check for existing description tag

### DIFF
--- a/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
+++ b/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
@@ -248,10 +248,10 @@ def diff_configs(current_config, new_config) {
     new_doc = builder.parse(new_config_stream)
 
     // ignore description which contains a timestamp
-    if (current_doc.getElementsByTagName('description')) {
+    if (current_doc.getElementsByTagName('description').getLength() > 0) {
         current_doc.getElementsByTagName('description').item(0).setTextContent('')
     }
-    if (new_doc.getElementsByTagName('description')) {
+    if (new_doc.getElementsByTagName('description').getLength() > 0) {
         new_doc.getElementsByTagName('description').item(0).setTextContent('')
     }
 


### PR DESCRIPTION
`getElementsByTagName()` returns a [NodeList](https://docs.oracle.com/javase/8/docs/api/org/w3c/dom/NodeList.html). Therefore checking it as a `bool` doesn't make sense. Instead it needs to be checked that it contains at least one item before accessing the first item and calling a method on it.

Fixes #513.