### PR TITLE
add missing import from future for python2 compatibility

### DIFF
--- a/scripts/doc/create_doc_task_generator.py
+++ b/scripts/doc/create_doc_task_generator.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 import argparse
 import copy
 import os

--- a/scripts/doc/extract_metadata.py
+++ b/scripts/doc/extract_metadata.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 import argparse
 import os
 import sys

--- a/scripts/doc/generate_doc_independent_job.py
+++ b/scripts/doc/generate_doc_independent_job.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 import argparse
 import sys
 

--- a/scripts/doc/generate_doc_maintenance_jobs.py
+++ b/scripts/doc/generate_doc_maintenance_jobs.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 import argparse
 import os
 import sys

--- a/scripts/doc/generate_doc_metadata_job.py
+++ b/scripts/doc/generate_doc_metadata_job.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 import argparse
 import sys
 

--- a/scripts/release/check_sync_criteria.py
+++ b/scripts/release/check_sync_criteria.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 import argparse
 import sys
 


### PR DESCRIPTION
While these scripts have python3 in the shebang line, if setup.py is invoked with python2, the executable shebang line will by python2 and these scripts will fail.

Example of backtrace:
```
Traceback (most recent call last):
  File "/usr/local/bin/generate_all_jobs.py", line 4, in <module>
    __import__('pkg_resources').run_script('ros-buildfarm===2.0.1-master', 'generate_all_jobs.py')
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 719, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 1504, in run_script
    exec(code, namespace, namespace)
  File "/usr/local/lib/python2.7/dist-packages/ros_buildfarm-2.0.1_master-py2.7.egg/EGG-INFO/scripts/generate_all_jobs.py", line 319, in <module>
    main()
  File "/usr/local/lib/python2.7/dist-packages/ros_buildfarm-2.0.1_master-py2.7.egg/EGG-INFO/scripts/generate_all_jobs.py", line 118, in main
    dry_run=not args.commit)
  File "/usr/local/lib/python2.7/dist-packages/ros_buildfarm-2.0.1_master-py2.7.egg/EGG-INFO/scripts/generate_all_jobs.py", line 265, in generate_doc_maintenance_jobs
    _check_call(cmd)
  File "/usr/local/lib/python2.7/dist-packages/ros_buildfarm-2.0.1_master-py2.7.egg/EGG-INFO/scripts/generate_all_jobs.py", line 311, in _check_call
    module = imp.load_source('script', cmd[0])
  File "/usr/local/lib/python2.7/dist-packages/ros_buildfarm-2.0.1_master-py2.7.egg/EGG-INFO/scripts/generate_doc_maintenance_jobs.py", line 55
    file=sys.stderr)
        ^
SyntaxError: invalid syntax

```