### PR TITLE
show who is maintainer

### DIFF
--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -789,7 +789,7 @@ def _get_blocked_releases_info(config_url, rosdistro_name, repo_names=None):
                     except InvalidPackage:
                         pass
                     else:
-                        pkg_maintainers = {m.name: m.email for m in pkg.maintainers}
+                        pkg_maintainers = {str(m.name.encode('utf-8')): m.email for m in pkg.maintainers}
                         if package not in repo_maintainers:
                             repo_maintainers[package] = {}
                         repo_maintainers[package].update(pkg_maintainers)
@@ -838,7 +838,7 @@ def _get_blocked_releases_info(config_url, rosdistro_name, repo_names=None):
                         except InvalidPackage:
                             pass
                         else:
-                            pkg_maintainers = {m.name: m.email for m in pkg.maintainers}
+                            pkg_maintainers = {str(m.name.encode('utf-8')): m.email for m in pkg.maintainers}
                             if unreleased_repo_name not in maintainers:
                                 maintainers[unreleased_repo_name] = {}
                             maintainers[unreleased_repo_name].update(pkg_maintainers)

--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -789,7 +789,10 @@ def _get_blocked_releases_info(config_url, rosdistro_name, repo_names=None):
                     except InvalidPackage:
                         pass
                     else:
-                        pkg_maintainers = {str(m.name.encode('utf-8')): m.email for m in pkg.maintainers}
+                        if sys.version_info < (3,0):
+                            pkg_maintainers = {m.name.encode('utf-8'): m.email for m in pkg.maintainers}
+                        else:
+                            pkg_maintainers = {m.name: m.email for m in pkg.maintainers}
                         if package not in repo_maintainers:
                             repo_maintainers[package] = {}
                         repo_maintainers[package].update(pkg_maintainers)
@@ -838,7 +841,10 @@ def _get_blocked_releases_info(config_url, rosdistro_name, repo_names=None):
                         except InvalidPackage:
                             pass
                         else:
-                            pkg_maintainers = {str(m.name.encode('utf-8')): m.email for m in pkg.maintainers}
+                            if sys.version_info < (3,0):
+                                pkg_maintainers = {m.name.encode('utf-8'): m.email for m in pkg.maintainers}
+                            else:
+                                pkg_maintainers = {m.name: m.email for m in pkg.maintainers}
                             if unreleased_repo_name not in maintainers:
                                 maintainers[unreleased_repo_name] = {}
                             maintainers[unreleased_repo_name].update(pkg_maintainers)

--- a/ros_buildfarm/templates/status/blocked_releases_page.html.em
+++ b/ros_buildfarm/templates/status/blocked_releases_page.html.em
@@ -64,6 +64,7 @@ import time
           <!-- warning: if titles run onto two lines, first row of table data may be affected -->
           <th class="sortable"><div>Repository</div></th>
           <th class="sortable"><div>Version</div></th>
+          <th class="sortable"><div>Maintainers</div></th>
           <th class="sortable">
             <div title="Number of unreleased repositories that are directly blocking this one">
               # blocking release
@@ -105,6 +106,7 @@ import time
 @[  for col in [
       'name',
       'version',
+      'maintainers',
       'num_repos_blocked_by',
       'repos_blocked_by',
       'maintainers_of_repos_blocked_by',


### PR DESCRIPTION
add row to show who is maintainer of the package
Currently we only have who is the maintainer of the blocked package, but I could not remember all package that I have to run `bloom-release`...

![screenshot from 2018-09-01 15-43-50](https://user-images.githubusercontent.com/493276/44943258-525e2480-adfe-11e8-9ad5-57e31b5f3bc7.png)

