### PR TITLE
Generate the blocked releases page against the previous LTS.

### DIFF
--- a/ros_buildfarm/config/index.py
+++ b/ros_buildfarm/config/index.py
@@ -59,6 +59,7 @@ class Index(object):
                     'notification_emails': list,
                     'release_builds': dict,
                     'source_builds': dict,
+                    'tags': list,
                 }
                 for key in distro_data:
                     if key not in value_types.keys():


### PR DESCRIPTION
Note that this requires a change in https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml to add a `tags` list to each distribution ([example](https://gist.github.com/clalancette/bc691f407e29d57497bb98c91531f2d5)).  Once that is in place, the below will go looking for the previous distribution marked as `lts`, and if that is not found, default to the immediately preceding distribution.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>