### PR TITLE
Allow searching by email on status pages

### DIFF
--- a/ros_buildfarm/templates/status/js/setup.js
+++ b/ros_buildfarm/templates/status/js/setup.js
@@ -216,15 +216,14 @@ function scan_rows() {
   // go in chunks, with timeouts in between.
   window.rows = [];
   $('table tbody tr').each(function() {
-    // Add lowercased version of name (which is the last meta column) for faster case-insensitive search.
     var name_td = $('td:nth-child(' + window.META_COLUMNS + ')', this);
     var hidden_text = '';
-    if (name_td.text() && name_td.text().length > 0) {
-      hidden_text += name_td.text().toLowerCase()
-    }
-    // Add a copy of the email to the hidden text for additional searching
+    // Add lowercased version of name (which is the last meta column) for faster case-insensitive search.
+    // Also, add a copy of the email to the hidden text for additional searching
     name_td.find('a').each(function() {
-      hidden_text += this['href'];
+      hidden_text += this.text.toLowerCase()
+      hidden_text += this['href'].replace('mailto:', ' ');
+      hidden_text += ' ';
     });
     if (hidden_text.length > 0) {
       name_td.append(' <span class="ht">' + hidden_text + '</span>');

--- a/ros_buildfarm/templates/status/js/setup.js
+++ b/ros_buildfarm/templates/status/js/setup.js
@@ -218,8 +218,16 @@ function scan_rows() {
   $('table tbody tr').each(function() {
     // Add lowercased version of name (which is the last meta column) for faster case-insensitive search.
     var name_td = $('td:nth-child(' + window.META_COLUMNS + ')', this);
+    var hidden_text = '';
     if (name_td.text() && name_td.text().length > 0) {
-      name_td.append(' <span class="ht">' + name_td.text().toLowerCase() + '</span>');
+      hidden_text += name_td.text().toLowerCase()
+    }
+    // Add a copy of the email to the hidden text for additional searching
+    name_td.find('a').each(function() {
+      hidden_text += this['href'];
+    });
+    if (hidden_text.length > 0) {
+      name_td.append(' <span class="ht">' + hidden_text + '</span>');
     }
     var row_info = [$(this).html()];
     for (var i = 1; i <= window.META_COLUMNS; i++) {


### PR DESCRIPTION
[This link](http://repositories.ros.org/status_page/ros_lunar_default.html?q=dthomas) does not currently return any results. This PR enables searching by email address by adding all the email addresses to the hidden text field. 