### PR TITLE
Add the mail publisher to the trigger_upload_repo_job.

### DIFF
--- a/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
+++ b/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
@@ -38,11 +38,12 @@ $HOME/upload_triggers/upload_repo.bash @repo
     </hudson.tasks.Shell>
   </builders>
   <publishers>
-    <hudson.tasks.Mailer plugin="mailer@@1.20">
-      <recipients>@notification_emails</recipients>
-      <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
-      <sendToIndividuals>false</sendToIndividuals>
-    </hudson.tasks.Mailer>
+@(SNIPPET(
+    'publisher_mailer',
+    recipients=recipients,
+    dynamic_recipients=[],
+    send_to_individuals=False
+))@
   </publishers>
   <buildWrappers/>
 </project>

--- a/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
+++ b/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
@@ -37,6 +37,12 @@ $HOME/upload_triggers/upload_repo.bash @repo
 </command>
     </hudson.tasks.Shell>
   </builders>
-  <publishers/>
+  <publishers>
+    <hudson.tasks.Mailer plugin="mailer@@1.20">
+      <recipients>steven+build.ros.org@@openrobotics.org tfoote+buildfarm@@osrfoundation.org</recipients>
+      <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
+      <sendToIndividuals>false</sendToIndividuals>
+    </hudson.tasks.Mailer>
+  </publishers>
   <buildWrappers/>
 </project>

--- a/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
+++ b/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
@@ -39,7 +39,7 @@ $HOME/upload_triggers/upload_repo.bash @repo
   </builders>
   <publishers>
     <hudson.tasks.Mailer plugin="mailer@@1.20">
-      <recipients>steven+build.ros.org@@openrobotics.org tfoote+buildfarm@@osrfoundation.org</recipients>
+      <recipients>@notification_emails</recipients>
       <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
       <sendToIndividuals>false</sendToIndividuals>
     </hudson.tasks.Mailer>

--- a/scripts/release/generate_release_trigger_upload_jobs.py
+++ b/scripts/release/generate_release_trigger_upload_jobs.py
@@ -49,7 +49,7 @@ def main(argv=sys.argv[1:]):
             'block_when_upstream_building': block_when_upstream_building,
             'repo': repo,
             'upstream_job_names': get_upstream_job_names(config, repo),
-            'notification_emails': ' '.join(config.notify_emails)})
+            'recipients': config.notify_emails})
 
         configure_job(jenkins, job_name, job_config, dry_run=args.dry_run)
 

--- a/scripts/release/generate_release_trigger_upload_jobs.py
+++ b/scripts/release/generate_release_trigger_upload_jobs.py
@@ -48,7 +48,8 @@ def main(argv=sys.argv[1:]):
         job_config = expand_template(template_name, {
             'block_when_upstream_building': block_when_upstream_building,
             'repo': repo,
-            'upstream_job_names': get_upstream_job_names(config, repo)})
+            'upstream_job_names': get_upstream_job_names(config, repo),
+            'notification_emails': ' '.join(config.notify_emails)})
 
         configure_job(jenkins, job_name, job_config, dry_run=args.dry_run)
 


### PR DESCRIPTION
This makes it match the actual configuration on the build
farm.

I realize that there are 2 hard-coded email addresses in here.  We should probably change that to ros-buildfarm@googlegroups.com, but this configuration matches the one that is currently deployed.  I'm happy to change it, but if we do, we'll need to re-deploy to the build farm.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>