### PR TITLE
[Debian] don't overwrite default sources

### DIFF
--- a/ros_buildfarm/__init__.py
+++ b/ros_buildfarm/__init__.py
@@ -14,4 +14,4 @@
 
 # the version must be either a released version number which is also a tag name
 # or an upcoming version number followed by a branch name separated by a dash
-__version__ = '2.0.2-master'  # same version as in setup.py
+__version__ = '2.0.2-no_cloudfront'  # same version as in setup.py

--- a/ros_buildfarm/templates/snippet/add_additional_repositories.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/add_additional_repositories.Dockerfile.em
@@ -39,5 +39,5 @@ for component in ('contrib', 'non-free'):
 RUN @(' && '.join(commands))
 # Hit cloudfront mirror because of corrupted packages on fastly mirrors (https://github.com/ros-infrastructure/ros_buildfarm/issues/455)
 # You can remove this line to target the default mirror or replace this to use the mirror of your preference
-RUN sed -i 's/httpredir\.debian\.org/cloudfront.debian.net/' /etc/apt/sources.list
+# RUN sed -i 's/httpredir\.debian\.org/cloudfront.debian.net/' /etc/apt/sources.list
 @[end if]@


### PR DESCRIPTION
We're facing apt failures on the farm for all debian platforms. Opening this for visibility yand testing. If this proves stable after some time we can consider merging it.

http://build.ros.org/job/Mbin_dsv8_dSv8__catkin__debian_stretch_arm64__binary/6/console

Context for why we overwrote the sources in the first place: https://github.com/ros-infrastructure/ros_buildfarm/issues/455