### PR TITLE
Use the distribution cache for the package names instead of the distf…

### DIFF
--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -75,16 +75,7 @@ def configure_release_jobs(
         print('No distribution file matches the build file')
         return
 
-    dist_cache = get_distribution_cache(index, rosdistro_name)
-
-    # We can get the list of packages either from dist_file.release_packages,
-    # or from dist_cache.release_package_xmls.  The problem with the former
-    # is that it may come directly from GitHub, and we have seen cases where
-    # we get an outdated copy of the distribution file.  The cache file always
-    # comes directly from the infrastructure, so we use that as an
-    # authoritative source.
-    pkg_names = dist_cache.release_package_xmls.keys()
-
+    pkg_names = dist_file.release_packages.keys()
     filtered_pkg_names = build_file.filter_packages(pkg_names)
     explicitly_ignored_pkg_names = set(pkg_names) - set(filtered_pkg_names)
     if explicitly_ignored_pkg_names:
@@ -94,6 +85,7 @@ def configure_release_jobs(
         for pkg_name in sorted(explicitly_ignored_pkg_names):
             print('  -', pkg_name)
 
+    dist_cache = get_distribution_cache(index, rosdistro_name)
 
     if explicitly_ignored_pkg_names:
         # get direct dependencies from distro cache for each package

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -75,7 +75,16 @@ def configure_release_jobs(
         print('No distribution file matches the build file')
         return
 
-    pkg_names = dist_file.release_packages.keys()
+    dist_cache = get_distribution_cache(index, rosdistro_name)
+
+    # We can get the list of packages either from dist_file.release_packages,
+    # or from dist_cache.release_package_xmls.  The problem with the former
+    # is that it may come directly from GitHub, and we have seen cases where
+    # we get an outdated copy of the distribution file.  The cache file always
+    # comes directly from the infrastructure, so we use that as an
+    # authoritative source.
+    pkg_names = dist_cache.release_package_xmls.keys()
+
     filtered_pkg_names = build_file.filter_packages(pkg_names)
     explicitly_ignored_pkg_names = set(pkg_names) - set(filtered_pkg_names)
     if explicitly_ignored_pkg_names:
@@ -85,7 +94,6 @@ def configure_release_jobs(
         for pkg_name in sorted(explicitly_ignored_pkg_names):
             print('  -', pkg_name)
 
-    dist_cache = get_distribution_cache(index, rosdistro_name)
 
     if explicitly_ignored_pkg_names:
         # get direct dependencies from distro cache for each package

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -174,6 +174,16 @@ def configure_release_jobs(
         pkg_xml = dist_cache.release_package_xmls[pkg_name]
         pkg = parse_package_string(pkg_xml)
         pkgs[pkg_name] = pkg
+
+    # We have seen situations in the past where the distribution
+    # file (dist_file) version we get is a cached, out-of-date version from a
+    # CDN, but where the distribution cache (dist_cache) is up-to-date.  Check
+    # for and warn about this situation so that nobody has to spend time
+    # debugging when this is the case.
+    for pkg_name in dist_cache.release_package_xmls.keys():
+        if pkg_name not in pkgs:
+            print("Skipping package '%s': in cache but not in distribution file (can happen if a CDN returns an outdated distfile)" % (pkg_name), file=sys.stderr)
+
     ordered_pkg_tuples = topological_order_packages(pkgs)
 
     other_build_files = [v for k, v in build_files.items() if k != release_build_name]


### PR DESCRIPTION
…ile.

This will ensure that we always get an authoritative copy, as opposed to a possibly cached, outdated one.

I've tested this a bit locally, and this seems to give me the same results as using the `dist_file`.  If we switch to this, it will increase the load on repositories.ros.org, but the files are small enough that I don't think that should be a huge issue.  There may be other gotchas that I'm not aware of with this change; I want to see what everyone thinks of doing this.