### PR TITLE
add artful to list of old releases

### DIFF
--- a/ros_buildfarm/templates/snippet/old_release_set.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/old_release_set.Dockerfile.em
@@ -1,3 +1,3 @@
-@[if os_name == 'ubuntu' and os_code_name in ['saucy', 'utopic', 'vivid', 'wily', 'yakkety', 'zesty']]@
+@[if os_name == 'ubuntu' and os_code_name in ['saucy', 'utopic', 'vivid', 'wily', 'yakkety', 'zesty', 'artful']]@
 RUN find /etc/apt/ -name *.list -exec sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' {} \;
 @[end if]@


### PR DESCRIPTION
~~DO NOT MERGE~~

Artful has been EOL for a month. This PR changes the sources to use `old-releases.ubuntu.com` for artful.

We need to wait for ubuntu to migrate artful packages from `archive.ubuntu.com` to `old-releases.ubuntu.com` before merging this