### PR TITLE
Super status

### DIFF
--- a/ros_buildfarm/aggregate_status.py
+++ b/ros_buildfarm/aggregate_status.py
@@ -1,0 +1,182 @@
+import re
+import collections
+
+CANDIDATES = ['build', 'test', 'main']
+VERSION_PATTERN = re.compile('([\d\-\.]+)\w+.*')
+
+
+def map_value_matches(M, key, value_list):
+    """
+       Convenience function for repeated operation to check if the
+       dictionary M's value for the given key (which is a set)
+       matches the set version of the list of values passed in.
+    """
+    return M[key] == set(value_list)
+
+
+def some_map_value_matches(M, value_list):
+    """
+       Returns true if some value in M
+       matches the set version of the list of values passed in.
+    """
+    values = set(value_list)
+    for key in M.keys():
+        if M[key] == values:
+            return True
+    return False
+
+
+def some_other_value_matches(M, value_list, exclude):
+    """
+       Returns true if some value in M except the one with key=exclude
+       matches the set version of the list of values passed in.
+    """
+    values = set(value_list)
+    for key in M.keys():
+        if key != exclude and M[key] == values:
+            return True
+    return False
+
+def no_overlap_in_values_and_none(M):
+    if None not in M:
+        return False
+    # Assume M has two key/value pairs
+    values0, values1 = M.values()
+    return len(values0.intersection(values1)) == 0
+
+def get_distro_status(D, expected, blacklist, candidates=CANDIDATES, skip_source=False, debug=False):
+    """
+     D is a recursive structure that map a specific build i.e.
+      (os_name, os_flavor, cpu, candidate) to a version number
+      If the version number is not present, then it is an error, i.e. version_number = None
+
+     expected is the values of (os_name, os_flavor, cpu) that we expect to see
+       (this is constant across all packages)
+
+     blacklist is a set of (os_name, os_flavor, cpu) that we don't expect to see
+       (specific to this package)
+    """
+
+    # The first thing we do is reverse the mapping
+
+    # version_map maps version to a list of (os_name, os_flavor, cpu, candidate)
+    version_map = collections.defaultdict(list)
+
+    # the following four structures map the version to either the os_name, os_flavor, etc
+    os_map = collections.defaultdict(set)
+    flavor_map = collections.defaultdict(set)
+    cpu_map = collections.defaultdict(set)
+    candidate_map = collections.defaultdict(set)
+
+    # this maps the version to the os_flavor + cpu
+    combo_map = collections.defaultdict(set)
+
+    # build the reversed maps
+    for os_name in expected:
+        os_d = D.get(os_name, {})
+        for os_flavor in expected[os_name]:
+            fl_d = os_d.get(os_flavor, {})
+            for cpu in expected[os_name][os_flavor]:
+                if skip_source and cpu == 'source':
+                    continue
+                cpu_d = fl_d.get(cpu, {})
+                for candidate in candidates:
+                    version = None
+                    if candidate in cpu_d:
+                        version = VERSION_PATTERN.match(cpu_d[candidate]).group(1)
+                    elif (os_name, os_flavor, cpu) in blacklist:
+                        continue
+                    os_map[version].add(os_name)
+                    flavor_map[version].add(os_flavor)
+                    cpu_map[version].add(cpu)
+                    candidate_map[version].add(candidate)
+                    combo_map[version].add(os_flavor + '/' + cpu)
+                    version_map[version].append((os_name, os_flavor, cpu, candidate))
+
+    # If there's only one version across all builds (and nothing is missing), then
+    # this package is completely synced and released
+    if len(version_map) == 1:
+        return 'released'
+
+    # If there are two different versions available
+    if len(version_map) == 2:
+        if map_value_matches(candidate_map, None, ['main']):
+            # one version for build/test, and all the main builds are None
+            # this package hasn't been released yet, but it builds fine otherwise
+            return 'waiting for new release'
+        elif some_map_value_matches(candidate_map, ['main']):
+            # still one version for build/test, and some other version for main
+            return 'waiting for re-release'
+
+        if some_map_value_matches(cpu_map, ['source']):
+            cpu_version0, cpu_version1 = sorted(cpu_map.keys())
+            # these versions could be (None, version) or (old_version, new_version)
+
+            if cpu_version0 is None:
+                return 'source builds, binary doesn\'t'
+            elif map_value_matches(cpu_map, cpu_version0, ['source']):
+                # the source is the only thing that builds for the new version
+                return 'source builds, binary doesn\'t'
+
+        if no_overlap_in_values_and_none(flavor_map):
+            # if the thing that separates the working builds and nonworking builds is the os_flavor
+            return 'does not build on ' + ', '.join(sorted(flavor_map[None]))
+        elif no_overlap_in_values_and_none(cpu_map):
+            return 'does not build on ' + ', '.join(sorted(cpu_map[None]))
+        elif no_overlap_in_values_and_none(combo_map):
+            return 'does not build on ' + ', '.join(sorted(combo_map[None]))
+
+    # If there are three different versions availble
+    elif len(version_map) == 3:
+        if map_value_matches(candidate_map, None, ['main']) and some_other_value_matches(candidate_map, ['main'], None):
+            # This package builds fine in build/test, and has two different versions
+            # in main, including None, then been released for some builds but not others
+            return 'waiting for new/re-release'
+
+    if None in version_map:
+        # if some version is breaking (and doesn't match the above patterns)
+        # gather all the flavor/cpu combos that are breaking
+        DX = set([(os_flavor, cpu) for os_name, os_flavor, cpu, candidate in version_map[None]])
+        if len(DX) == 1:
+            os_flavor, cpu = list(DX)[0]
+            return "does not build on %s/%s" % (os_flavor, cpu)
+
+    if candidates == CANDIDATES:
+        sub_candidates = CANDIDATES[:-1]  # skip main
+        status = get_distro_status(D, expected, blacklist, sub_candidates)
+        if status and status != 'released':
+            return status
+
+        status = get_distro_status(D, expected, blacklist, sub_candidates, True)
+        if status and status != 'released':
+            return 'binary: ' + status
+
+    if not debug:
+        return
+    print('{} versions ({})'.format(len(version_map), ', '.join(map(str, sorted(version_map)))))
+    for name, M in [('os', os_map), ('flavor', flavor_map), ('cpu', cpu_map), ('candidate', candidate_map),
+                    ('combo', combo_map)]:
+        print(name)
+        for version, values in M.iteritems():
+            print('\t{}: {}'.format(version, ', '.join(values)))
+
+    for version, M in sorted(version_map.items()):
+        print(version, len(M))
+        if version is None:
+            print(M)
+    print()
+
+def get_aggregate_status(D, expected, pkg_name=None, blacklist={}, debug=False):
+    per_distro = {}
+    for distro in sorted(D):
+        if distro == 'maintainers':
+            continue
+        status = get_distro_status(D[distro]['build_status'],
+                                   expected[distro],
+                                   blacklist.get(pkg_name, {}).get(distro, set()),
+                                   debug=debug)
+        if status is None:
+            status = 'complicated'
+        per_distro[distro] = status
+
+    return per_distro

--- a/ros_buildfarm/super_status.py
+++ b/ros_buildfarm/super_status.py
@@ -1,0 +1,210 @@
+import collections
+import os
+import requests
+import re
+import time
+import yaml
+from .aggregate_status import get_aggregate_status
+from .config import get_index as get_config_index, get_release_build_files
+from .templates import expand_template
+
+YAML_FOLDER = 'http://repositories.ros.org/status_page/yaml/'
+YAML_PATTERN = re.compile('<a href="(ros_(\w+)_(\w+).yaml)">')
+GITHUB_PATTERN = re.compile('https?://github.com/([^/]+)/(.+)\.git')
+GITHUB_BRANCH_PATTERN = re.compile('https://github.com/([^/]+)/([^/]+)/tree/(.*)')
+BB_PATTERN = re.compile('https://bitbucket.org/(.*)/(.*)')
+GITLAB_PATTERN = re.compile('https?://gitlab.[^/]+/([^/]+)/(.+).git')
+URL_PATTERNS = [GITHUB_PATTERN, GITHUB_BRANCH_PATTERN, BB_PATTERN, GITLAB_PATTERN]
+
+"""
+  Naming Conventions
+   * distro refers to ROS Distro (e.g. indigo)
+   * machine refers to different release builds (e.g. default, uxhf, dsv8)
+   * os_name refers to the name of the Operating System (e.g. ubuntu, debian)
+   * os_flavor refers to specific distros of the os (e.g. xenial, jessie)
+   * cpu refers to the cpu architecture (or source), (e.g. i386, amd64, source)
+   * candidate refers to different candidate builds, (e.g. build, test, main)
+   * combo refers to the os_flavor + the cpu
+"""
+
+
+def get_yaml_filenames():
+    filenames = {}
+    r = requests.get(YAML_FOLDER)
+    for filename, distro, machine in YAML_PATTERN.findall(r.text):
+        filenames[distro, machine] = filename
+    return filenames
+
+
+def dict_merge(dct, merge_dct):
+    for k, v in merge_dct.iteritems():
+        if (k in dct and isinstance(dct[k], dict) and isinstance(merge_dct[k], collections.Mapping)):
+            dict_merge(dct[k], merge_dct[k])
+        else:
+            dct[k] = merge_dct[k]
+
+
+def merge_status_yaml(data, new_data, new_distro):
+    for pkg, D in new_data.items():
+        D2 = {new_distro: {}, 'maintainers': {}}
+        for k, v in D.iteritems():
+            if k == 'maintainers':
+                for d in v:
+                    D2['maintainers'][d['email']] = d['name']
+            else:
+                D2[new_distro][k] = v
+
+        if pkg in data:
+            dict_merge(data[pkg], D2)
+        else:
+            data[pkg] = D2
+
+
+def get_multi_distro_status(distros):
+    status = {}
+    for (distro, machine), filename in sorted(get_yaml_filenames().items()):
+        if distro not in distros:
+            continue
+        print('Loading {}/{}'.format(distro, machine))
+        r = requests.get(YAML_FOLDER + filename)
+        distro_status = yaml.load(r.text)
+        merge_status_yaml(status, distro_status, distro)
+    return status
+
+
+def get_url_fields(s):
+    for pattern in URL_PATTERNS:
+        m = pattern.match(s)
+        if m:
+            return m.groups()
+
+
+def get_organization_and_repo(entry):
+    """
+       Iterates through the different distributions and returns the org and repo for the most recent distro
+    """
+    url = None
+    for key, distro_dict in sorted(entry.items(), reverse=True):
+        if 'url' not in distro_dict:
+            continue
+        url = distro_dict['url']
+        fields = get_url_fields(url)
+        if fields is not None:
+            return fields[0], fields[1]
+    # If nothing found, return organization=None and repo=full url
+    return None, url
+
+
+def get_blacklist(build_file_dict):
+    blacklist = collections.defaultdict(lambda: collections.defaultdict(set))
+
+    for distro in sorted(build_file_dict):
+        for machine in build_file_dict[distro]:
+            build_file = build_file_dict[distro][machine]
+            if len(build_file.package_blacklist) == 0:
+                continue
+            for pkg in build_file.package_blacklist:
+                for os_name, os_d in build_file.targets.items():
+                    for os_flavor, fl_d in os_d.items():
+                        for cpu in fl_d:
+                            blacklist[pkg][distro].add((os_name, os_flavor, cpu))
+    return dict(blacklist)
+
+
+def collect_expected_values(build_file_dict):
+    C = collections.defaultdict(lambda: collections.defaultdict(lambda: collections.defaultdict(set)))
+    for distro in build_file_dict:
+        for machine in build_file_dict[distro]:
+            build_file = build_file_dict[distro][machine]
+            for os_name, os_d in build_file.targets.items():
+                for os_flavor, fl_d in os_d.items():
+                    C[distro][os_name][os_flavor].add('source')
+                    for cpu in fl_d:
+                        C[distro][os_name][os_flavor].add(cpu)
+    return C
+
+
+def merge_statuses(statuses):
+    if len(statuses) == 1:
+        return list(statuses)[0]
+    all_waiting = True
+    all_broken = True
+    for status in statuses:
+        if 'waiting' not in status:
+            all_waiting = False
+        if 'build' not in status:
+            all_broken = False
+    if all_waiting:
+        return 'waiting for new/re-release'
+    elif all_broken:
+        return 'does not build on some platforms'
+    else:
+        return 'mixed'
+
+
+def build_super_status_page(config_url, output_dir='.', distros=[]):
+    config = get_config_index(config_url)
+    if len(distros) == 0:
+        distros = list(sorted(config.distributions.keys()))
+
+    build_file_dict = {}
+    for distro in distros:
+        build_file_dict[distro] = get_release_build_files(config, distro)
+
+    multi_distro_status = get_multi_distro_status(distros)
+    print('Write yaml file')
+    yaml_filename = os.path.join(output_dir, 'multi_distro_status.yaml')
+    yaml.safe_dump(multi_distro_status, open(yaml_filename, 'w'), allow_unicode=True)
+
+    print('Examining each package')
+    super_status = {}
+    blacklist = get_blacklist(build_file_dict)
+    expected = collect_expected_values(build_file_dict)
+    for pkg, entry in sorted(multi_distro_status.items()):
+        org, repo = get_organization_and_repo(entry)
+        if org not in super_status:
+            super_status[org] = {'repos': {}}
+        org_dict = super_status[org]['repos']
+        if repo not in org_dict:
+            org_dict[repo] = {'pkgs': {}}
+        repo_dict = org_dict[repo]['pkgs']
+        status = get_aggregate_status(entry, expected, pkg, blacklist)
+        d = {'status': status}
+        if 'maintainers' in entry:
+            d['maintainers'] = entry['maintainers']
+        repo_dict[pkg] = d
+
+    print('Getting status for each org/repo')
+    for org, org_dict in super_status.items():
+        org_set = collections.defaultdict(set)
+        for repo, repo_dict in org_dict['repos'].items():
+            repo_set = collections.defaultdict(set)
+            for pkg, pkg_dict in repo_dict['pkgs'].items():
+                for distro, status in pkg_dict['status'].iteritems():
+                    org_set[distro].add(status)
+                    repo_set[distro].add(status)
+            repo_dict['status'] = {}
+            for distro, statuses in repo_set.items():
+                repo_dict['status'][distro] = merge_statuses(statuses)
+        org_dict['status'] = {}
+        for distro, statuses in org_set.items():
+            org_dict['status'][distro] = merge_statuses(statuses)
+
+    print('Write parsed yaml file')
+    yaml_filename = os.path.join(output_dir, 'super_status.yaml')
+    yaml.safe_dump(super_status, open(yaml_filename, 'w'), allow_unicode=True)
+
+    output_filename = os.path.join(output_dir, 'super_status.html')
+    print("Generating super status page '%s':" % output_filename)
+    template_name = 'status/super_status_page.html.em'
+    start_time = time.time()
+    data = {
+        'title': 'ROS Buildfarm Super Status',
+        'start_time': start_time,
+        'start_time_local_str': time.strftime('%Y-%m-%d %H:%M:%S %z', time.localtime(start_time)),
+        'super_status': super_status,
+        'distros': distros
+    }
+    html = expand_template(template_name, data)
+    with open(output_filename, 'w') as h:
+        h.write(html)

--- a/ros_buildfarm/super_status.py
+++ b/ros_buildfarm/super_status.py
@@ -172,6 +172,9 @@ def build_super_status_page(config_url, output_dir='.', distros=[]):
         d = {'status': status}
         if 'maintainers' in entry:
             d['maintainers'] = entry['maintainers']
+        versions = dict([(distro, entry[distro]['version']) for distro in status])
+        if versions:
+            d['versions'] = versions
         repo_dict[pkg] = d
 
     print('Getting status for each org/repo')

--- a/ros_buildfarm/templates/status/js/setup.js
+++ b/ros_buildfarm/templates/status/js/setup.js
@@ -7,7 +7,12 @@ var QUERY_TRANSFORMS = {
   'RED1': '<td><a class="m"></a>',
   'RED2': '</a><a class="m"></a><a',
   'RED3': '<a class="m"></a></td>',
-  'ORPHANED' : '<span class="unmaintained"|<span class="end-of-life"'
+  'ORPHANED' : '<span class="unmaintained"|<span class="end-of-life"',
+  'RELEASED': 'class="released',
+  'WAITING': 'class="waiting',
+  'SOURCE_PROBLEM': 'class="source',
+  'BROKEN': 'class="broken',
+  'COMPLICATED': 'class="complicated',
 };
 
 window.body_ready = function() {
@@ -334,6 +339,12 @@ function filter_table() {
     for (var i = 0; i < result_rows.length; ++i) {
       result_rows[i].pop();
     }
+
+    // Since the filtering can drastically change the size of the columns, we trigger a resize event to reset
+    // the custom table header
+    setTimeout(function() {
+      $(window).trigger('resize');
+    }, 0);
   }
 
   var result_rows_plain = $.map(result_rows, function(row) { return row[0]; });
@@ -361,3 +372,22 @@ function filter_table() {
   }
 }
 
+function expand(item)
+{
+  var child = item.children[0];
+  var cell = item.parentElement;
+  var row = cell.parentElement;
+
+  if (getComputedStyle(child).display == 'none') {
+    child.style.display = "inline";
+    child.style.width = row.clientWidth + 'px';
+    cell.style.height = (cell.offsetHeight + 5 + child.offsetHeight) + 'px';
+    item.classList.remove('expand_button');
+    item.classList.add('collapse_button');
+  } else {
+    cell.style.height = (cell.offsetHeight - 7 - child.offsetHeight) + 'px';
+    child.style.display = "none";
+    item.classList.remove('collapse_button');
+    item.classList.add('expand_button');
+  }
+}

--- a/ros_buildfarm/templates/status/super_status_job.xml.em
+++ b/ros_buildfarm/templates/status/super_status_job.xml.em
@@ -1,0 +1,97 @@
+<project>
+  <actions/>
+  <description>Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+@(SNIPPET(
+    'property_log-rotator',
+    days_to_keep=100,
+    num_to_keep=100,
+))@
+@(SNIPPET(
+    'property_job-priority',
+    priority=20,
+))@
+@(SNIPPET(
+    'property_requeue-job',
+))@
+  </properties>
+@(SNIPPET(
+    'scm_git',
+    url=ros_buildfarm_repository.url,
+    branch_name=ros_buildfarm_repository.version or 'master',
+    relative_target_dir='ros_buildfarm',
+    refspec=None,
+))@
+  <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
+  <assignedNode>agent_on_master</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+@(SNIPPET(
+    'trigger_timer',
+    spec='0 * * * *',
+))@
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+@(SNIPPET(
+    'builder_shell_docker-info',
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'rm -fr $WORKSPACE/docker_generate_super_status_page',
+        'mkdir -p $WORKSPACE/docker_generate_super_status_page',
+        '',
+        '# monitor all subprocesses and enforce termination',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/subprocess_reaper.py $$ --cid-file $WORKSPACE/docker_generate_super_status_page/docker.cid > $WORKSPACE/docker_generate_super_status_page/subprocess_reaper.log 2>&1 &',
+        '# sleep to give python time to startup',
+        'sleep 1',
+        '',
+        '# generate Dockerfile, build and run it',
+        '# generating the super status page',
+        'echo "# BEGIN SECTION: Generate Dockerfile - super status page"',
+        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/status/run_super_status_page_job.py' +
+        ' --dockerfile-dir $WORKSPACE/docker_generate_super_status_page' +
+        ' --rosdistro ' + rosdistro_index_url,
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: Build Dockerfile - super status page"',
+        'cd $WORKSPACE/docker_generate_super_status_page',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
+        'docker build --force-rm -t super_status_page_generation .',
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: Run Dockerfile - super status page"',
+        'rm -fr $WORKSPACE/super_status',
+        'mkdir -p $WORKSPACE/super_status',
+        'docker run' +
+        ' --rm ' +
+        ' --cidfile=$WORKSPACE/docker_generate_super_status_page/docker.cid' +
+        ' --net=host' +
+        ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
+        ' -v $WORKSPACE/super_status:/tmp/super_status' +
+        ' super_status_page_generation',
+        'echo "# END SECTION"',
+    ]),
+))@
+  </builders>
+  <publishers>
+@(SNIPPET(
+    'publisher_publish-over-ssh',
+    config_name='status_page',
+    remote_directory='',
+    source_files=['status_page/**'],
+    remove_prefix='status_page',
+))@
+  </publishers>
+  <buildWrappers>
+@(SNIPPET(
+    'build-wrapper_timestamper',
+))@
+  </buildWrappers>
+</project>

--- a/ros_buildfarm/templates/status/super_status_page.html.em
+++ b/ros_buildfarm/templates/status/super_status_page.html.em
@@ -130,7 +130,7 @@ def status_cell(status):
         <th>
     </thead>
     <tbody>
-    @[for org in sorted(super_status, key=lambda d: d.lower())]@
+    @[for org in sorted(super_status, key=lambda d: str(d).lower())]@
         @[for repo in sorted(super_status[org]['repos'])]@
             @[for pkg in sorted(super_status[org]['repos'][repo]['pkgs'])]@
             <tr><td class="pkg">@pkg<td>@org<td>@repo
@@ -145,7 +145,8 @@ def status_cell(status):
                     <span class="moreinfo">
                         @[for distro in distros]@
                         @[if distro in super_status[org]['repos'][repo]['pkgs'][pkg]['status'] ]@
-                        <b>@distro</b>: @super_status[org]['repos'][repo]['pkgs'][pkg]['status'][distro] <br />
+                        <b>@distro</b>: @super_status[org]['repos'][repo]['pkgs'][pkg]['status'][distro]
+                                        (@super_status[org]['repos'][repo]['pkgs'][pkg]['versions'][distro])<br />
                         @[end if]@
                         @[end for]@
                     </span>

--- a/ros_buildfarm/templates/status/super_status_page.html.em
+++ b/ros_buildfarm/templates/status/super_status_page.html.em
@@ -7,17 +7,22 @@
   <script type="text/javascript" src="js/moment.min.js"></script>
   <script type="text/javascript" src="js/zepto.min.js"></script>
   </script>
-  <script src="http://code.jquery.com/jquery-2.0.3.min.js"></script>
-  <script src="http://culmat.github.io/jsTreeTable/treeTable.js"></script>
+  <script type="text/javascript">
+    window.META_COLUMNS = 4;
+  </script>
   <script type="text/javascript" src="js/setup.js"></script>
 
   <link rel="stylesheet" type="text/css" href="css/status_page.css" />
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
   <style>
   tbody tr td span { display: inline; }
-  .organization { font-size: 130%; }
-  .repo { font-size: 115%; }
-  .status {
+  td { vertical-align:top; }
+  .distro {
+    font-weight: 900;
+    font-style: normal;
+    font-size: 150%;
+  }
+  .status:before {
     font-weight: 900;
     font-family: "Font Awesome 5 Free";
     font-style: normal;
@@ -38,10 +43,6 @@
     content: "\f1c9";
     color: red;
   }
-  .mixed:before {
-    content: "\f24d";
-    color: gray;
-  }
   .broken:before {
     content: "\f057";
     color: red
@@ -50,6 +51,19 @@
     content: "\f1d0";
     font-family: "Font Awesome 5 Brands";
     color: red
+  }
+  .moreinfo {
+    position: absolute;
+    right: 0px;
+    bottom: 0px;
+    display: none;
+    text-align: center;
+  }
+  .expand_button:before {
+    content: "\f078";
+  }
+  .collapse_button:before {
+    content: "\f077";
   }
   </style>
 </head>
@@ -64,13 +78,11 @@ def status_cell(status):
         css_class = 'waiting'
     elif 'source' in status:
         css_class = 'source'
-    elif status == 'mixed':
-        css_class = 'mixed'
     elif 'build' in status:
         css_class = 'broken'
     elif 'complicated' in status:
         css_class = 'complicated'
-    return '<td class="status {}" title="{}"></td>'.format(css_class, status)
+    return '<td class="{} status" title="{}"></td>'.format(css_class, status)
 }
 <body>
   <script type="text/javascript">
@@ -79,36 +91,66 @@ def status_cell(status):
   <div class="top logo search">
     <h1><img src="http://wiki.ros.org/custom/images/ros_org.png" alt="ROS.org" width="150" height="32" /></h1>
     <h2>@title</h2>
+    <p>Quick filter:
+      <a href="?q=" title="Show all packages">*</a>,
+      <a href="?q=RELEASED">RELEASED</a>,
+      <a href="?q=WAITING">WAITING</a>,
+      <a href="?q=SOURCE_PROBLEM">SOURCE_PROBLEM</a>,
+      <a href="?q=BROKEN">BROKEN</a>,
+      <a href="?q=COMPLICATED">COMPLICATED</a>
+    </p>
+    <form action="?">
+      <input type="text" name="q" id="q" title="A query string can contain multiple '+' separated parts which must all be satisfied. Each part can also be a RegExp (e.g. to combine two parts with 'OR': 'foo|bar'), but can't contain '+'." />
+      <p id="search-count"></p>
+    </form>
+  </div>
+  <div class="top legend">
+    <ul class="squares">
+      <li class="released status">Released
+      <li class="waiting status">Waiting for Release
+      <li class="source status">Problem with Source
+      <li class="broken status">Broken
+      <li class="complicated status">Complicated
+    </ul>
   </div>
   <div class="top age">
     <p>This should show the age of the page...</p>
   </div>
-  <table id="table">
+  <table>
     <caption></caption>
     <thead>
-    <tr><th>Name
+      <tr>
+        <th class="sortable"><div>Package</div></th>
+        <th class="sortable"><div>Organization</div></th>
+        <th class="sortable"><div>Repo</div></th>
+        <th><div>Maintainers</div>
     @[for distro in distros]@
-    <th><div>@distro</div>
+        <th><div class="distro" title="@distro">@distro[0].upper()</div>
     @[end for]@
+        <th>
     </thead>
     <tbody>
     @[for org in sorted(super_status, key=lambda d: d.lower())]@
-    <tr data-tt-id="O@org" data-tt-level="1"><td class="organization">@org
-        @[for distro in distros]@
-        @status_cell(super_status[org]['status'].get(distro))
-        @[end for]@
-    </tr>
         @[for repo in sorted(super_status[org]['repos'])]@
-        <tr data-tt-id="R@repo" data-tt-parent-id="O@org" data-tt-level="2"><td class="repo">@repo
-            @[for distro in distros]@
-            @status_cell(super_status[org]['repos'][repo]['status'].get(distro))
-            @[end for]@
-        </tr>
             @[for pkg in sorted(super_status[org]['repos'][repo]['pkgs'])]@
-            <tr data-tt-id="@pkg" data-tt-parent-id="R@repo" data-tt-level="3"><td class="pkg">@pkg
+            <tr><td class="pkg">@pkg<td>@org<td>@repo
+                <td><div>@[for email, name in super_status[org]['repos'][repo]['pkgs'][pkg]['maintainers'].items() ]@
+                    <a href="mailto:@email">@name.encode('ascii', 'xmlcharrefreplace')</a><br />
+                    @[end for]@</div>
                 @[for distro in distros]@
                 @status_cell(super_status[org]['repos'][repo]['pkgs'][pkg]['status'].get(distro))
                 @[end for]@
+                <td style="position:relative; text-align: right">
+                  <span class="expand_button status" onclick="expand(this)">
+                    <span class="moreinfo">
+                        @[for distro in distros]@
+                        @[if distro in super_status[org]['repos'][repo]['pkgs'][pkg]['status'] ]@
+                        <b>@distro</b>: @super_status[org]['repos'][repo]['pkgs'][pkg]['status'][distro] <br />
+                        @[end if]@
+                        @[end for]@
+                    </span>
+                  </span>
+                </td>
             </tr>
             @[end for]@
         @[end for]@
@@ -116,9 +158,6 @@ def status_cell(status):
     </tbody>
 
     <script type="text/javascript">
-        com_github_culmat_jsTreeTable.register(this);
-        table = treeTable($('#table'));
-        table.expandLevel(0);
         window.tbody_ready();
     </script>
   </table>

--- a/ros_buildfarm/templates/status/super_status_page.html.em
+++ b/ros_buildfarm/templates/status/super_status_page.html.em
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>@title - @start_time_local_str</title>
+  <meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
+
+  <script type="text/javascript" src="js/moment.min.js"></script>
+  <script type="text/javascript" src="js/zepto.min.js"></script>
+  </script>
+  <script src="http://code.jquery.com/jquery-2.0.3.min.js"></script>
+  <script src="http://culmat.github.io/jsTreeTable/treeTable.js"></script>
+  <script type="text/javascript" src="js/setup.js"></script>
+
+  <link rel="stylesheet" type="text/css" href="css/status_page.css" />
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
+  <style>
+  tbody tr td span { display: inline; }
+  .organization { font-size: 130%; }
+  .repo { font-size: 115%; }
+  .status {
+    font-weight: 900;
+    font-family: "Font Awesome 5 Free";
+    font-style: normal;
+    font-size: 150%;
+  }
+  .status:before {
+    content: "\f0a3";
+  }
+  .released:before {
+    content: "\f14a";
+    color: green;
+  }
+  .waiting:before {
+    content: "\f055";
+    color: blue;
+  }
+  .source:before {
+    content: "\f1c9";
+    color: red;
+  }
+  .mixed:before {
+    content: "\f24d";
+    color: gray;
+  }
+  .broken:before {
+    content: "\f057";
+    color: red
+  }
+  .complicated:before {
+    content: "\f1d0";
+    font-family: "Font Awesome 5 Brands";
+    color: red
+  }
+  </style>
+</head>
+@{
+def status_cell(status):
+    if not status:
+        return '<td></td>'
+    css_class = ''
+    if status == 'released':
+        css_class = status
+    elif 'waiting' in status:
+        css_class = 'waiting'
+    elif 'source' in status:
+        css_class = 'source'
+    elif status == 'mixed':
+        css_class = 'mixed'
+    elif 'build' in status:
+        css_class = 'broken'
+    elif 'complicated' in status:
+        css_class = 'complicated'
+    return '<td class="status {}" title="{}"></td>'.format(css_class, status)
+}
+<body>
+  <script type="text/javascript">
+    window.body_ready_with_age(moment.duration(moment() - moment("@start_time", "X")));
+  </script>
+  <div class="top logo search">
+    <h1><img src="http://wiki.ros.org/custom/images/ros_org.png" alt="ROS.org" width="150" height="32" /></h1>
+    <h2>@title</h2>
+  </div>
+  <div class="top age">
+    <p>This should show the age of the page...</p>
+  </div>
+  <table id="table">
+    <caption></caption>
+    <thead>
+    <tr><th>Name
+    @[for distro in distros]@
+    <th><div>@distro</div>
+    @[end for]@
+    </thead>
+    <tbody>
+    @[for org in sorted(super_status, key=lambda d: d.lower())]@
+    <tr data-tt-id="O@org" data-tt-level="1"><td class="organization">@org
+        @[for distro in distros]@
+        @status_cell(super_status[org]['status'].get(distro))
+        @[end for]@
+    </tr>
+        @[for repo in sorted(super_status[org]['repos'])]@
+        <tr data-tt-id="R@repo" data-tt-parent-id="O@org" data-tt-level="2"><td class="repo">@repo
+            @[for distro in distros]@
+            @status_cell(super_status[org]['repos'][repo]['status'].get(distro))
+            @[end for]@
+        </tr>
+            @[for pkg in sorted(super_status[org]['repos'][repo]['pkgs'])]@
+            <tr data-tt-id="@pkg" data-tt-parent-id="R@repo" data-tt-level="3"><td class="pkg">@pkg
+                @[for distro in distros]@
+                @status_cell(super_status[org]['repos'][repo]['pkgs'][pkg]['status'].get(distro))
+                @[end for]@
+            </tr>
+            @[end for]@
+        @[end for]@
+    @[end for]@
+    </tbody>
+
+    <script type="text/javascript">
+        com_github_culmat_jsTreeTable.register(this);
+        table = treeTable($('#table'));
+        table.expandLevel(0);
+        window.tbody_ready();
+    </script>
+  </table>
+  <script type="text/javascript">window.body_done();</script>
+</body>
+</html>

--- a/ros_buildfarm/templates/status/super_status_page.html.em
+++ b/ros_buildfarm/templates/status/super_status_page.html.em
@@ -131,22 +131,26 @@ def status_cell(status):
     </thead>
     <tbody>
     @[for org in sorted(super_status, key=lambda d: str(d).lower())]@
+        @{ org_link = '<a href="%s">%s</a>' % (super_status[org]['url'], org) if ('url' in super_status[org]) else org }@
         @[for repo in sorted(super_status[org]['repos'])]@
             @[for pkg in sorted(super_status[org]['repos'][repo]['pkgs'])]@
-            <tr><td class="pkg">@pkg<td>@org<td>@repo
-                <td><div>@[for email, name in super_status[org]['repos'][repo]['pkgs'][pkg]['maintainers'].items() ]@
+            @{ PKG = super_status[org]['repos'][repo]['pkgs'][pkg] }@
+            <tr><td class="pkg">@pkg
+                <td><div>@org_link</div>
+                <td><div><a href="@super_status[org]['repos'][repo]['url']">@repo</a></div>
+                <td><div>@[for email, name in PKG['maintainers'].items() ]@
                     <a href="mailto:@email">@name.encode('ascii', 'xmlcharrefreplace')</a><br />
                     @[end for]@</div>
                 @[for distro in distros]@
-                @status_cell(super_status[org]['repos'][repo]['pkgs'][pkg]['status'].get(distro))
+                @status_cell(PKG['status'].get(distro))
                 @[end for]@
                 <td style="position:relative; text-align: right">
                   <span class="expand_button status" onclick="expand(this)">
                     <span class="moreinfo">
                         @[for distro in distros]@
-                        @[if distro in super_status[org]['repos'][repo]['pkgs'][pkg]['status'] ]@
-                        <b>@distro</b>: @super_status[org]['repos'][repo]['pkgs'][pkg]['status'][distro]
-                                        (@super_status[org]['repos'][repo]['pkgs'][pkg]['versions'][distro])<br />
+                        @[if distro in PKG['status'] ]@
+                        <b>@distro</b>: @PKG['status'][distro]
+                                        (@PKG['versions'][distro])<br />
                         @[end if]@
                         @[end for]@
                     </span>

--- a/ros_buildfarm/templates/status/super_status_page_task.Dockerfile.em
+++ b/ros_buildfarm/templates/status/super_status_page_task.Dockerfile.em
@@ -1,0 +1,41 @@
+# generated from @template_name
+
+FROM ubuntu:xenial
+
+VOLUME ["/var/cache/apt/archives"]
+
+ENV DEBIAN_FRONTEND noninteractive
+
+@(TEMPLATE(
+    'snippet/setup_locale.Dockerfile.em',
+    timezone=timezone,
+))@
+
+RUN useradd -u @uid -m buildfarm
+
+@(TEMPLATE(
+    'snippet/add_wrapper_scripts.Dockerfile.em',
+    wrapper_scripts=wrapper_scripts,
+))@
+
+# automatic invalidation once every day
+RUN echo "@today_str"
+
+@(TEMPLATE(
+    'snippet/install_python3.Dockerfile.em',
+    os_name='ubuntu',
+    os_code_name='xenial',
+))@
+
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-pip python3-yaml python3-empy
+RUN pip3 install pygithub requests
+
+USER buildfarm
+ENTRYPOINT ["sh", "-c"]
+@{
+cmd = \
+    'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH ROSDISTRO_INDEX_URL=' + rosdistro_index_url + ' python3 -u' + \
+    ' /tmp/ros_buildfarm/scripts/status/build_super_status_page.py' + \
+    ' --output-dir /tmp/status_page'
+}@
+CMD ["@cmd"]

--- a/scripts/generate_all_jobs.py
+++ b/scripts/generate_all_jobs.py
@@ -136,6 +136,8 @@ def main(argv=sys.argv[1:]):
             generate_blocked_releases_page_job(
                 args.config_url, ros_distro_name, dry_run=not args.commit)
 
+        generate_super_status_job(args.config_url, dry_run=not args.commit)
+
 
 def generate_check_agents_job(config_url, dry_run=False):
     cmd = [
@@ -291,6 +293,14 @@ def generate_doc_metadata_job(
         cmd.append('--dry-run')
     _check_call(cmd)
 
+def generate_super_status_job(config_url, dry_run=False):
+    cmd = [
+        _resolve_script('status', 'generate_super_status_job.py'),
+        config_url,
+    ]
+    if dry_run:
+        cmd.append('--dry-run')
+    _check_call(cmd)
 
 def _resolve_script(subfolder, filename):
     basepath = os.path.abspath(os.path.dirname(__file__))

--- a/scripts/status/build_super_status_page.py
+++ b/scripts/status/build_super_status_page.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+
+from ros_buildfarm.argument import add_argument_output_dir, add_argument_config_url
+from ros_buildfarm.super_status import build_super_status_page
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Run the 'build_super_status_page' job")
+    add_argument_config_url(parser)
+    add_argument_output_dir(parser)
+    parser.add_argument('distros', nargs='*', metavar='distro')
+    args = parser.parse_args(argv)
+    return build_super_status_page(args.config_url, output_dir=args.output_dir, distros=args.distros)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/status/generate_super_status_job.py
+++ b/scripts/status/generate_super_status_job.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# Copyright 2014-2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+
+from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_dry_run
+from ros_buildfarm.config import get_index
+from ros_buildfarm.git import get_repository
+from ros_buildfarm.jenkins import configure_job
+from ros_buildfarm.jenkins import configure_management_view
+from ros_buildfarm.jenkins import connect
+from ros_buildfarm.templates import expand_template
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Generate the 'super_status' job on Jenkins")
+    add_argument_config_url(parser)
+    add_argument_dry_run(parser)
+    args = parser.parse_args(argv)
+
+    config = get_index(args.config_url)
+    job_config = get_job_config(args, config)
+
+    jenkins = connect(config.jenkins_url)
+
+    configure_management_view(jenkins, dry_run=args.dry_run)
+
+    job_name = 'super_status'
+    configure_job(jenkins, job_name, job_config, dry_run=args.dry_run)
+
+
+def get_job_config(args, config):
+    template_name = 'status/super_status_job.xml.em'
+    job_data = {
+        'ros_buildfarm_repository': get_repository(),
+        'rosdistro_index_url': config.rosdistro_index_url,
+    }
+    job_config = expand_template(template_name, job_data)
+    return job_config
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/status/run_super_status_page_job.py
+++ b/scripts/status/run_super_status_page_job.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import argparse
+import copy
+import sys
+
+from ros_buildfarm.argument import add_argument_dockerfile_dir
+from ros_buildfarm.argument import add_argument_rosdistro_index_url
+from ros_buildfarm.common import get_user_id
+from ros_buildfarm.templates import create_dockerfile
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Run the 'super_status_page' job")
+    add_argument_dockerfile_dir(parser)
+    add_argument_rosdistro_index_url(parser, required=True)
+    args = parser.parse_args(argv)
+
+    data = copy.deepcopy(args.__dict__)
+    data.update({
+        'uid': get_user_id(),
+    })
+    create_dockerfile(
+        'status/super_status_page_task.Dockerfile.em',
+        data, args.dockerfile_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/aggregate_status_tests.yaml
+++ b/test/aggregate_status_tests.yaml
@@ -1,0 +1,143 @@
+test_cases:
+  - build_status:
+      ubuntu:
+        trusty:
+          amd64: {build: 1.2.1-0trusty-20180517-084419-0800, main: 1.2.1-0trusty-20180317-100619-0800,
+            test: 1.2.1-0trusty-20180517-084419-0800}
+          armhf: {build: 1.2.1-0trusty-20180519-162619-0800, main: 1.2.1-0trusty-20180319-012433-0800,
+            test: 1.2.1-0trusty-20180519-162619-0800}
+          i386: {build: 1.2.1-0trusty-20180517-080409-0800, main: 1.2.1-0trusty-20180317-102156-0800,
+            test: 1.2.1-0trusty-20180317-102156-0800}
+          source: {build: 1.2.1-0trusty, main: 1.2.1-0trusty, test: 1.2.1-0trusty}
+    result: released
+  - build_status:
+      ubuntu:
+        trusty:
+          amd64: {build: 1.2.1-0trusty-20180517-084419-0800,
+            test: 1.2.1-0trusty-20180517-084419-0800}
+          armhf: {build: 1.2.1-0trusty-20180519-162619-0800,
+            test: 1.2.1-0trusty-20180519-162619-0800}
+          i386: {build: 1.2.1-0trusty-20180517-080409-0800,
+            test: 1.2.1-0trusty-20180317-102156-0800}
+          source: {build: 1.2.1-0trusty, test: 1.2.1-0trusty}
+    result: waiting for new release
+  - build_status:
+      ubuntu:
+        trusty:
+          amd64: {build: 1.2.1-0trusty-20180517-084419-0800, main: 1.2.0-0trusty-20180317-100619-0800,
+            test: 1.2.1-0trusty-20180517-084419-0800}
+          armhf: {build: 1.2.1-0trusty-20180519-162619-0800, main: 1.2.0-0trusty-20180319-012433-0800,
+            test: 1.2.1-0trusty-20180519-162619-0800}
+          i386: {build: 1.2.1-0trusty-20180517-080409-0800, main: 1.2.0-0trusty-20180317-102156-0800,
+            test: 1.2.1-0trusty-20180317-102156-0800}
+          source: {build: 1.2.1-0trusty, main: 1.2.1-0trusty, test: 1.2.1-0trusty}
+    result: waiting for re-release
+  - build_status:
+      ubuntu:
+        trusty:
+          amd64: {build: 1.2.1-0trusty-20180517-084419-0800, main: 1.2.0-0trusty-20180317-100619-0800,
+            test: 1.2.1-0trusty-20180517-084419-0800}
+          armhf: {build: 1.2.1-0trusty-20180519-162619-0800,
+            test: 1.2.1-0trusty-20180519-162619-0800}
+          i386: {build: 1.2.1-0trusty-20180517-080409-0800, main: 1.2.0-0trusty-20180317-102156-0800,
+            test: 1.2.1-0trusty-20180317-102156-0800}
+          source: {build: 1.2.1-0trusty, main: 1.2.1-0trusty, test: 1.2.1-0trusty}
+    result: waiting for new/re-release
+  - build_status:
+        ubuntu:
+          trusty:
+            source: {build: 0.0.1-1trusty, main: 0.0.1-1trusty, test: 0.0.1-1trusty}
+    result: source builds, binary doesn't
+  - build_status:
+        ubuntu:
+          trusty:
+            amd64: {build: 1.2.3-0trusty-20180517-084419-0800, main: 1.2.3-0trusty-20180317-100619-0800,
+              test: 1.2.3-0trusty-20180517-084419-0800}
+            armhf: {build: 1.2.3-0trusty-20180519-162619-0800, main: 1.2.3-0trusty-20180319-012433-0800,
+              test: 1.2.3-0trusty-20180519-162619-0800}
+            i386: {build: 1.2.3-0trusty-20180517-080409-0800, main: 1.2.3-0trusty-20180317-102156-0800,
+              test: 1.2.3-0trusty-20180317-102156-0800}
+            source: {build: 1.2.1-0trusty, main: 1.2.1-0trusty, test: 1.2.1-0trusty}
+    result: source builds, binary doesn't
+  - result: does not build on armhf
+    build_status:
+      ubuntu:
+        trusty:
+          amd64: {build: 0.1.1-0trusty-20180604-045911-0800, main: 0.1.1-0trusty-20180604-045911-0800,
+            test: 0.1.1-0trusty-20180604-045911-0800}
+          i386: {build: 0.1.1-0trusty-20180605-064610-0800, main: 0.1.1-0trusty-20180605-064610-0800,
+            test: 0.1.1-0trusty-20180605-064610-0800}
+          source: {build: 0.1.1-0trusty, main: 0.1.1-0trusty, test: 0.1.1-0trusty}
+  - result: does not build on armhf, i386
+    build_status:
+      ubuntu:
+        trusty:
+          amd64: {build: 0.1.1-0trusty-20180604-045911-0800, main: 0.1.1-0trusty-20180604-045911-0800,
+            test: 0.1.1-0trusty-20180604-045911-0800}
+          source: {build: 0.1.1-0trusty, main: 0.1.1-0trusty, test: 0.1.1-0trusty}
+  - result: does not build on stretch/amd64, stretch/arm64
+    distro: melodic
+    build_status:
+        debian:
+          stretch:
+            source: {build: 0.1.22-0stretch, main: 0.1.22-0stretch, test: 0.1.22-0stretch}
+        ubuntu:
+          artful:
+            amd64: {build: 0.1.22-0artful.20180607.072438, main: 0.1.22-0artful.20180607.072438,
+              test: 0.1.22-0artful.20180607.072438}
+            source: {build: 0.1.22-0artful, main: 0.1.22-0artful, test: 0.1.22-0artful}
+          bionic:
+            amd64: {build: 0.1.22-0bionic.20180606.231409, main: 0.1.22-0bionic.20180606.231409,
+              test: 0.1.22-0bionic.20180606.231409}
+            arm64: {build: 0.1.22-0bionic.20180607.092205, main: 0.1.22-0bionic.20180607.092205,
+              test: 0.1.22-0bionic.20180607.092205}
+            armhf: {build: 0.1.22-0bionic.20180607.112928, main: 0.1.22-0bionic.20180607.112928,
+              test: 0.1.22-0bionic.20180607.112928}
+            source: {build: 0.1.22-0bionic, main: 0.1.22-0bionic, test: 0.1.22-0bionic}
+  - result: source builds, binary doesn't
+    build_status:
+        ubuntu:
+          trusty:
+            source: {build: 0.0.1-1trusty, main: 0.0.2-1trusty, test: 0.0.1-1trusty}
+  - result: does not build on trusty/armhf
+    build_status:
+      ubuntu:
+        trusty:
+          amd64: {build: 0.1.1-0trusty-20180604-045911-0800, main: 0.1.2-0trusty-20180604-045911-0800,
+            test: 0.1.1-0trusty-20180604-045911-0800}
+          i386: {build: 0.1.1-0trusty-20180605-064610-0800, main: 0.1.2-0trusty-20180605-064610-0800,
+            test: 0.1.1-0trusty-20180605-064610-0800}
+          source: {build: 0.1.1-0trusty, main: 0.1.2-0trusty, test: 0.1.1-0trusty}
+  - result: released
+    build_status:
+      ubuntu:
+        trusty:
+          amd64: {build: 0.1.1-0trusty-20180604-045911-0800, main: 0.1.1-0trusty-20180604-045911-0800,
+            test: 0.1.1-0trusty-20180604-045911-0800}
+          i386: {build: 0.1.1-0trusty-20180605-064610-0800, main: 0.1.1-0trusty-20180605-064610-0800,
+            test: 0.1.1-0trusty-20180605-064610-0800}
+          source: {build: 0.1.1-0trusty, main: 0.1.1-0trusty, test: 0.1.1-0trusty}
+    blacklist:
+        - [ubuntu, trusty, armhf]
+  - build_status:
+      ubuntu:
+        artful:
+          amd64: {build: 1.2.1-0trusty-20180517-084419-0800, main: 1.2.1-0trusty-20180317-100619-0800,
+            test: 1.2.1-0trusty-20180517-084419-0800}
+          source: {build: 1.2.1-0trusty, main: 1.2.1-0trusty, test: 1.2.1-0trusty}
+    result: does not build on bionic, stretch
+    distro: melodic
+expected:
+  indigo:
+    ubuntu:
+      trusty:
+        - source
+        - i386
+        - amd64
+        - armhf
+  melodic:
+    debian:
+      stretch: [amd64, arm64, source]
+    ubuntu:
+      artful: [amd64, source]
+      bionic: [amd64, arm64, armhf, source]

--- a/test/test_aggregate_status.py
+++ b/test/test_aggregate_status.py
@@ -1,0 +1,16 @@
+#!/usr/bin/python
+
+import yaml
+from ros_buildfarm.aggregate_status import get_distro_status
+
+D = yaml.load(open('test/aggregate_status_tests.yaml'))
+match = 0
+for i, case in enumerate(D['test_cases']):
+    distro = case.get('distro', 'indigo')
+    blacklist = set(map(tuple, case.get('blacklist', [])))
+    status = get_distro_status(case['build_status'], D['expected'][distro], blacklist)
+    if status == case['result']:
+        match += 1
+    else:
+        print('Failure in test case #{}: {} != {}'.format(i + 1, status, case['result']))
+print('{}/{} correct'.format(match, len(D['test_cases'])))


### PR DESCRIPTION
Awhile ago (2016), [I complained about the relative unreadability of the build farm status pages](http://lists.ros.org/lurker/message/20160115.033604.cac2d7e5.it.html) and I demoed the first version of [ROS Crawl](http://www.metrorobots.com/ros_crawl/).

Unfortunately, that page is out of date because it relied on the csv that the build farm used to generate. Since then, I added the ability to generate yaml (#521) and I've learned some more of the basics about how the build farm actually runs jobs. So here is my replacement for ROS Crawl, but generated from the buildfarm. 

The key module here is `super_status.py` which has the `build_super_status_page` function in it, which 
 * Reads all the [yaml files generated](http://repositories.ros.org/status_page/yaml/)
 * Merges them into one data structure and writes that yaml file to `multi_distro_status.yaml` (which I initially tried to do in #529)
 * Determines the "aggregate status" of each package (more on that below)
 * Merges all of the aggregate statuses for each package into a new dictionary, organized by Git Organization (i.e. `ros-planning`) (or similar structure for other hosts) and repository. 
 * Writes that data structure to `super_status.yaml`
 * Generates `super_status.html`

The aggregate status is my way to collect the build status across different CPU architectures (e.g. [ros_lunar_default](http://repositories.ros.org/status_page/ros_lunar_default.html), [ros_lunar_ds](http://repositories.ros.org/status_page/ros_lunar_ds.html)) and translate it to a per-ROS-distro English status. Current statuses include
 * released (i.e. all green)
 * waiting for new release (all green in build/test, nothing in main)
 * waiting for re-release (all green in build/test, old version in main)
 * source builds, binary doesn't
 * does not build on X (where X could be a OS, OS code name, CPU, or some combination)
 * More than 99% of the current build farm fall into one of those categories. *The rest are marked as complicated*
I even added some tests for this portion of the logic. 

You can see the (*old*) generated files here:
[super_status.tar.gz](https://github.com/ros-infrastructure/ros_buildfarm/files/2128667/super_status.tar.gz)

The (*new*) generated HTML looks like this:
![screenshot from 2018-07-16 16-27-59](https://user-images.githubusercontent.com/1016143/42781902-645f3ede-8915-11e8-8217-8ab13fba0e6e.png)
*You can expand each row to get the English status.* ~~Each organization/repo is expandable/collapsible.~~
Caveats:
 * ~~The dynamic filtering and URL parameters that the other status pages have are not yet implemented.~~
 * ~~The super_status.yaml contains information about the maintainers, but I haven't added to the HTML yet.~~ 
 * I haven't tried all the job generating stuff yet on a real build farm. 
 * The folder where to download the yaml from is hard coded, as I haven't found a place where that is saved in the buildfarm configuration.