### PR TITLE
Revert "remove using the test_depend from binary jobs (#534)"

### DIFF
--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -547,6 +547,9 @@ def _get_direct_dependencies(pkg_name, dist_cache, pkg_names):
         return None
     pkg_xml = dist_cache.release_package_xmls[pkg_name]
     pkg = parse_package_string(pkg_xml)
+    # test dependencies are treated as build dependencies by bloom
+    # so we need them here to ensure that all dependencies are available
+    # before starting a build
     depends = set([
         d.name for d in (
             pkg.buildtool_depends +


### PR DESCRIPTION
This reverts commit 0ab65b0f0e7a51d04c24503a152b40423aecc347.

See https://github.com/ros-infrastructure/ros_buildfarm/issues/539 for details