### PR TITLE
Use egrep to find repository components in arbitrary positions.

### DIFF
--- a/ros_buildfarm/templates/snippet/add_additional_repositories.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/add_additional_repositories.Dockerfile.em
@@ -8,9 +8,9 @@ archive_commands = []
 old_releases_commands = []
 for distribution, archive_type in product((os_code_name, os_code_name + '-updates', os_code_name + '-security'), ('deb', 'deb-src')):
     archive_entry = '%s http://archive.ubuntu.com/ubuntu/ %s multiverse' % (archive_type, distribution)
-    archive_pattern = '%s http://archive.ubuntu.com/ubuntu/ %s ([-a-z]+ )*multiverse( [-a-z])*' % (archive_type, distribution)
+    archive_pattern = '%s http://archive\.ubuntu\.com/ubuntu/ %s ([-a-z]+ )*multiverse( [-a-z])*' % (archive_type, distribution)
     old_releases_entry = '%s http://old-releases.ubuntu.com/ubuntu/ %s multiverse' % (archive_type, distribution)
-    old_releases_pattern = '%s http://old-releases.ubuntu.com/ubuntu/ %s ([-a-z]+ )*multiverse( [-a-z]+)*' % (archive_type, distribution)
+    old_releases_pattern = '%s http://old-releases\.ubuntu\.com/ubuntu/ %s ([-a-z]+ )*multiverse( [-a-z]+)*' % (archive_type, distribution)
     archive_commands.append('(grep -q -E -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (archive_pattern, archive_entry))
     old_releases_commands.append('(grep -q -E -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (old_releases_pattern, old_releases_entry))
 }@
@@ -20,7 +20,7 @@ RUN grep -q -F -e "deb http://old-releases.ubuntu.com" /etc/apt/sources.list && 
 commands = []
 for distribution, archive_type in product((os_code_name, os_code_name + '-updates', os_code_name + '-security'), ('deb', 'deb-src')):
     entry = '%s http://ports.ubuntu.com// %s multiverse' % (archive_type, distribution)
-    pattern = '%s http://ports.ubuntu.com// %s ([-a-z]+ )*multiverse( [-a-z])*' % (archive_type, distribution)
+    pattern = '%s http://ports\.ubuntu\.com// %s ([-a-z]+ )*multiverse( [-a-z])*' % (archive_type, distribution)
     commands.append('(grep -q -E -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (pattern, entry))
 }@
 RUN @(' && '.join(commands))
@@ -33,11 +33,11 @@ RUN @(' && '.join(commands))
 commands = []
 for component in ('contrib', 'non-free'):
     entry = 'deb http://httpredir.debian.org/debian %s %s' % (os_code_name, component)
-    pattern = 'deb http://httpredir.debian.org/debian %s ([-a-z] )*%s( [-a-z])*' % (os_code_name, component)
+    pattern = 'deb http://httpredir\.debian\.org/debian %s ([-a-z] )*%s( [-a-z])*' % (os_code_name, component)
     commands.append('(grep -q -E -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (pattern, entry))
 }@
 RUN @(' && '.join(commands))
 # Hit cloudfront mirror because of corrupted packages on fastly mirrors (https://github.com/ros-infrastructure/ros_buildfarm/issues/455)
 # You can remove this line to target the default mirror or replace this to use the mirror of your preference
-RUN sed -i 's/httpredir.debian.org/cloudfront.debian.net/' /etc/apt/sources.list
+RUN sed -i 's/httpredir\.debian\.org/cloudfront.debian.net/' /etc/apt/sources.list
 @[end if]@

--- a/ros_buildfarm/templates/snippet/add_additional_repositories.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/add_additional_repositories.Dockerfile.em
@@ -8,9 +8,11 @@ archive_commands = []
 old_releases_commands = []
 for distribution, archive_type in product((os_code_name, os_code_name + '-updates', os_code_name + '-security'), ('deb', 'deb-src')):
     archive_entry = '%s http://archive.ubuntu.com/ubuntu/ %s multiverse' % (archive_type, distribution)
+    archive_pattern = '%s http://archive.ubuntu.com/ubuntu/ %s ([a-z]+ )*multiverse( [a-z])*' % (archive_type, distribution)
     old_releases_entry = '%s http://old-releases.ubuntu.com/ubuntu/ %s multiverse' % (archive_type, distribution)
-    archive_commands.append('(grep -q -F -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (archive_entry, archive_entry))
-    old_releases_commands.append('(grep -q -F -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (old_releases_entry, old_releases_entry))
+    old_releases_pattern = '%s http://old-releases.ubuntu.com/ubuntu/ %s ([a-z]+ )*multiverse( [a-z]+)*' % (archive_type, distribution)
+    archive_commands.append('(grep -q -E -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (archive_pattern, archive_entry))
+    old_releases_commands.append('(grep -q -E -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (old_releases_pattern, old_releases_entry))
 }@
 RUN grep -q -F -e "deb http://old-releases.ubuntu.com" /etc/apt/sources.list && (@(' && '.join(old_releases_commands))) || (@(' && '.join(archive_commands)))
 @[  elif arch in ['armhf', 'armv8']]@
@@ -18,7 +20,8 @@ RUN grep -q -F -e "deb http://old-releases.ubuntu.com" /etc/apt/sources.list && 
 commands = []
 for distribution, archive_type in product((os_code_name, os_code_name + '-updates', os_code_name + '-security'), ('deb', 'deb-src')):
     entry = '%s http://ports.ubuntu.com// %s multiverse' % (archive_type, distribution)
-    commands.append('(grep -q -F -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (entry, entry))
+    pattern = '%s http://ports.ubuntu.com// %s ([a-z]+ )*multiverse( [a-z])*' % (archive_type, distribution)
+    commands.append('(grep -q -E -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (pattern, entry))
 }@
 RUN @(' && '.join(commands))
 @[  end if]@
@@ -30,7 +33,8 @@ RUN @(' && '.join(commands))
 commands = []
 for component in ('contrib', 'non-free'):
     entry = 'deb http://httpredir.debian.org/debian %s %s' % (os_code_name, component)
-    commands.append('(grep -q -F -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (entry, entry))
+    pattern = 'deb http://httpredir.debian.org/debian %s ([a-z] )*%s( [a-z])*' % (os_code_name, component)
+    commands.append('(grep -q -E -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (pattern, entry))
 }@
 RUN @(' && '.join(commands))
 # Hit cloudfront mirror because of corrupted packages on fastly mirrors (https://github.com/ros-infrastructure/ros_buildfarm/issues/455)

--- a/ros_buildfarm/templates/snippet/add_additional_repositories.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/add_additional_repositories.Dockerfile.em
@@ -8,9 +8,9 @@ archive_commands = []
 old_releases_commands = []
 for distribution, archive_type in product((os_code_name, os_code_name + '-updates', os_code_name + '-security'), ('deb', 'deb-src')):
     archive_entry = '%s http://archive.ubuntu.com/ubuntu/ %s multiverse' % (archive_type, distribution)
-    archive_pattern = '%s http://archive.ubuntu.com/ubuntu/ %s ([a-z]+ )*multiverse( [a-z])*' % (archive_type, distribution)
+    archive_pattern = '%s http://archive.ubuntu.com/ubuntu/ %s ([-a-z]+ )*multiverse( [-a-z])*' % (archive_type, distribution)
     old_releases_entry = '%s http://old-releases.ubuntu.com/ubuntu/ %s multiverse' % (archive_type, distribution)
-    old_releases_pattern = '%s http://old-releases.ubuntu.com/ubuntu/ %s ([a-z]+ )*multiverse( [a-z]+)*' % (archive_type, distribution)
+    old_releases_pattern = '%s http://old-releases.ubuntu.com/ubuntu/ %s ([-a-z]+ )*multiverse( [-a-z]+)*' % (archive_type, distribution)
     archive_commands.append('(grep -q -E -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (archive_pattern, archive_entry))
     old_releases_commands.append('(grep -q -E -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (old_releases_pattern, old_releases_entry))
 }@
@@ -20,7 +20,7 @@ RUN grep -q -F -e "deb http://old-releases.ubuntu.com" /etc/apt/sources.list && 
 commands = []
 for distribution, archive_type in product((os_code_name, os_code_name + '-updates', os_code_name + '-security'), ('deb', 'deb-src')):
     entry = '%s http://ports.ubuntu.com// %s multiverse' % (archive_type, distribution)
-    pattern = '%s http://ports.ubuntu.com// %s ([a-z]+ )*multiverse( [a-z])*' % (archive_type, distribution)
+    pattern = '%s http://ports.ubuntu.com// %s ([-a-z]+ )*multiverse( [-a-z])*' % (archive_type, distribution)
     commands.append('(grep -q -E -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (pattern, entry))
 }@
 RUN @(' && '.join(commands))
@@ -33,7 +33,7 @@ RUN @(' && '.join(commands))
 commands = []
 for component in ('contrib', 'non-free'):
     entry = 'deb http://httpredir.debian.org/debian %s %s' % (os_code_name, component)
-    pattern = 'deb http://httpredir.debian.org/debian %s ([a-z] )*%s( [a-z])*' % (os_code_name, component)
+    pattern = 'deb http://httpredir.debian.org/debian %s ([-a-z] )*%s( [-a-z])*' % (os_code_name, component)
     commands.append('(grep -q -E -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (pattern, entry))
 }@
 RUN @(' && '.join(commands))

--- a/ros_buildfarm/templates/snippet/add_additional_repositories.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/add_additional_repositories.Dockerfile.em
@@ -8,9 +8,9 @@ archive_commands = []
 old_releases_commands = []
 for distribution, archive_type in product((os_code_name, os_code_name + '-updates', os_code_name + '-security'), ('deb', 'deb-src')):
     archive_entry = '%s http://archive.ubuntu.com/ubuntu/ %s multiverse' % (archive_type, distribution)
-    archive_pattern = '%s http://archive\.ubuntu\.com/ubuntu/ %s ([-a-z]+ )*multiverse( [-a-z])*' % (archive_type, distribution)
+    archive_pattern = '%s http://archive\.ubuntu\.com/ubuntu/? %s ([-a-z]+ )*multiverse( [-a-z])*' % (archive_type, distribution)
     old_releases_entry = '%s http://old-releases.ubuntu.com/ubuntu/ %s multiverse' % (archive_type, distribution)
-    old_releases_pattern = '%s http://old-releases\.ubuntu\.com/ubuntu/ %s ([-a-z]+ )*multiverse( [-a-z]+)*' % (archive_type, distribution)
+    old_releases_pattern = '%s http://old-releases\.ubuntu\.com/ubuntu/? %s ([-a-z]+ )*multiverse( [-a-z]+)*' % (archive_type, distribution)
     archive_commands.append('(grep -q -E -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (archive_pattern, archive_entry))
     old_releases_commands.append('(grep -q -E -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (old_releases_pattern, old_releases_entry))
 }@
@@ -19,8 +19,8 @@ RUN grep -q -F -e "deb http://old-releases.ubuntu.com" /etc/apt/sources.list && 
 @{
 commands = []
 for distribution, archive_type in product((os_code_name, os_code_name + '-updates', os_code_name + '-security'), ('deb', 'deb-src')):
-    entry = '%s http://ports.ubuntu.com// %s multiverse' % (archive_type, distribution)
-    pattern = '%s http://ports\.ubuntu\.com// %s ([-a-z]+ )*multiverse( [-a-z])*' % (archive_type, distribution)
+    entry = '%s http://ports.ubuntu.com/ %s multiverse' % (archive_type, distribution)
+    pattern = '%s http://ports\.ubuntu\.com/? %s ([-a-z]+ )*multiverse( [-a-z])*' % (archive_type, distribution)
     commands.append('(grep -q -E -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (pattern, entry))
 }@
 RUN @(' && '.join(commands))
@@ -33,7 +33,7 @@ RUN @(' && '.join(commands))
 commands = []
 for component in ('contrib', 'non-free'):
     entry = 'deb http://httpredir.debian.org/debian %s %s' % (os_code_name, component)
-    pattern = 'deb http://httpredir\.debian\.org/debian %s ([-a-z] )*%s( [-a-z])*' % (os_code_name, component)
+    pattern = 'deb http://httpredir\.debian\.org/debian/? %s ([-a-z] )*%s( [-a-z])*' % (os_code_name, component)
     commands.append('(grep -q -E -x -e "%s" /etc/apt/sources.list || echo "%s" >> /etc/apt/sources.list)' % (pattern, entry))
 }@
 RUN @(' && '.join(commands))


### PR DESCRIPTION
This is a proposed enhancement of #530 

The existing implementation assumes that the repositories in question are part of the sources.list on a line of their own when they may exist as one component among several on the same line. This trades the fixed string check for regular expression that will find the desired component regardless of its position among multiple components or if it is on a
line by itself.

@dirk-thomas did you have a Debian test case that you were using for #530? I've only tested this using generate_devel_script.py for indigo fanuc on ubuntu trusty.