### PR TITLE
Create all_distro yaml

### DIFF
--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -24,7 +24,6 @@ import shutil
 import sys
 import time
 import yaml
-import collections
 
 from .common import get_debian_package_name
 from .common import get_release_view_name
@@ -157,10 +156,7 @@ def build_release_status_page(
         os.mkdir(yaml_folder)
 
     yaml_filename = os.path.join(yaml_folder, 'ros_%s_%s.yaml' % (rosdistro_name, release_build_name))
-    summary = write_yaml(yaml_filename, ordered_pkgs, repos_data, rosdistro_name)
-
-    super_yaml_filename = os.path.join(yaml_folder, 'all_builds.yaml')
-    merge_yaml(super_yaml_filename, summary)
+    write_yaml(yaml_filename, ordered_pkgs, repos_data, rosdistro_name)
 
 
 def build_debian_repos_status_page(
@@ -1082,21 +1078,3 @@ def write_yaml(yaml_filename, ordered_pkgs, repos_data, rosdistro_name):
 
     with open(yaml_filename, 'w') as f:
         yaml.safe_dump(summary, f, allow_unicode=True)
-    return summary
-
-def dict_merge(dct, merge_dct):
-    for k, v in merge_dct.iteritems():
-        if (k in dct and isinstance(dct[k], dict) and isinstance(merge_dct[k], collections.Mapping)):
-            dict_merge(dct[k], merge_dct[k])
-        else:
-            dct[k] = merge_dct[k]
-
-def merge_yaml(super_yaml_filename, summary):
-    print("Updating aggregated yaml '%s':" % super_yaml_filename)
-    if os.path.exists(super_yaml_filename):
-        main_dict = yaml.load(open(super_yaml_filename))
-    else:
-        main_dict = {}
-    dict_merge(main_dict, summary)
-    with open(super_yaml_filename, 'w') as f:
-        yaml.safe_dump(main_dict, f, allow_unicode=True)

--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -24,6 +24,7 @@ import shutil
 import sys
 import time
 import yaml
+import collections
 
 from .common import get_debian_package_name
 from .common import get_release_view_name
@@ -156,7 +157,10 @@ def build_release_status_page(
         os.mkdir(yaml_folder)
 
     yaml_filename = os.path.join(yaml_folder, 'ros_%s_%s.yaml' % (rosdistro_name, release_build_name))
-    write_yaml(yaml_filename, ordered_pkgs, repos_data)
+    summary = write_yaml(yaml_filename, ordered_pkgs, repos_data, rosdistro_name)
+
+    super_yaml_filename = os.path.join(yaml_folder, 'all_builds.yaml')
+    merge_yaml(super_yaml_filename, summary)
 
 
 def build_debian_repos_status_page(
@@ -1041,16 +1045,20 @@ def _compare_package_version(distros, pkg_name):
 
 
 REPOS_DATA_NAMES = ['build', 'test', 'main']
-def write_yaml(yaml_filename, ordered_pkgs, repos_data):
+VERSION_PATTERN = re.compile('([\d\.\-]+).*')
+def write_yaml(yaml_filename, ordered_pkgs, repos_data, rosdistro_name):
     print("Generating status yaml '%s':" % yaml_filename)
     summary = {}
     for pkg in ordered_pkgs:
-        pkg_d = {'version': pkg.version, 'url': pkg.repository_url, 'status': pkg.status}
+        pkg_d = {}
+        version_d = {'version': pkg.version, 'url': pkg.repository_url, 'status': pkg.status}
+        pkg_d[rosdistro_name] = version_d
         if pkg.status_description:
-            pkg_d['status_description'] = pkg.status_description
-        pkg_d['maintainers'] = [{'email': m.email, 'name': m.name} for m in pkg.maintainers]
+            version_d['status_description'] = pkg.status_description
 
-        pkg_d['build_status'] = {}
+        pkg_d['maintainers'] = dict([(m.email, m.name) for m in pkg.maintainers])
+
+        version_d['build_status'] = {}
 
         for name, repo_set in zip(REPOS_DATA_NAMES, repos_data):
             for key, build_data in repo_set.items():
@@ -1058,13 +1066,37 @@ def write_yaml(yaml_filename, ordered_pkgs, repos_data):
                     continue
 
                 # Dynamically Create the Nested Dictionary
-                d = pkg_d['build_status']
+                d = version_d['build_status']
                 for field in [key.os_name, key.os_code_name, key.arch]:
                     if field not in d:
                         d[field] = {}
                     d = d[field]
-                d[name] = str(build_data[pkg.debian_name])
+                debian_s = str(build_data[pkg.debian_name])
+                m = VERSION_PATTERN.match(debian_s)
+                if m:
+                    debian_version = m.group(1)
+                else:
+                    debian_version = debian_s
+                d[name] = debian_version
         summary[pkg.name] = pkg_d
 
     with open(yaml_filename, 'w') as f:
         yaml.safe_dump(summary, f, allow_unicode=True)
+    return summary
+
+def dict_merge(dct, merge_dct):
+    for k, v in merge_dct.iteritems():
+        if (k in dct and isinstance(dct[k], dict) and isinstance(merge_dct[k], collections.Mapping)):
+            dict_merge(dct[k], merge_dct[k])
+        else:
+            dct[k] = merge_dct[k]
+
+def merge_yaml(super_yaml_filename, summary):
+    print("Updating aggregated yaml '%s':" % super_yaml_filename)
+    if os.path.exists(super_yaml_filename):
+        main_dict = yaml.load(open(super_yaml_filename))
+    else:
+        main_dict = {}
+    dict_merge(main_dict, summary)
+    with open(super_yaml_filename, 'w') as f:
+        yaml.safe_dump(main_dict, f, allow_unicode=True)


### PR DESCRIPTION
Following up on #521, this PR creates an additional YAML file that makes it easier to aggregate info across distros/releases. The goal is to make the separate distros easier to merge recursively and reduce file size.

Previously we had this as the entry.
```
navigation:
  build_status:
    ubuntu:
      xenial:
        amd64: 
            build: 1.15.1-0xenial-20180215-152207-0800
            main: 1.15.1-0xenial-20171213-034534-0800
            test: 1.15.1-0xenial-20180215-152207-0800
        source:
            build: 1.15.1-0xenial
            main: 1.15.1-0xenial
            test: 1.15.1-0xenial}
  maintainers:
  - {email: davidvlu@gmail.com, name: David V. Lu!!}
  - {email: mferguson@fetchrobotics.com, name: Michael Ferguson}
  status: developed
  url: https://github.com/ros-planning/navigation.git
  version: 1.15.1-0
```

Now we change it to
```
navigation:
  kinetic:
    build_status:
      ubuntu:
        xenial:
          amd64: {build: 1.15.1-0, main: 1.15.1-0, test: 1.15.1-0}
          source: {build: 1.15.1-0, main: 1.15.1-0, test: 1.15.1-0}
    status: developed
    url: https://github.com/ros-planning/navigation.git
    version: 1.15.1-0
  maintainers: {davidvlu@gmail.com: David V. Lu!!, mferguson@fetchrobotics.com: Michael Ferguson}
```
Of note:
 * `build_status`, `status` `url` and `version` are dropped down a level underneath the rosdistro name.
 * The `build_status` only marks the version number, not the full debian name.
 * The maintainers list becomes a dictionary mapping email address to name.

~~After the distro/release specific yaml is made, it is recursively merged with `all_distros.yaml`~~

~~I acknowledge that the merging might end up being slow, given the size of the individual yamls, but it was a little fuzzy to me how to spin it off into a separate job.~~