### PR TITLE
Call super in JobValidationError to correcly print the error

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -31,7 +31,7 @@ class JobValidationError(Exception):
     """
 
     def __init__(self, message):
-        self.message = message
+        super(JobValidationError, self).__init__(message)
 
 
 next_scope_id = 1


### PR DESCRIPTION
Without this call, you get a meaningless JobValidationError. With this change it'll properly print the message when an exception occurs.