### PR TITLE
consider CCACHE_DIR variable from environment

### DIFF
--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -191,7 +191,7 @@ if pull_request:
         ' -e=TRAVIS=$TRAVIS' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/catkin_workspace:/tmp/catkin_workspace' +
-        ' -v ~/.ccache:/home/buildfarm/.ccache' +
+        ' -v $CCACHE_DIR:/home/buildfarm/.ccache' +
         ' devel_build_and_install.%s_%s' % (rosdistro_name, source_repo_spec.name.lower()),
         'cd -',  # restore pwd when used in scripts
         'echo "# END SECTION"',
@@ -219,7 +219,7 @@ if pull_request:
         ' -e=TRAVIS=$TRAVIS' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/catkin_workspace:/tmp/catkin_workspace' +
-        ' -v ~/.ccache:/home/buildfarm/.ccache' +
+        ' -v $CCACHE_DIR:/home/buildfarm/.ccache' +
         ' devel_build_and_test.%s_%s' % (rosdistro_name, source_repo_spec.name.lower()),
         'cd -',  # restore pwd when used in scripts
         'echo "# END SECTION"',

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -191,7 +191,7 @@ if pull_request:
         ' -e=TRAVIS=$TRAVIS' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/catkin_workspace:/tmp/catkin_workspace' +
-        ' -v $CCACHE_DIR:/home/buildfarm/.ccache' +
+        ' -v ~/.ccache:/home/buildfarm/.ccache' +
         ' devel_build_and_install.%s_%s' % (rosdistro_name, source_repo_spec.name.lower()),
         'cd -',  # restore pwd when used in scripts
         'echo "# END SECTION"',
@@ -219,7 +219,7 @@ if pull_request:
         ' -e=TRAVIS=$TRAVIS' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/catkin_workspace:/tmp/catkin_workspace' +
-        ' -v $CCACHE_DIR:/home/buildfarm/.ccache' +
+        ' -v ~/.ccache:/home/buildfarm/.ccache' +
         ' devel_build_and_test.%s_%s' % (rosdistro_name, source_repo_spec.name.lower()),
         'cd -',  # restore pwd when used in scripts
         'echo "# END SECTION"',

--- a/ros_buildfarm/templates/devel/devel_script.sh.em
+++ b/ros_buildfarm/templates/devel/devel_script.sh.em
@@ -13,6 +13,9 @@ echo "If you want the script to return a non-zero return code in that case"
 echo "you can set the environment variable ABORT_ON_TEST_FAILURE=1."
 echo ""
 
+# consider CCACHE_DIR from environment, otherwise set to default
+CCACHE_DIR=${CCACHE_DIR:-~/.ccache}
+
 export WORKSPACE=`pwd`
 echo "Use workspace: $WORKSPACE"
 echo ""

--- a/ros_buildfarm/templates/doc/doc_script.sh.em
+++ b/ros_buildfarm/templates/doc/doc_script.sh.em
@@ -9,6 +9,9 @@ set -e
 echo "Doc job: @doc_job_name"
 echo ""
 
+# consider CCACHE_DIR from environment, otherwise set to default
+CCACHE_DIR=${CCACHE_DIR:-~/.ccache}
+
 export WORKSPACE=`pwd`
 echo "Use workspace: $WORKSPACE"
 echo ""

--- a/ros_buildfarm/templates/prerelease/prerelease_build_overlay_script.sh.em
+++ b/ros_buildfarm/templates/prerelease/prerelease_build_overlay_script.sh.em
@@ -3,6 +3,9 @@
 # fail script if any single command fails
 set -e
 
+# consider CCACHE_DIR from environment, otherwise set to default
+CCACHE_DIR=${CCACHE_DIR:-~/.ccache}
+
 if [ -z "$WORKSPACE" ]; then
     WORKSPACE=`pwd`
     echo "Using workspace: $WORKSPACE"

--- a/ros_buildfarm/templates/prerelease/prerelease_build_underlay_script.sh.em
+++ b/ros_buildfarm/templates/prerelease/prerelease_build_underlay_script.sh.em
@@ -3,6 +3,9 @@
 # fail script if any single command fails
 set -e
 
+# consider CCACHE_DIR from environment, otherwise set to default
+CCACHE_DIR=${CCACHE_DIR:-~/.ccache}
+
 if [ -z "$WORKSPACE" ]; then
     WORKSPACE=`pwd`
     echo "Using workspace: $WORKSPACE"

--- a/ros_buildfarm/templates/release/binarydeb_job.xml.em
+++ b/ros_buildfarm/templates/release/binarydeb_job.xml.em
@@ -129,7 +129,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/binarydeb:/tmp/binarydeb' +
         ' -v $WORKSPACE/docker_build_binarydeb:/tmp/docker_build_binarydeb' +
-        ' -v $CCACHE_DIR:/home/buildfarm/.ccache' + \
+        ' -v ~/.ccache:/home/buildfarm/.ccache' + \
         ' binarydeb_task_generation.%s_%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
         'echo "# END SECTION"',
     ]),
@@ -160,7 +160,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' --net=host' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/binarydeb:/tmp/binarydeb' +
-        ' -v $CCACHE_DIR:/home/buildfarm/.ccache' +
+        ' -v ~/.ccache:/home/buildfarm/.ccache' +
         ' binarydeb_build.%s_%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
         'echo "# END SECTION"',
     ]),

--- a/ros_buildfarm/templates/release/binarydeb_job.xml.em
+++ b/ros_buildfarm/templates/release/binarydeb_job.xml.em
@@ -129,7 +129,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/binarydeb:/tmp/binarydeb' +
         ' -v $WORKSPACE/docker_build_binarydeb:/tmp/docker_build_binarydeb' +
-        ' -v ~/.ccache:/home/buildfarm/.ccache' + \
+        ' -v $CCACHE_DIR:/home/buildfarm/.ccache' + \
         ' binarydeb_task_generation.%s_%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
         'echo "# END SECTION"',
     ]),
@@ -160,7 +160,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' --net=host' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/binarydeb:/tmp/binarydeb' +
-        ' -v ~/.ccache:/home/buildfarm/.ccache' +
+        ' -v $CCACHE_DIR:/home/buildfarm/.ccache' +
         ' binarydeb_build.%s_%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
         'echo "# END SECTION"',
     ]),

--- a/ros_buildfarm/templates/release/release_script.sh.em
+++ b/ros_buildfarm/templates/release/release_script.sh.em
@@ -6,6 +6,9 @@ import os
 # fail script if any single command fails
 set -e
 
+# consider CCACHE_DIR from environment, otherwise set to default
+CCACHE_DIR=${CCACHE_DIR:-~/.ccache}
+
 echo "Source job: @source_job_name"
 echo "Binary job: @binary_job_name"
 


### PR DESCRIPTION
In private pre-release scenarios, it's useful to consider the `CCACHE_DIR` variable from the environment.
In my particular use case, my home is on a slow network volume, and thus I redirect `CCACHE_DIR` to some local, fast drive. However, without this patch `pre-release.sh` yields the following error (because the home is also Kerberos-protected and even root cannot write there):
```
docker: Error response from daemon: error while creating mount source path '/homes/rhaschke/.ccache': mkdir /homes/rhaschke/.ccache: permission denied.
```
