### PR TITLE
gracefully work for existing job configs with using code from master

### DIFF
--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -292,7 +292,8 @@ def add_argument_build_tool(parser, required=False):
         help='The build tool to use' + default_help)
 
 
-def add_argument_ros_version(parser):
+def add_argument_ros_version(parser, required=False):
     parser.add_argument(
-        '--ros-version', type=int, required=True,
+        '--ros-version', type=int, required=required,
+        default=None if required else 1,
         help='The major ROS version')

--- a/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
@@ -74,7 +74,7 @@ cmd = \
     ' --arch ' + arch + \
     ' --distribution-repository-urls ' + ' '.join(distribution_repository_urls) + \
     ' --distribution-repository-key-files ' + ' ' .join(['/tmp/keys/%d.key' % i for i in range(len(distribution_repository_keys))]) + \
-    ' --build-tool ' + build_tool + \
+    ' --build-tool ' + (build_tool if build_tool is not None else 'catkin_make_isolated') + \
     ' --ros-version ' + str(ros_version) + \
     ' --env-vars ' + ' ' .join(env_vars)
 cmds += [

--- a/ros_buildfarm/templates/doc/doc_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_create_task.Dockerfile.em
@@ -69,7 +69,7 @@ cmds = [
     ' --os-name ' + os_name + \
     ' --os-code-name ' + os_code_name + \
     ' --arch ' + arch + \
-    ' --build-tool ' + build_tool + \
+    ' --build-tool ' + (build_tool if build_tool is not None else 'catkin_make_isolated') + \
     ' --vcs-info "%s"' % vcs_info + \
     ' --distribution-repository-urls ' + ' '.join(distribution_repository_urls) + \
     ' --distribution-repository-key-files ' + ' ' .join(['/tmp/keys/%d.key' % i for i in range(len(distribution_repository_keys))]) + \

--- a/scripts/devel/create_devel_task_generator.py
+++ b/scripts/devel/create_devel_task_generator.py
@@ -64,7 +64,7 @@ def main(argv=sys.argv[1:]):
     add_argument_distribution_repository_urls(parser)
     add_argument_distribution_repository_key_files(parser)
     add_argument_build_tool(parser, required=True)
-    add_argument_ros_version(parser)
+    add_argument_ros_version(parser, required=True)
     add_argument_env_vars(parser)
     add_argument_dockerfile_dir(parser)
     parser.add_argument(

--- a/scripts/devel/run_devel_job.py
+++ b/scripts/devel/run_devel_job.py
@@ -55,7 +55,7 @@ def main(argv=sys.argv[1:]):
         '--prerelease-overlay',
         action='store_true',
         help='Operate on two catkin workspaces')
-    add_argument_build_tool(parser, required=True)
+    add_argument_build_tool(parser)
     add_argument_ros_version(parser)
     add_argument_env_vars(parser)
     add_argument_dockerfile_dir(parser)

--- a/scripts/doc/run_doc_job.py
+++ b/scripts/doc/run_doc_job.py
@@ -50,7 +50,7 @@ def main(argv=sys.argv[1:]):
     add_argument_os_name(parser)
     add_argument_os_code_name(parser)
     add_argument_arch(parser)
-    add_argument_build_tool(parser, required=True)
+    add_argument_build_tool(parser)
     add_argument_vcs_information(parser)
     add_argument_distribution_repository_urls(parser)
     add_argument_distribution_repository_key_files(parser)


### PR DESCRIPTION
Fixes temporary regression of #585.

Existing job configuration neither pass `--build-tool` nor `--ros-version` to the `run_devel_job.py` or `run_doc_job.py` scripts. Though the updated scripts currently require these arguments. And aexample of a failing job due to this: http://build.ros.org/job/Mdev__common_msgs__ubuntu_bionic_amd64/11/

Once the jobs are being reconfigured the option `--build-tool` and `--ros-version` are always being passed so the problem goes away. In order to fix this in the meantime this patch relaxes the input requirements for these two scrips and falls back to the previous behavior. See succeeding build: http://build.ros.org/job/Mdev__common_msgs__ubuntu_bionic_amd64/13/