### PR TITLE
Don't set an empty ssh-agent wrapper on devel jobs.

### DIFF
--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -269,14 +269,11 @@ if pull_request:
 @(SNIPPET(
     'build-wrapper_timestamper',
 ))@
-@{
-credential_ids = []
-if git_ssh_credential_id:
-    credential_ids.append(git_ssh_credential_id)
-}@
+@[if git_ssh_credential_id]@
 @(SNIPPET(
     'build-wrapper_ssh-agent',
-    credential_ids=credential_ids,
+    credential_ids=[git_ssh_gredential_id],
 ))@
+@[end if]@
   </buildWrappers>
 </project>


### PR DESCRIPTION
Setting the ssh agent build wrapper without a credential id causes changes to the devel job config from the Jenkins UI to add the first configured ssh key credential. In addition to noise when reconfiguring, manual config changes could also unintentionally expose an ssh key to a devel job that does not need it.

This is an example of a devel job before and after manual
reconfiguration.

```diff
--- previous-config.xml       2018-03-22 06:49:23.427691589 -0700
+++ current-config.xml        2018-03-22 06:49:54.783617638 -0700
@@ -464,9 +464,10 @@
     </hudson.plugins.build__timeout.BuildTimeoutWrapper>
     <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.8"/>
     <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@1.15">
+      <credentialIds>
+        <string>1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5</string>
+      </credentialIds>
       <ignoreMissing>false</ignoreMissing>
     </com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>
   </buildWrappers>
 </project>
 ```

With this change the job template no longer adds the ssh agent build
wrapper to the job unless it is actually needed.

```diff
--- remote config
+++ new config
@@ -468,5 +467,0 @@
-    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@1.15">
-      <credentialIds>
-      </credentialIds>
-      <ignoreMissing>false</ignoreMissing>
-    </com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>
```