### PR TITLE
Add ddebs to published binarydeb files.

### DIFF
--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -660,6 +660,7 @@ def _get_binarydeb_job_config(
     binarydeb_files = [
         'binarydeb/*.changes',
         'binarydeb/*.deb',
+        'binarydeb/*.ddeb',
     ]
 
     sync_to_testing_job_name = [get_sync_packages_to_testing_job_name(


### PR DESCRIPTION
ddebs containing debug symbols stripped from binary packages are being generated by default for artful and bionic. Reprepro cannot ingest ddeb files so we removed them from the changes file in reprepro updater (see https://github.com/ros-infrastructure/reprepro-updater/pull/55).

Since we would like to provide debug symbols we've found a slightly different approach: renaming the ddeb file to a regular deb (see https://github.com/ros-infrastructure/reprepro-updater/pull/60).

In order for that to work, we actually need to publish the ddeb to the repo host with the other files. I opted to publish it as a ddeb and rename it at import time so that no changes need to be made to ros_buildfarm if we change the handling in the future.

This change needs to merge before https://github.com/ros-infrastructure/reprepro-updater/pull/60. If merged with the current behavior the transferred ddeb will just be ignored.