### PR TITLE
Ignore the seccomp profile warning in `docker info`.

### DIFF
--- a/ros_buildfarm/templates/snippet/builder_system-groovy_extract-warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy_extract-warnings.xml.em
@@ -15,7 +15,7 @@ try {
   r = build.getLogReader()
   br = new BufferedReader(r)
   pattern = Pattern.compile(".*WARNING:.*")
-  ignore_pattern = Pattern.compile(".*WARNING: No swap limit support.*")
+  ignore_pattern = Pattern.compile(".*WARNING: (You're not using the default seccomp profile|No swap limit support).*")
   def warnings = []
   def line
   while ((line = br.readLine()) != null) {


### PR DESCRIPTION
When using a custom seccomp profile a warning is printed in docker info.

Connects to https://github.com/ros-infrastructure/buildfarm_deployment/issues/176.