### PR TITLE
Fix typo

### DIFF
--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -272,7 +272,7 @@ if pull_request:
 @[if git_ssh_credential_id]@
 @(SNIPPET(
     'build-wrapper_ssh-agent',
-    credential_ids=[git_ssh_gredential_id],
+    credential_ids=[git_ssh_credential_id],
 ))@
 @[end if]@
   </buildWrappers>


### PR DESCRIPTION
This PR fixes a typo introduced in https://github.com/ros-infrastructure/ros_buildfarm/commit/3b98057cee81bbb96cd95cd05b02ccfda9dd10c7