### PR TITLE
move back --force--cmake to test invocation

### DIFF
--- a/scripts/devel/build_and_test.py
+++ b/scripts/devel/build_and_test.py
@@ -87,7 +87,7 @@ def main(argv=sys.argv[1:]):
                     additional_args = ['--cmake-target-skip-unavailable']
                 rc = call_build_tool(
                     args.build_tool, args.rosdistro_name, args.workspace_root,
-                    cmake_args=cmake_args, force_cmake=True,
+                    cmake_args=cmake_args,
                     make_args=['tests'], args=additional_args,
                     parent_result_spaces=parent_result_spaces, env=env)
             if not rc:
@@ -113,6 +113,7 @@ def main(argv=sys.argv[1:]):
                         args.build_tool,
                         args.rosdistro_name, args.workspace_root,
                         cmake_args=cmake_args,
+                        force_cmake=args.build_tool == 'catkin_make_isolated',
                         make_args=make_args, args=additional_args,
                         parent_result_spaces=parent_result_spaces, env=env,
                         colcon_verb='test')


### PR DESCRIPTION
Follow up of https://github.com/ros-infrastructure/ros_buildfarm/pull/585#issuecomment-438002768 [restoring](https://github.com/ros-infrastructure/ros_buildfarm/pull/585/commits/0550a9f48636a89b0eea863e9f695950995412c4#diff-c9a4dba59a5ae382e62173ee29bce906L97) where `--force-cmake` is being passed.

A cloned job of `Mdev__ros_comm__ubuntu_bionic_amd64` using this branch passed all tests.