### PR TITLE
Updates for working with newer Jenkins versions

### DIFF
--- a/ros_buildfarm/templates/dashboard_view_all_jobs.xml.em
+++ b/ros_buildfarm/templates/dashboard_view_all_jobs.xml.em
@@ -15,7 +15,7 @@
     <hudson.views.LastSuccessColumn/>
     <hudson.views.LastFailureColumn/>
     <hudson.views.LastDurationColumn/>
-    <jenkins.plugins.extracolumns.BuildDescriptionColumn plugin="extra-columns@@1.18">
+    <jenkins.plugins.extracolumns.BuildDescriptionColumn plugin="extra-columns@@1.20">
       <columnWidth>80</columnWidth>
       <forceWidth>true</forceWidth>
     </jenkins.plugins.extracolumns.BuildDescriptionColumn>

--- a/ros_buildfarm/templates/dashboard_view_devel_jobs.xml.em
+++ b/ros_buildfarm/templates/dashboard_view_devel_jobs.xml.em
@@ -15,15 +15,15 @@
     <hudson.views.LastSuccessColumn/>
     <hudson.views.LastFailureColumn/>
     <hudson.views.LastDurationColumn/>
-    <jenkins.plugins.extracolumns.BuildDescriptionColumn plugin="extra-columns@@1.18">
+    <jenkins.plugins.extracolumns.BuildDescriptionColumn plugin="extra-columns@@1.20">
       <columnWidth>80</columnWidth>
       <forceWidth>true</forceWidth>
     </jenkins.plugins.extracolumns.BuildDescriptionColumn>
     <hudson.views.BuildButtonColumn/>
-    <jenkins.plugins.extracolumns.TestResultColumn plugin="extra-columns@@1.18">
+    <jenkins.plugins.extracolumns.TestResultColumn plugin="extra-columns@@1.20">
       <testResultFormat>1</testResultFormat>
     </jenkins.plugins.extracolumns.TestResultColumn>
-    <hudson.plugins.warnings.WarningsColumn plugin="warnings@@4.63"/>
+    <hudson.plugins.warnings.WarningsColumn plugin="warnings@@4.68"/>
   </columns>
 @[if include_regex]@
   <includeRegex>@include_regex</includeRegex>

--- a/ros_buildfarm/templates/release/trigger_jobs.groovy.em
+++ b/ros_buildfarm/templates/release/trigger_jobs.groovy.em
@@ -21,7 +21,7 @@ add_job_names_@(int(i / group_size) + 1)(job_names)
 
 @(FILE('snippet/check_recursive_upstream_projects.groovy'))@
 
-println "Triggering " + job_names.size + " jobs..."
+println "Triggering " + job_names.size() + " jobs..."
 triggered = 0
 skipped = 0
 for (job_name in job_names) {

--- a/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
+++ b/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
@@ -3,7 +3,7 @@
   <description/>
   <keepDependencies>false</keepDependencies>
   <properties>
-    <jenkins.advancedqueue.priority.strategy.PriorityJobProperty plugin="PrioritySorter@@3.5.1">
+    <jenkins.advancedqueue.priority.strategy.PriorityJobProperty plugin="PrioritySorter@@3.6.0">
       <useJobPriority>false</useJobPriority>
       <priority>-1</priority>
     </jenkins.advancedqueue.priority.strategy.PriorityJobProperty>

--- a/ros_buildfarm/templates/snippet/build-wrapper_build-timeout.xml.em
+++ b/ros_buildfarm/templates/snippet/build-wrapper_build-timeout.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@@1.18">
+    <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@@1.19">
       <strategy class="hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy">
         <timeoutMinutes>@int(timeout_minutes)</timeoutMinutes>
       </strategy>

--- a/ros_buildfarm/templates/snippet/build-wrapper_ssh-agent.xml.em
+++ b/ros_buildfarm/templates/snippet/build-wrapper_ssh-agent.xml.em
@@ -1,4 +1,4 @@
-    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.15">
+    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@@1.17">
       <credentialIds>
 @[for credential_id in credential_ids]@
         <string>@credential_id</string>

--- a/ros_buildfarm/templates/snippet/build-wrapper_timestamper.xml.em
+++ b/ros_buildfarm/templates/snippet/build-wrapper_timestamper.xml.em
@@ -1,1 +1,1 @@
-    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.8.8"/>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.8.10"/>

--- a/ros_buildfarm/templates/snippet/builder_parameterized-trigger.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_parameterized-trigger.xml.em
@@ -5,6 +5,7 @@
           <configs>
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
               <properties>@ESCAPE(parameters)</properties>
+              <textParamValueOnNewLine>false</textParamValueOnNewLine>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
 @[else]@

--- a/ros_buildfarm/templates/snippet/builder_parameterized-trigger.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_parameterized-trigger.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.parameterizedtrigger.TriggerBuilder plugin="parameterized-trigger@@2.35.1">
+    <hudson.plugins.parameterizedtrigger.TriggerBuilder plugin="parameterized-trigger@@2.35.2">
       <configs>
         <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
 @[if parameters]@

--- a/ros_buildfarm/templates/snippet/builder_publish-over-ssh.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_publish-over-ssh.xml.em
@@ -1,4 +1,4 @@
-    <jenkins.plugins.publish__over__ssh.BapSshBuilderPlugin plugin="publish-over-ssh@@1.17">
+    <jenkins.plugins.publish__over__ssh.BapSshBuilderPlugin plugin="publish-over-ssh@@1.20.1">
       <delegate>
         <consolePrefix>SSH: </consolePrefix>
         <delegate>

--- a/ros_buildfarm/templates/snippet/builder_publish-over-ssh.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_publish-over-ssh.xml.em
@@ -1,9 +1,9 @@
     <jenkins.plugins.publish__over__ssh.BapSshBuilderPlugin plugin="publish-over-ssh@@1.20.1">
       <delegate>
         <consolePrefix>SSH: </consolePrefix>
-        <delegate>
+        <delegate plugin="publish-over@@0.22">
           <publishers>
-            <jenkins.plugins.publish__over__ssh.BapSshPublisher>
+            <jenkins.plugins.publish__over__ssh.BapSshPublisher plugin="publish-over-ssh@@1.20.1">
               <configName>@config_name</configName>
               <verbose>false</verbose>
               <transfers>

--- a/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
@@ -1,7 +1,7 @@
     <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.0">
 @[if command]@
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
-        <script plugin="script-security@@1.34">
+        <script plugin="script-security@@1.48">
           <script>@ESCAPE(command)</script>
           <sandbox>false</sandbox>
         </script>

--- a/ros_buildfarm/templates/snippet/property_github-project.xml.em
+++ b/ros_buildfarm/templates/snippet/property_github-project.xml.em
@@ -1,4 +1,4 @@
-    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.28.0">
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.29.3">
       <projectUrl>@ESCAPE(project_url)</projectUrl>
       <displayName/>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>

--- a/ros_buildfarm/templates/snippet/property_job-priority.xml.em
+++ b/ros_buildfarm/templates/snippet/property_job-priority.xml.em
@@ -1,4 +1,4 @@
-    <jenkins.advancedqueue.priority.strategy.PriorityJobProperty plugin="PrioritySorter@@3.5.1">
+    <jenkins.advancedqueue.priority.strategy.PriorityJobProperty plugin="PrioritySorter@@3.6.0">
       <useJobPriority>@('true' if priority != -1 else 'false')</useJobPriority>
       <priority>@int(priority)</priority>
     </jenkins.advancedqueue.priority.strategy.PriorityJobProperty>

--- a/ros_buildfarm/templates/snippet/property_parameters-definition.xml.em
+++ b/ros_buildfarm/templates/snippet/property_parameters-definition.xml.em
@@ -12,6 +12,7 @@
           <name>@parameter['name']</name>
           <description>@(parameter['description'] if 'description' in parameter and parameter['description'] is not None else '')</description>
           <defaultValue>@(parameter['default_value'] if 'default_value' in parameter and parameter['default_value'] is not None else '')</defaultValue>
+          <trim>false</trim>
         </hudson.model.StringParameterDefinition>
 @[else]@
 @{assert False, "Unsupported parameter type '%s'" % parameter['type']}@

--- a/ros_buildfarm/templates/snippet/publisher_extended-email.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_extended-email.xml.em
@@ -1,5 +1,5 @@
 @[if recipients]@
-    <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@@2.58">
+    <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@@2.63">
       <recipientList>@ESCAPE(' '.join(sorted(recipients)))</recipientList>
       <configuredTriggers>
         <hudson.plugins.emailext.plugins.trigger.FailureTrigger>

--- a/ros_buildfarm/templates/snippet/publisher_groovy-postbuild.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_groovy-postbuild.xml.em
@@ -1,5 +1,5 @@
-    <org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder plugin="groovy-postbuild@@2.3.1">
-      <script plugin="script-security@@1.34">
+    <org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder plugin="groovy-postbuild@@2.4.2">
+      <script plugin="script-security@@1.48">
         <script>@ESCAPE(script)</script>
         <sandbox>false</sandbox>
       </script>

--- a/ros_buildfarm/templates/snippet/publisher_mailer.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_mailer.xml.em
@@ -1,5 +1,5 @@
 @[if recipients or dynamic_recipients or send_to_individuals]@
-    <hudson.tasks.Mailer plugin="mailer@@1.20">
+    <hudson.tasks.Mailer plugin="mailer@@1.22">
       <recipients>@ESCAPE(' '.join(sorted(recipients)))@ESCAPE(('\t' + ' '.join(sorted(dynamic_recipients))) if dynamic_recipients else '')</recipients>
       <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
       <sendToIndividuals>@(send_to_individuals ? 'true' ! 'false')</sendToIndividuals>

--- a/ros_buildfarm/templates/snippet/publisher_publish-over-git.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_publish-over-git.xml.em
@@ -1,4 +1,4 @@
-<hudson.plugins.git.GitPublisher plugin="git@@3.5.1">
+<hudson.plugins.git.GitPublisher plugin="git@@3.9.1">
   <configVersion>2</configVersion>
   <pushMerge>false</pushMerge>
   <pushOnlyIfSuccess>true</pushOnlyIfSuccess>

--- a/ros_buildfarm/templates/snippet/publisher_publish-over-ssh.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_publish-over-ssh.xml.em
@@ -1,4 +1,4 @@
-    <jenkins.plugins.publish__over__ssh.BapSshPublisherPlugin plugin="publish-over-ssh@@1.17">
+    <jenkins.plugins.publish__over__ssh.BapSshPublisherPlugin plugin="publish-over-ssh@@1.20.1">
       <consolePrefix>SSH: </consolePrefix>
       <delegate>
         <publishers>

--- a/ros_buildfarm/templates/snippet/publisher_publish-over-ssh.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_publish-over-ssh.xml.em
@@ -1,8 +1,8 @@
     <jenkins.plugins.publish__over__ssh.BapSshPublisherPlugin plugin="publish-over-ssh@@1.20.1">
       <consolePrefix>SSH: </consolePrefix>
-      <delegate>
+      <delegate plugin="publish-over@@0.22">
         <publishers>
-          <jenkins.plugins.publish__over__ssh.BapSshPublisher>
+          <jenkins.plugins.publish__over__ssh.BapSshPublisher plugin="publish-over-ssh@@1.20.1">
             <configName>@config_name</configName>
             <verbose>false</verbose>
             <transfers>

--- a/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.warnings.WarningsPublisher plugin="warnings@@4.63">
+    <hudson.plugins.warnings.WarningsPublisher plugin="warnings@@4.68">
       <healthy/>
       <unHealthy/>
       <thresholdLimit>low</thresholdLimit>
@@ -8,7 +8,7 @@
       <usePreviousBuildAsReference>false</usePreviousBuildAsReference>
       <useStableBuildAsReference>false</useStableBuildAsReference>
       <useDeltaValues>false</useDeltaValues>
-      <thresholds plugin="analysis-core@@1.92">
+      <thresholds plugin="analysis-core@@1.95">
 @[if unstable_threshold != '']@
         <unstableTotalAll>@unstable_threshold</unstableTotalAll>
 @[else]@

--- a/ros_buildfarm/templates/snippet/publisher_xunit.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_xunit.xml.em
@@ -1,4 +1,4 @@
-    <xunit plugin="xunit@@1.102">
+    <xunit plugin="xunit@@2.3.1">
       <types>
         <GoogleTestType>
           <pattern>@ESCAPE(pattern)</pattern>

--- a/ros_buildfarm/templates/snippet/scm_git.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_git.xml.em
@@ -1,4 +1,4 @@
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@@3.5.1">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@@3.9.1">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>

--- a/ros_buildfarm/templates/snippet/scm_hg.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_hg.xml.em
@@ -1,4 +1,4 @@
-  <scm class="hudson.plugins.mercurial.MercurialSCM" plugin="mercurial@@2.1">
+  <scm class="hudson.plugins.mercurial.MercurialSCM" plugin="mercurial@@2.4">
     <installation>Default</installation>
     <source>@ESCAPE(source)</source>
     <modules/>

--- a/ros_buildfarm/templates/snippet/scm_svn.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_svn.xml.em
@@ -1,4 +1,4 @@
-<scm class="hudson.scm.SubversionSCM" plugin="subversion@@2.9">
+<scm class="hudson.scm.SubversionSCM" plugin="subversion@@2.12.1">
   <locations>
     <hudson.scm.SubversionSCM_-ModuleLocation>
       <remote>@ESCAPE(remote)</remote>

--- a/ros_buildfarm/templates/snippet/trigger_github-pull-request-builder.xml.em
+++ b/ros_buildfarm/templates/snippet/trigger_github-pull-request-builder.xml.em
@@ -1,4 +1,4 @@
-    <org.jenkinsci.plugins.ghprb.GhprbTrigger plugin="ghprb@@1.39.0">
+    <org.jenkinsci.plugins.ghprb.GhprbTrigger plugin="ghprb@@1.42.0">
       <spec/>
       <latestVersion>3</latestVersion>
       <configVersion>3</configVersion>


### PR DESCRIPTION
Incorporating these changes will require updates to the buildfarm deployment and live Jenkins instance. As I document the process a guide will be available in ros-infrastructure/buildfarm_deployment#207 and the final version will get published to discourse.

Connects to ros-infrastructure/buildfarm_deployment#207

