### PR TITLE
remove using the test_depend from binary jobs

### DIFF
--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -547,14 +547,15 @@ def _get_direct_dependencies(pkg_name, dist_cache, pkg_names):
         return None
     pkg_xml = dist_cache.release_package_xmls[pkg_name]
     pkg = parse_package_string(pkg_xml)
+    # downstream binary packages don't change if an upstream package is rebuild
+    # if it only has a test dependency therefore don't use test dependencies
     depends = set([
         d.name for d in (
             pkg.buildtool_depends +
             pkg.build_depends +
             pkg.buildtool_export_depends +
             pkg.build_export_depends +
-            pkg.exec_depends +
-            pkg.test_depends)
+            pkg.exec_depends)
         if d.name in pkg_names])
     return depends
 


### PR DESCRIPTION
When releasing a new version of the `ros2cli` repo into Ardent the binarydeb job of e.g. `ros1_bridge` was being retriggered by the rebuild of `ros2run` since it has a [test_depend](https://github.com/ros2/ros1_bridge/blob/f8a6b6dce79937380b341d943d667ccde5287e5e/package.xml#L33) on it.

This patch removes considering `test_depend` for dependencies between binarydeb jobs. While this looks like the "right" thing to be done I would like to get feedback what others think or if they see any problems with this change.