### PR TITLE
Mount the shared jenkins hgcache to allow hg operations.

### DIFF
--- a/ros_buildfarm/templates/doc/doc_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_job.xml.em
@@ -127,11 +127,11 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
     'builder_shell_key-files',
     script_generating_key_files=script_generating_key_files,
 ))@
-
-@{if doc_repo_spec.type == 'hg':
-  hgcache_mount_arg = ' -v $HOME/hgcache:$HOME/hgcache '
+@{
+if doc_repo_spec.type == 'hg':
+    hgcache_mount_arg = ' -v $HOME/hgcache:$HOME/hgcache '
 else:
-  hgcache_mount_arg = ''
+    hgcache_mount_arg = ''
 }@
 @(SNIPPET(
     'builder_shell',

--- a/ros_buildfarm/templates/doc/doc_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_job.xml.em
@@ -127,6 +127,12 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
     'builder_shell_key-files',
     script_generating_key_files=script_generating_key_files,
 ))@
+
+@{if doc_repo_spec.type == 'hg':
+  hgcache_mount_arg = ' -v $HOME/hgcache:$HOME/hgcache '
+else:
+  hgcache_mount_arg = ''
+}@
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
@@ -183,6 +189,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' -v $WORKSPACE/catkin_workspace:/tmp/catkin_workspace' +
         ' -v $WORKSPACE/generated_documentation:/tmp/generated_documentation' +
         ' -v $WORKSPACE/docker_doc:/tmp/docker_doc' +
+        hgcache_mount_arg +
         ' doc_task_generation.%s_%s' % (rosdistro_name, doc_repo_spec.name.lower()),
         'echo "# END SECTION"',
     ]),


### PR DESCRIPTION
This fixes #502 by mounting the hgcache directory in-place within the doc_task_generation container which uses `hg id --id` to get the current commit id when checking whether docs should be rebuilt.

