### PR TITLE
Generate YAML of build information

### DIFF
--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -1044,20 +1044,7 @@ def write_yaml(yaml_filename, ordered_pkgs, repos_data):
         pkg_d = {'version': pkg.version, 'url': pkg.repository_url, 'status': pkg.status}
         if pkg.status_description:
             pkg_d['status_description'] = pkg.status_description
-        pkg_d['maintainers'] = []
-        for maintainer in pkg.maintainers:
-            maintainer_dict = {'email': maintainer.email}
-            # In order to write the simplest data to the yaml, we try to encode the name to ascii.
-            ascii_name = maintainer.name.decode('utf-8').encode('ascii', 'ignore')
-            if maintainer.name == ascii_name:
-                # If it is the same, we write the ascii name to the dict
-                # Otherwise it will appear in the file as
-                # name: !!python/unicode 'David V. Lu!!'
-                maintainer_dict['name'] = ascii_name
-            else:
-                # Otherwise, we write in all its unicode glory
-                maintainer_dict['name'] = maintainer.name
-            pkg_d['maintainers'].append(maintainer_dict)
+        pkg_d['maintainers'] = [{'email': m.email, 'name': m.name} for m in pkg.maintainers]
 
         pkg_d['build_status'] = {}
 
@@ -1076,4 +1063,4 @@ def write_yaml(yaml_filename, ordered_pkgs, repos_data):
         summary[pkg.name] = pkg_d
 
     with open(yaml_filename, 'w') as f:
-        yaml.dump(summary, f, allow_unicode=True)
+        yaml.safe_dump(summary, f, allow_unicode=True)


### PR DESCRIPTION
In lieu of [the csv that used to be generated](http://www.ros.org/debbuild/hydro.csv), this PR now generates a neat YAML file with the build information. 

I have not tested with the main build farm, but a private build farm. With the main build farm, I cannot access http://54.183.65.232. 

Resulting yaml entry:
```
navigation:
  build_status:
    ubuntu:
      xenial:
        amd64: 
            build: 1.15.1-0xenial-20180215-152207-0800
            main: 1.15.1-0xenial-20171213-034534-0800
            test: 1.15.1-0xenial-20180215-152207-0800
        source:
            build: 1.15.1-0xenial
            main: 1.15.1-0xenial
            test: 1.15.1-0xenial}
  maintainers:
  - {email: davidvlu@gmail.com, name: David V. Lu!!}
  - {email: mferguson@fetchrobotics.com, name: Michael Ferguson}
  status: developed
  url: https://github.com/ros-planning/navigation.git
  version: 1.15.1-0
```