### PR TITLE
use single pipe to avoid problems with Jenkins reading them concurrently

### DIFF
--- a/ros_buildfarm/catkin_workspace.py
+++ b/ros_buildfarm/catkin_workspace.py
@@ -64,4 +64,5 @@ def call_catkin_make_isolated(
             cmd = '. %s && %s' % (setup_file, cmd)
 
     print("Invoking '%s' in '%s'" % (cmd, workspace_root))
-    return subprocess.call(cmd, cwd=workspace_root, shell=True)
+    return subprocess.call(
+        cmd, cwd=workspace_root, shell=True, stderr=subprocess.STDOUT)


### PR DESCRIPTION
Otherwise since Jenkins reads both streams concurrently arbitrary interleaving might happen in the build log.