### PR TITLE
[prerelease] add ability to generate repos files for faster cloning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install dpkg -y  # necessary for catkin-pkg to be installable
         - sudo apt-get install ros-indigo-catkin -y
+        - sudo apt-get install python3-vcstool -y
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm
@@ -89,6 +90,10 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
+        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
+        - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+        - sudo apt-get update -qq
+        - sudo apt-get install python3-vcstool -y
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm
@@ -173,6 +178,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install dpkg -y  # necessary for catkin-pkg to be installable
         - sudo apt-get install ros-indigo-catkin -y
+        - sudo apt-get install python3-vcstool -y
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm
@@ -188,6 +194,10 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
+        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
+        - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+        - sudo apt-get update -qq
+        - sudo apt-get install python3-vcstool -y
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm
@@ -272,6 +282,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install dpkg -y  # necessary for catkin-pkg to be installable
         - sudo apt-get install ros-indigo-catkin -y
+        - sudo apt-get install python3-vcstool -y
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm
@@ -287,6 +298,10 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
+        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
+        - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+        - sudo apt-get update -qq
+        - sudo apt-get install python3-vcstool -y
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm
@@ -374,6 +389,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install dpkg -y  # necessary for catkin-pkg to be installable
         - sudo apt-get install ros-indigo-catkin -y
+        - sudo apt-get install python-vcstool -y
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm
@@ -389,7 +405,10 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
-        - sudo apt-get update
+        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
+        - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+        - sudo apt-get update -qq
+        - sudo apt-get install python-vcstool -y
         - sudo apt-get install -y python3-pip
         - sudo pip3 install EmPy
         - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,10 +90,9 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
-        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
-        - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
-        - sudo apt-get update -qq
-        - sudo apt-get install python3-vcstool -y
+        - sudo apt-get update
+        - sudo apt-get install -y python3-pip
+        - sudo pip3 install vcstool
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm
@@ -194,10 +193,9 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
-        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
-        - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
-        - sudo apt-get update -qq
-        - sudo apt-get install python3-vcstool -y
+        - sudo apt-get update
+        - sudo apt-get install -y python3-pip
+        - sudo pip3 install vcstool
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm
@@ -298,10 +296,9 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
-        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
-        - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
-        - sudo apt-get update -qq
-        - sudo apt-get install python3-vcstool -y
+        - sudo apt-get update
+        - sudo apt-get install -y python3-pip
+        - sudo pip3 install vcstool
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm
@@ -405,12 +402,9 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
-        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
-        - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
-        - sudo apt-get update -qq
-        - sudo apt-get install python-vcstool -y
+        - sudo apt-get update
         - sudo apt-get install -y python3-pip
-        - sudo pip3 install EmPy
+        - sudo pip3 install EmPy vcstool
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm

--- a/ros_buildfarm/templates/prerelease/prerelease_clone_overlay_script.sh.em
+++ b/ros_buildfarm/templates/prerelease/prerelease_clone_overlay_script.sh.em
@@ -9,8 +9,7 @@ if [ -z "$WORKSPACE" ]; then
     echo ""
 fi
 
-PYTHONPATH=@ros_buildfarm_python_path:$PYTHONPATH @python_executable @prerelease_script_path/generate_prerelease_overlay_script.py @config_url @rosdistro_name @os_name @os_code_name @arch --pkg @(' '.join(pkg)) --exclude-pkg @(' '.join(exclude_pkg)) --level @level > prerelease_clone_overlay_impl.sh
+PYTHONPATH=@ros_buildfarm_python_path:$PYTHONPATH @python_executable @prerelease_script_path/generate_prerelease_overlay_script.py @config_url @rosdistro_name @os_name @os_code_name @arch --pkg @(' '.join(pkg)) --exclude-pkg @(' '.join(exclude_pkg)) --level @level --vcstool > overlay.repos
 echo ""
 
-chmod u+x prerelease_clone_overlay_impl.sh
-./prerelease_clone_overlay_impl.sh
+vcs import $WORKSPACE < overlay.repos

--- a/scripts/prerelease/generate_prerelease_overlay_script.py
+++ b/scripts/prerelease/generate_prerelease_overlay_script.py
@@ -108,9 +108,10 @@ def main(argv=sys.argv[1:]):
     elif args.vcstool:
         print('repositories:')
         for r, p in scms:
-            print('  %s:\n    %s\n    %s\n    %s' % (
-                p, 'type: ' + r.type, 'url: ' + r.url, 'version: ' + r.version),
-            )
+            print('  %s:' % p)
+            print('    type: ' + r.type)
+            print('    url: ' + r.url)
+            print('    version: ' + r.version)
     else:
         value = expand_template(
             'prerelease/prerelease_overlay_script.sh.em', {

--- a/scripts/prerelease/generate_prerelease_overlay_script.py
+++ b/scripts/prerelease/generate_prerelease_overlay_script.py
@@ -56,12 +56,13 @@ def main(argv=sys.argv[1:]):
              '(by default package names come from packages found in '
              "'catkin_workspace/src')"
     )
-    parser.add_argument(
-        '--json', action='store_true', default=False,
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        '--json', action='store_true',
         help='Output overlay information as JSON instead of a shell script'
     )
-    parser.add_argument(
-        '--vcstool', action='store_true', default=False,
+    group.add_argument(
+        '--vcstool', action='store_true',
         help='Output overlay information as vcstool repos file'
     )
 

--- a/scripts/prerelease/generate_prerelease_overlay_script.py
+++ b/scripts/prerelease/generate_prerelease_overlay_script.py
@@ -57,8 +57,12 @@ def main(argv=sys.argv[1:]):
              "'catkin_workspace/src')"
     )
     parser.add_argument(
-        '--json', action='store_true',
+        '--json', action='store_true', default=False,
         help='Output overlay information as JSON instead of a shell script'
+    )
+    parser.add_argument(
+        '--vcstool', action='store_true', default=False,
+        help='Output overlay information as vcstool repos file'
     )
 
     args = parser.parse_args(argv)
@@ -98,14 +102,20 @@ def main(argv=sys.argv[1:]):
         (repositories[k], 'catkin_workspace_overlay/src/%s' % k)
         for k in sorted(repositories.keys())]
 
-    if not args.json:
+    if args.json:
+        print(json.dumps([vars(r) for r, p in scms], sort_keys=True, indent=2))
+    elif args.vcstool:
+        print('repositories:')
+        for r, p in scms:
+            print('  %s:\n    %s\n    %s\n    %s' % (
+                p, 'type: ' + r.type, 'url: ' + r.url, 'version: ' + r.version),
+            )
+    else:
         value = expand_template(
             'prerelease/prerelease_overlay_script.sh.em', {
                 'scms': scms},
             options={BANGPATH_OPT: False})
         print(value)
-    else:
-        print(json.dumps([vars(r) for r, p in scms], sort_keys=True, indent=2))
 
 
 def get_repository_specification_for_released_package(dist_file, pkg_name):


### PR DESCRIPTION
Opening this for discussion: not ready for review yet, just attaching code if it helps the discussion.

When running prerelease jobs, the cloning of the overlay can be pretty slow due to the fact that packages are cloned 1 by 1.

I would like to be able to generate a file (vcstool repos file or rosinstall file) so that users running the prerelease jobs can elect to invoke the ROS VCS tools manually for cloning the packages in the overlay.

Questions I'd like feedback on:
- What file format should be generated ? it looks like the rosinstall format would be supported by all tools and thus should be preferred over the vcstool format?
- Should the file always be generated (but not invoked) ? or should it be an option to the `generate_prerelease_script.py` script?