### PR TITLE
Build environment variables from build files.

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -162,6 +162,12 @@ The following options are valid in version ``2`` (beside the generic options):
   trigger downstream packages for rebuilding them (default: ``false``).
   For ROS 1 this flag must always be ``true``.
 
+* ``build_environment_variables``: a dictionary containing environment
+  variables which will be inserted into binarydeb build containers before
+  package dependencies are installed using Dockerfile ``ENV`` directives. Note
+  that yaml will turn bare words like ``yes`` into boolean values so it is
+  recommended to quote values to avoid interpretation. (default: ``None``).
+
 * ``jenkins_binary_job_label``: the label expression for *binary* jobs
   (default: ``buildagent || <ROSDISTRO_NAME>_binarydeb_<BUILD_FILE_NAME>``).
 * ``jenkins_binary_job_priority``: the job priority of *binary* jobs.

--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -164,9 +164,9 @@ The following options are valid in version ``2`` (beside the generic options):
 
 * ``build_environment_variables``: a dictionary containing environment
   variables which will be inserted into binarydeb build containers before
-  package dependencies are installed using Dockerfile ``ENV`` directives. Note
-  that yaml will turn bare words like ``yes`` into boolean values so it is
-  recommended to quote values to avoid interpretation. (default: ``None``).
+  package dependencies are installed using Dockerfile ``ENV`` directives.
+  Note that yaml will turn bare words like ``yes`` into boolean values so it
+  is recommended to quote values to avoid interpretation.
 
 * ``jenkins_binary_job_label``: the label expression for *binary* jobs
   (default: ``buildagent || <ROSDISTRO_NAME>_binarydeb_<BUILD_FILE_NAME>``).

--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -70,6 +70,12 @@ Generic options in build files
 
 A set of options which can be used in any build file.
 
+* ``build_environment_variables``: a dictionary containing environment
+  variables which will be inserted into binarydeb build containers before
+  package dependencies are installed using Dockerfile ``ENV`` directives.
+  Note that yaml will turn bare words like ``yes`` into boolean values so it
+  is recommended to quote values to avoid interpretation.
+
 * ``repositories``: additional repositories to fetch packages from.
 
   * ``keys``: a list of PGP keys each as a multi line string.
@@ -161,12 +167,6 @@ The following options are valid in version ``2`` (beside the generic options):
 * ``abi_incompatibility_assumed``: a boolean flag if binary packages should
   trigger downstream packages for rebuilding them (default: ``false``).
   For ROS 1 this flag must always be ``true``.
-
-* ``build_environment_variables``: a dictionary containing environment
-  variables which will be inserted into binarydeb build containers before
-  package dependencies are installed using Dockerfile ``ENV`` directives.
-  Note that yaml will turn bare words like ``yes`` into boolean values so it
-  is recommended to quote values to avoid interpretation.
 
 * ``jenkins_binary_job_label``: the label expression for *binary* jobs
   (default: ``buildagent || <ROSDISTRO_NAME>_binarydeb_<BUILD_FILE_NAME>``).

--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -63,6 +63,13 @@ def add_argument_build_name(parser, build_file_type):
              build_file_type)
 
 
+def add_argument_env_vars(parser):
+    parser.add_argument(
+        '--env-vars',
+        nargs='*',
+        help="Environment variables as 'key=value' for Dockerfile ENV directives")
+
+
 def add_argument_repository_name(parser):
     parser.add_argument(
         'repository_name',

--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -67,7 +67,8 @@ def add_argument_env_vars(parser):
     parser.add_argument(
         '--env-vars',
         nargs='*',
-        help="Environment variables as 'key=value' for Dockerfile ENV directives")
+        help="Environment variables as 'key=value' for Dockerfile "
+        'ENV directives')
 
 
 def add_argument_repository_name(parser):

--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -68,7 +68,7 @@ def add_argument_env_vars(parser):
         '--env-vars',
         nargs='*',
         help="Environment variables as 'key=value' for Dockerfile "
-        'ENV directives')
+             'ENV directives')
 
 
 def add_argument_repository_name(parser):

--- a/ros_buildfarm/config/build_file.py
+++ b/ros_buildfarm/config/build_file.py
@@ -16,13 +16,13 @@
 class BuildFile(object):
 
     def __init__(self, name, data):
+        self.name = name
+
         self.build_environment_variables = None
         if 'build_environment_variables' in data:
             self.build_environment_variables = \
                     data['build_environment_variables']
             assert(isinstance(self.build_environment_variables, dict))
-
-        self.name = name
 
         self.notify_emails = []
         self.notify_maintainers = None

--- a/ros_buildfarm/config/build_file.py
+++ b/ros_buildfarm/config/build_file.py
@@ -16,6 +16,12 @@
 class BuildFile(object):
 
     def __init__(self, name, data):
+        self.build_environment_variables = None
+        if 'build_environment_variables' in data:
+            self.build_environment_variables = \
+                    data['build_environment_variables']
+            assert(isinstance(self.build_environment_variables, dict))
+
         self.name = name
 
         self.notify_emails = []

--- a/ros_buildfarm/config/release_build_file.py
+++ b/ros_buildfarm/config/release_build_file.py
@@ -43,6 +43,12 @@ class ReleaseBuildFile(BuildFile):
             self.abi_incompatibility_assumed = \
                 bool(data['abi_incompatibility_assumed'])
 
+        self.build_environment_variables = {}
+        if 'build_environment_variables' in data:
+            self.build_environment_variables = \
+                    data['build_environment_variables']
+            assert(isinstance(self.build_environment_variables, dict))
+
         self.jenkins_binary_job_label = None
         if 'jenkins_binary_job_label' in data:
             self.jenkins_binary_job_label = data['jenkins_binary_job_label']

--- a/ros_buildfarm/config/release_build_file.py
+++ b/ros_buildfarm/config/release_build_file.py
@@ -43,12 +43,6 @@ class ReleaseBuildFile(BuildFile):
             self.abi_incompatibility_assumed = \
                 bool(data['abi_incompatibility_assumed'])
 
-        self.build_environment_variables = None
-        if 'build_environment_variables' in data:
-            self.build_environment_variables = \
-                    data['build_environment_variables']
-            assert(isinstance(self.build_environment_variables, dict))
-
         self.jenkins_binary_job_label = None
         if 'jenkins_binary_job_label' in data:
             self.jenkins_binary_job_label = data['jenkins_binary_job_label']

--- a/ros_buildfarm/config/release_build_file.py
+++ b/ros_buildfarm/config/release_build_file.py
@@ -43,7 +43,7 @@ class ReleaseBuildFile(BuildFile):
             self.abi_incompatibility_assumed = \
                 bool(data['abi_incompatibility_assumed'])
 
-        self.build_environment_variables = {}
+        self.build_environment_variables = None
         if 'build_environment_variables' in data:
             self.build_environment_variables = \
                     data['build_environment_variables']

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -330,6 +330,12 @@ def _get_devel_job_config(
     repository_args, script_generating_key_files = \
         get_repositories_and_script_generating_key_files(build_file=build_file)
 
+    build_environment_variables = []
+    if build_file.build_environment_variables:
+        build_environment_variables = [
+            '%s=%s' % (var, value)
+            for var, value in build_file.build_environment_variables.items()]
+
     maintainer_emails = set([])
     if build_file.notify_maintainers and dist_cache and repo_name and \
             repo_name in dist_cache.distribution_file.repositories:
@@ -380,6 +386,7 @@ def _get_devel_job_config(
         'os_code_name': os_code_name,
         'arch': arch,
         'repository_args': repository_args,
+        'build_environment_variables': build_environment_variables,
 
         'notify_compiler_warnings': build_file.notify_compiler_warnings,
         'notify_emails': build_file.notify_emails,

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -699,6 +699,7 @@ def _get_binarydeb_job_config(
         'append_timestamp': build_file.abi_incompatibility_assumed,
 
         'binarydeb_files': binarydeb_files,
+        'build_environment_variables': ['%s=%s' % (var, value) for var, value in build_file.build_environment_variables.items()],
 
         'import_package_job_name': get_import_package_job_name(rosdistro_name),
         'debian_package_name': get_debian_package_name(

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -663,6 +663,12 @@ def _get_binarydeb_job_config(
         'binarydeb/*.ddeb',
     ]
 
+    build_environment_variables = None
+    if build_file.build_environment_variables:
+        build_environment_variables = [
+            '%s=%s' % (var, value)
+            for var, value in build_file.build_environment_variables.items()]
+
     sync_to_testing_job_name = [get_sync_packages_to_testing_job_name(
         rosdistro_name, os_code_name, arch)]
 
@@ -699,9 +705,7 @@ def _get_binarydeb_job_config(
         'append_timestamp': build_file.abi_incompatibility_assumed,
 
         'binarydeb_files': binarydeb_files,
-        'build_environment_variables': [
-            '%s=%s' % (var, value)
-            for var, value in build_file.build_environment_variables.items()],
+        'build_environment_variables': build_environment_variables
 
         'import_package_job_name': get_import_package_job_name(rosdistro_name),
         'debian_package_name': get_debian_package_name(

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -699,7 +699,9 @@ def _get_binarydeb_job_config(
         'append_timestamp': build_file.abi_incompatibility_assumed,
 
         'binarydeb_files': binarydeb_files,
-        'build_environment_variables': ['%s=%s' % (var, value) for var, value in build_file.build_environment_variables.items()],
+        'build_environment_variables': [
+            '%s=%s' % (var, value)
+            for var, value in build_file.build_environment_variables.items()],
 
         'import_package_job_name': get_import_package_job_name(rosdistro_name),
         'debian_package_name': get_debian_package_name(

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -705,7 +705,7 @@ def _get_binarydeb_job_config(
         'append_timestamp': build_file.abi_incompatibility_assumed,
 
         'binarydeb_files': binarydeb_files,
-        'build_environment_variables': build_environment_variables
+        'build_environment_variables': build_environment_variables,
 
         'import_package_job_name': get_import_package_job_name(rosdistro_name),
         'debian_package_name': get_debian_package_name(

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -663,7 +663,7 @@ def _get_binarydeb_job_config(
         'binarydeb/*.ddeb',
     ]
 
-    build_environment_variables = None
+    build_environment_variables = []
     if build_file.build_environment_variables:
         build_environment_variables = [
             '%s=%s' % (var, value)

--- a/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
@@ -73,7 +73,8 @@ cmd = \
     ' --os-code-name ' + os_code_name + \
     ' --arch ' + arch + \
     ' --distribution-repository-urls ' + ' '.join(distribution_repository_urls) + \
-    ' --distribution-repository-key-files ' + ' ' .join(['/tmp/keys/%d.key' % i for i in range(len(distribution_repository_keys))])
+    ' --distribution-repository-key-files ' + ' ' .join(['/tmp/keys/%d.key' % i for i in range(len(distribution_repository_keys))]) + \
+    ' --env-vars ' + ' ' .join(env_vars)
 cmds += [
     cmd +
     ' --dockerfile-dir /tmp/docker_build_and_install',

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -136,6 +136,7 @@ if pull_request:
         ' ' + os_code_name +
         ' ' + arch +
         ' ' + ' '.join(repository_args) +
+        ' --env-vars ' + ' '.join(build_environment_variables) +
         ' --dockerfile-dir $WORKSPACE/docker_generating_dockers',
         'echo "# END SECTION"',
         '',

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -57,6 +57,11 @@ RUN echo "@today_str"
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
 
 @(TEMPLATE(
+    'snippet/set_environment_variables.Dockerfile.em',
+    environment_variables=build_environment_variables,
+))@
+
+@(TEMPLATE(
     'snippet/install_dependencies.Dockerfile.em',
     dependencies=dependencies,
     dependency_versions=dependency_versions,

--- a/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
@@ -100,7 +100,7 @@ cmds.append(
     ' --distribution-repository-urls ' + ' '.join(distribution_repository_urls) +
     ' --distribution-repository-key-files ' + ' ' .join(['/tmp/keys/%d.key' % i for i in range(len(distribution_repository_keys))]) +
     ' --binarydeb-dir ' + binarydeb_dir +
-    (' --env-vars ' + ' '.join(build_environment_variables) if len(build_environment_variables) > 0 else '') +
+    (' --env-vars ' + ' '.join(build_environment_variables) if build_environment_variables else '') +
     ' --dockerfile-dir ' + dockerfile_dir)
 }@
 CMD ["@(' && '.join(cmds))"]

--- a/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
@@ -100,7 +100,7 @@ cmds.append(
     ' --distribution-repository-urls ' + ' '.join(distribution_repository_urls) +
     ' --distribution-repository-key-files ' + ' ' .join(['/tmp/keys/%d.key' % i for i in range(len(distribution_repository_keys))]) +
     ' --binarydeb-dir ' + binarydeb_dir +
-    (' --env-vars ' + ' '.join(build_environment_variables) if build_environment_variables else '') +
+    ' --env-vars ' + ' '.join(build_environment_variables) +
     ' --dockerfile-dir ' + dockerfile_dir)
 }@
 CMD ["@(' && '.join(cmds))"]

--- a/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
@@ -100,6 +100,7 @@ cmds.append(
     ' --distribution-repository-urls ' + ' '.join(distribution_repository_urls) +
     ' --distribution-repository-key-files ' + ' ' .join(['/tmp/keys/%d.key' % i for i in range(len(distribution_repository_keys))]) +
     ' --binarydeb-dir ' + binarydeb_dir +
+    (' --env-vars ' + ' '.join(build_environment_variables) if len(build_environment_variables) > 0 else '') +
     ' --dockerfile-dir ' + dockerfile_dir)
 }@
 CMD ["@(' && '.join(cmds))"]

--- a/ros_buildfarm/templates/release/binarydeb_job.xml.em
+++ b/ros_buildfarm/templates/release/binarydeb_job.xml.em
@@ -104,7 +104,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' ' + ' '.join(repository_args) +
         ' --binarydeb-dir $WORKSPACE/binarydeb' +
         ' --dockerfile-dir $WORKSPACE/docker_generating_docker' +
-        (' --env-vars ' + ' '.join(build_environment_variables) if build_environment_variables else '') +
+        ' --env-vars ' + ' '.join(build_environment_variables) +
         (' --append-timestamp' if append_timestamp else ''),
         'echo "# END SECTION"',
         '',

--- a/ros_buildfarm/templates/release/binarydeb_job.xml.em
+++ b/ros_buildfarm/templates/release/binarydeb_job.xml.em
@@ -104,6 +104,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' ' + ' '.join(repository_args) +
         ' --binarydeb-dir $WORKSPACE/binarydeb' +
         ' --dockerfile-dir $WORKSPACE/docker_generating_docker' +
+        (' --env-vars ' + ' '.join(build_environment_variables) if len(build_environment_variables) > 0 else '') +
         (' --append-timestamp' if append_timestamp else ''),
         'echo "# END SECTION"',
         '',

--- a/ros_buildfarm/templates/release/binarydeb_job.xml.em
+++ b/ros_buildfarm/templates/release/binarydeb_job.xml.em
@@ -104,7 +104,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' ' + ' '.join(repository_args) +
         ' --binarydeb-dir $WORKSPACE/binarydeb' +
         ' --dockerfile-dir $WORKSPACE/docker_generating_docker' +
-        (' --env-vars ' + ' '.join(build_environment_variables) if len(build_environment_variables) > 0 else '') +
+        (' --env-vars ' + ' '.join(build_environment_variables) if build_environment_variables else '') +
         (' --append-timestamp' if append_timestamp else ''),
         'echo "# END SECTION"',
         '',

--- a/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
@@ -63,7 +63,7 @@ RUN echo "@today_str"
 
 @(TEMPLATE(
     'snippet/set_environment_variables.Dockerfile.em',
-    environment_variables=release_build_environment_variables,
+    environment_variables=build_environment_variables,
 ))@
 
 @(TEMPLATE(

--- a/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
@@ -60,13 +60,11 @@ RUN echo "@today_str"
     os_name=os_name,
     os_code_name=os_code_name,
 ))@
-@[if build_environment_variables]@
 
 @(TEMPLATE(
     'snippet/set_environment_variables.Dockerfile.em',
     environment_variables=build_environment_variables,
 ))@
-@[end if]@
 
 @(TEMPLATE(
     'snippet/install_dependencies.Dockerfile.em',

--- a/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
@@ -61,10 +61,12 @@ RUN echo "@today_str"
     os_code_name=os_code_name,
 ))@
 
+@[if build_environment_variables]@
 @(TEMPLATE(
     'snippet/set_environment_variables.Dockerfile.em',
     environment_variables=build_environment_variables,
 ))@
+@[end if]@
 
 @(TEMPLATE(
     'snippet/install_dependencies.Dockerfile.em',

--- a/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
@@ -62,6 +62,11 @@ RUN echo "@today_str"
 ))@
 
 @(TEMPLATE(
+    'snippet/set_environment_variables.Dockerfile.em',
+    environment_variables=release_build_environment_variables,
+))@
+
+@(TEMPLATE(
     'snippet/install_dependencies.Dockerfile.em',
     dependencies=dependencies,
     dependency_versions=dependency_versions,

--- a/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
@@ -60,8 +60,8 @@ RUN echo "@today_str"
     os_name=os_name,
     os_code_name=os_code_name,
 ))@
-
 @[if build_environment_variables]@
+
 @(TEMPLATE(
     'snippet/set_environment_variables.Dockerfile.em',
     environment_variables=build_environment_variables,

--- a/ros_buildfarm/templates/snippet/set_environment_variables.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/set_environment_variables.Dockerfile.em
@@ -1,0 +1,3 @@
+@[for name, value in environment_variables.items()]@
+ENV @(name)='@(value)'
+@[end for]@

--- a/ros_buildfarm/templates/snippet/set_environment_variables.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/set_environment_variables.Dockerfile.em
@@ -1,3 +1,3 @@
-@[for name, value in environment_variables.items()]@
-ENV @(name)='@(value)'
+@[for var in environment_variables]@
+ENV @var
 @[end for]@

--- a/scripts/devel/create_devel_task_generator.py
+++ b/scripts/devel/create_devel_task_generator.py
@@ -24,6 +24,7 @@ from ros_buildfarm.argument import \
     add_argument_distribution_repository_key_files
 from ros_buildfarm.argument import add_argument_distribution_repository_urls
 from ros_buildfarm.argument import add_argument_dockerfile_dir
+from ros_buildfarm.argument import add_argument_env_vars
 from ros_buildfarm.common import get_binary_package_versions
 from ros_buildfarm.common import get_debian_package_name
 from ros_buildfarm.common import get_distribution_repository_keys
@@ -60,6 +61,7 @@ def main(argv=sys.argv[1:]):
         help="The architecture (e.g. 'amd64')")
     add_argument_distribution_repository_urls(parser)
     add_argument_distribution_repository_key_files(parser)
+    add_argument_env_vars(parser)
     add_argument_dockerfile_dir(parser)
     parser.add_argument(
         '--testing',
@@ -142,6 +144,8 @@ def main(argv=sys.argv[1:]):
         'rosdistro_name': args.rosdistro_name,
 
         'uid': get_user_id(),
+
+        'build_environment_variables': args.env_vars,
 
         'dependencies': debian_pkg_names,
         'dependency_versions': debian_pkg_versions,

--- a/scripts/devel/run_devel_job.py
+++ b/scripts/devel/run_devel_job.py
@@ -25,6 +25,7 @@ from ros_buildfarm.argument import \
     add_argument_distribution_repository_key_files
 from ros_buildfarm.argument import add_argument_distribution_repository_urls
 from ros_buildfarm.argument import add_argument_dockerfile_dir
+from ros_buildfarm.argument import add_argument_env_vars
 from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
 from ros_buildfarm.argument import add_argument_repository_name
@@ -52,6 +53,7 @@ def main(argv=sys.argv[1:]):
         '--prerelease-overlay',
         action='store_true',
         help='Operate on two catkin workspaces')
+    add_argument_env_vars(parser)
     add_argument_dockerfile_dir(parser)
     args = parser.parse_args(argv)
 

--- a/scripts/release/create_binarydeb_task_generator.py
+++ b/scripts/release/create_binarydeb_task_generator.py
@@ -99,10 +99,10 @@ def main(argv=sys.argv[1:]):
             args.distribution_repository_urls,
             args.distribution_repository_key_files),
 
+        'build_environment_variables': args.env_vars,
+
         'dependencies': debian_pkg_names,
         'dependency_versions': debian_pkg_versions,
-
-        'build_environment_variables': args.env_vars,
 
         'rosdistro_name': args.rosdistro_name,
         'package_name': args.package_name,

--- a/scripts/release/create_binarydeb_task_generator.py
+++ b/scripts/release/create_binarydeb_task_generator.py
@@ -28,6 +28,7 @@ from ros_buildfarm.argument import \
     add_argument_distribution_repository_key_files
 from ros_buildfarm.argument import add_argument_distribution_repository_urls
 from ros_buildfarm.argument import add_argument_dockerfile_dir
+from ros_buildfarm.argument import add_argument_env_vars
 from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
 from ros_buildfarm.argument import add_argument_package_name
@@ -56,6 +57,7 @@ def main(argv=sys.argv[1:]):
     add_argument_distribution_repository_key_files(parser)
     add_argument_binarydeb_dir(parser)
     add_argument_dockerfile_dir(parser)
+    add_argument_env_vars(parser)
     args = parser.parse_args(argv)
 
     debian_package_name = get_debian_package_name(
@@ -99,6 +101,8 @@ def main(argv=sys.argv[1:]):
 
         'dependencies': debian_pkg_names,
         'dependency_versions': debian_pkg_versions,
+
+        'build_environment_variables': args.env_vars,
 
         'rosdistro_name': args.rosdistro_name,
         'package_name': args.package_name,

--- a/scripts/release/run_binarydeb_job.py
+++ b/scripts/release/run_binarydeb_job.py
@@ -25,6 +25,7 @@ from ros_buildfarm.argument import \
     add_argument_distribution_repository_key_files
 from ros_buildfarm.argument import add_argument_distribution_repository_urls
 from ros_buildfarm.argument import add_argument_dockerfile_dir
+from ros_buildfarm.argument import add_argument_env_vars
 from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
 from ros_buildfarm.argument import add_argument_package_name
@@ -53,6 +54,7 @@ def main(argv=sys.argv[1:]):
     add_argument_dockerfile_dir(parser)
     add_argument_skip_download_sourcedeb(parser)
     add_argument_append_timestamp(parser)
+    add_argument_env_vars(parser)
     args = parser.parse_args(argv)
 
     data = copy.deepcopy(args.__dict__)
@@ -69,6 +71,7 @@ def main(argv=sys.argv[1:]):
 
         'binarydeb_dir': '/tmp/binarydeb',
         'dockerfile_dir': '/tmp/docker_build_binarydeb',
+        'build_environment_variables': args.env_vars
     })
     create_dockerfile(
         'release/binarydeb_create_task.Dockerfile.em',

--- a/scripts/release/run_binarydeb_job.py
+++ b/scripts/release/run_binarydeb_job.py
@@ -70,8 +70,8 @@ def main(argv=sys.argv[1:]):
         'skip_download_sourcedeb': args.skip_download_sourcedeb,
 
         'binarydeb_dir': '/tmp/binarydeb',
+        'build_environment_variables': args.env_vars,
         'dockerfile_dir': '/tmp/docker_build_binarydeb',
-        'build_environment_variables': args.env_vars
     })
     create_dockerfile(
         'release/binarydeb_create_task.Dockerfile.em',


### PR DESCRIPTION
Allows release build files to specify environment variables which will be made available in the binarydeb build containers.