### PR TITLE
Add CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,24 @@ matrix:
       sudo: required
       services:
         - docker
+      env: JOB_TYPE=ci UNDERLAY_PACKAGES="ament_flake8 ament_pep257" OVERLAY_PACKAGES="ament_cmake_ros"
+      before_script:
+        # install colcon for test results
+        - pip install colcon-core colcon-test-result
+        - python setup.py install
+        - mkdir job job/underlay && cd job
+        - ln -s .. ros_buildfarm
+      script:
+        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME default $OS_NAME $OS_CODE_NAME2 $ARCH --packages-select $UNDERLAY_PACKAGES --build-up-to > job.sh
+        - (. job.sh -y; exit $test_result_RC)
+        - tar -xjf ros2-$ROS2_DISTRO_NAME-linux-$OS_CODE_NAME2-$ARCH-ci.tar.bz2 -C underlay
+        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME default $OS_NAME $OS_CODE_NAME2 $ARCH --packages-select $OVERLAY_PACKAGES --build-up-to --build-ignore $UNDERLAY_PACKAGES --underlay-source-path underlay/ros2-linux > job.sh
+        - (. job.sh -y; exit $test_result_RC)
+    - language: python
+      python: "3.6"
+      sudo: required
+      services:
+        - docker
       env: JOB_TYPE=devel BUILD_TOOL=colcon REPOSITORY_NAME=roscpp_core ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros2/rosdistro/ros2/index-v4.yaml
       before_script:
         # install colcon for test results

--- a/doc/jobs/ci_jobs.rst
+++ b/doc/jobs/ci_jobs.rst
@@ -1,0 +1,194 @@
+*CI* jobs
+=========
+
+A *CI* job is used for continuous integration across repositories.
+It builds the code and runs the tests to check for regressions.
+It operates on many source repositories as specified in one or more ``.repos``
+files, and is triggered to produce a nightly comprehensive archive, and can
+also be triggered manually to quickly test changes on a select set of
+packages.
+
+Each build is performed within a clean environment (provided by a Docker
+container) which only contains the specific dependencies of packages in the
+repository as well as tools needed to perform the build and any packages
+specified as part of the ``install_packages``.
+
+Entry points
+------------
+
+The following scripts are the entry points for *CI* jobs.
+The scripts operate on the default ``.repos`` file in the ROS build farm
+configuration, unless specified otherwise:
+
+* **generate_ci_maintenance_jobs.py** generates a set of jobs on the farm
+  which will perform maintenance tasks.
+
+  * The ``reconfigure-jobs`` job will (re-)configure the *CI* nightly and
+    overlay jobs on a regular basis (e.g. once every day).
+
+* **generate_ci_jobs.py** invokes *generate_ci_job.py* for both the nightly
+  configuration as well as the overlay configuration.
+* **generate_ci_job.py** generates a *CI* nightly job for for each platform
+  and architecture listed in the *CI build file*.
+* **generate_ci_script.py** generates a *shell* script which will run the
+  same tasks as the *CI* job on a local machine.
+
+The build process in detail
+---------------------------
+
+The actual build is performed within a Docker container in order to ensure
+only declared dependencies are available.
+
+The actual build process starts in the script *create_ci_task_generator.py*.
+It generates three Dockerfiles: one to perform the *create-workspace* task to
+populate the workspace and enumerate prerequisites, one to perform the
+*build-and-install* task, and one to perform the *build-and-test* task.
+
+Create workspace
+^^^^^^^^^^^^^^^^
+
+This task is performed by the script *create_workspace.py*, the ``colcon``
+executable and the ``rosdep`` executable.
+
+The task performs the following steps:
+
+* Prepare the package sources
+
+  * Fetches the ``.repos`` file(s)
+  * Fetches the source repositories containing the package(s) to be built
+  * If necessary, merges a specified branch with the current release of those
+    repositories
+
+* Select the packages which should be built, tested, and installed
+
+  * Marks the packages explicitly listed as ignored
+  * If necessary, ignores packages to reduce the buildable packages based on:
+
+    * Whether the package is specifically listed for inclusion
+    * Whether the package is within a given number of dependency steps after
+      a selected package
+    * Whether the package is a dependency of one of the selected packages
+
+* Enumerate dependencies
+
+  * Lists the dependencies necessary to build and test the remaining ROS
+    packages in the workspace, as well as the dependencies of any ROS packages
+    in the underlay workspace(s) needed to support them.
+  * Uses the rosdep tool to resolve those dependency keys to package names
+
+Build and install
+^^^^^^^^^^^^^^^^^
+
+This task is identical to `the one used by the devel jobs <devel_jobs.rst#Build-and-install>`_.
+
+Build and test
+^^^^^^^^^^^^^^
+
+This task is identical to `the one used by the devel jobs <devel_jobs.rst#Build-and-test>`_.
+
+Known limitations
+^^^^^^^^^^^^^^^^^
+
+System dependency enumeration happens for all ROS packages that are part of the
+non-underlay workspace.
+This means that any non-ROS packages present in that workspace may need their
+dependencies explicitly called out for inclusion in the ``install_package``
+list, and also means that a missing dependency may be occluded by another
+package in the workspace correctly declaring the same dependency.
+
+Run the *CI* job locally
+------------------------
+
+Example invocation
+^^^^^^^^^^^^^^^^^^
+
+The following commands run the *CI* job for the *ament_cmake_ros* package
+from ROS *Crystal* for Ubuntu *Bionic* *amd64*:
+
+.. code:: sh
+
+  mkdir /tmp/ci_job
+  generate_ci_script.py https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml crystal default ubuntu bionic amd64 --packages-select ament_cmake_ros --build-up-to > /tmp/ci_job/ci_job_crystal_ament_cmake_ros.sh
+  cd /tmp/ci_job
+  sh ci_job_crystal_ament_cmake_ros.sh
+
+Return code
+-----------
+
+The return code of the generated script will be zero if it successfully
+performed the build and ran the test even if some tests failed.
+By setting the environment variable ``ABORT_ON_TEST_FAILURE=1`` the return code
+will also be non-zero in case of failed tests.
+
+Instead of invoking the generated script it can also be *sourced*:
+
+.. code:: sh
+
+  . ci_job_crystal.sh
+
+The return code of the invocation of ``catkin_tests_results`` /
+``colcon test-result`` is then available in the environment variable
+``test_result_RC``.
+
+Run the *CI* job on Travis
+--------------------------
+
+Since it is easy to run a *CI* job locally it can also be run on Travis to
+either test every commit or pull request.
+The setup and invocation is the same as locally.
+The following .travis.yml template is a good starting point and is ready to be
+used:
+
+.. code:: yaml
+
+  # while this doesn't require sudo we don't want to run within a Docker container
+  sudo: true
+  dist: trusty
+  language: python
+  python:
+    - "3.4"
+  env:
+    global:
+      - JOB_PATH=/tmp/ci_job
+    matrix:
+      - ROS_DISTRO_NAME=crystal OS_NAME=ubuntu OS_CODE_NAME=trusty ARCH=amd64
+  install:
+    # either install the latest released version of ros_buildfarm
+    - pip install ros_buildfarm
+    # or checkout a specific branch
+    #- git clone -b master https://github.com/ros-infrastructure/ros_buildfarm /tmp/ros_buildfarm
+    #- pip install /tmp/ros_buildfarm
+
+    # use either of the two following options depending on the chosen build tool
+    # checkout catkin for catkin_test_results script
+    - git clone https://github.com/ros/catkin /tmp/catkin
+    # install colcon for test results
+    - pip install colcon-core colcon-test-result
+
+    # run CI job for a ROS repository with the same name as this repo
+    - export PACKAGES_SELECT=`basename $TRAVIS_BUILD_DIR`
+    # use the code already checked out by Travis
+    - mkdir -p $JOB_PATH/ws/src
+    - cp -R $TRAVIS_BUILD_DIR $JOB_PATH/ws/src/
+    # generate the script to run a CI job for that target and repo
+    - generate_ci_script.py https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH --packages-select $PACKAGE_SELECT --build-up-to > $JOB_PATH/ci_job.sh
+    - cd $JOB_PATH
+    - cat ci_job.sh
+    # run the actual job which involves Docker
+    - sh ci_job.sh -y
+  script:
+    # get summary of test results
+    # use either of the two following options depending on the chosen build tool
+    - /tmp/catkin/bin/catkin_test_results $JOB_PATH/ws/test_results --all
+    - colcon test-result --test-result-base $JOB_PATH/ws/test_results --all
+  notifications:
+    email: false
+
+An example can be found in the `.travis.yml <https://github.com/ros-infrastructure/ros_buildfarm/blob/master/.travis.yml>`_
+file of the *ros_buildfarm* repository.
+
+Run for "custom" repositories
+-----------------------------
+
+A *CI* job requires that repositories be listed in a ``.repos`` file hosted at
+some URL.

--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import os
 
 
@@ -312,3 +313,84 @@ def add_argument_install_pip_packages(parser):
         nargs='*',
         default=[],
         help='The list of packages to install with pip')
+
+
+def add_argument_above_depth(parser):
+    parser.add_argument(
+        '--above-depth', type=int, metavar='DEPTH', default=0,
+        help='Number of reverse-dependent packages which ' +
+             'depend upon the targeted package(s).')
+
+
+def add_argument_build_ignore(parser):
+    parser.add_argument(
+        '--build-ignore', nargs='*', metavar='PKG_NAME',
+        help='Package name(s) which should be excluded from the build')
+
+
+def add_argument_build_up_to(parser):
+    parser.add_argument(
+        '--build-up-to', action='store_true',
+        help='Include all forward dependencies of the selected ' +
+             'package(s) which are present in the workspace.')
+
+
+def add_argument_install_packages(parser):
+    parser.add_argument(
+        '--install-packages', nargs='*',
+        help='The specified package(s) will be installed prior to any '
+             'packages detected for installation by rosdep.')
+
+
+def add_argument_packages_select(parser):
+    parser.add_argument(
+        '--packages-select', nargs='*', metavar='PKG_NAME',
+        help='Package(s) to be built')
+
+
+def add_argument_repos_file_urls(parser, required=False):
+    parser.add_argument(
+        '--repos-file-urls', nargs='*', metavar='URL',
+        required=required,
+        help='URLs of repos files to import with vcs.')
+
+
+def add_argument_skip_cleanup(parser):
+    parser.add_argument(
+        '--skip-cleanup', action='store_true',
+        help='Skip cleanup of build artifacts')
+
+
+def add_argument_skip_rosdep_keys(parser):
+    parser.add_argument(
+        '--skip-rosdep-keys', nargs='*',
+        help='The specified rosdep keys will be ignored, i.e. not resolved '
+             'and not installed.')
+
+
+def add_argument_test_branch(parser):
+    parser.add_argument(
+        '--test-branch', default=None,
+        help='Branch to attempt to checkout before doing batch job.')
+
+
+def add_argument_testing(parser):
+    parser.add_argument(
+        '--testing', action='store_true',
+        help='Generate a task for testing packages rather than installing '
+             'them.')
+
+
+def check_len_action(minargs, maxargs):
+    class CheckLength(argparse.Action):
+        def __call__(self, parser, args, values, option_string=None):
+            if len(values) < minargs:
+                raise argparse.ArgumentError(
+                    argument=self,
+                    message='expected at least %s arguments' % (minargs))
+            elif len(values) > maxargs:
+                raise argparse.ArgumentError(
+                    argument=self,
+                    message='expected at most %s arguments' % (minargs))
+            setattr(args, self.dest, values)
+    return CheckLength

--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -1,0 +1,288 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+from collections import OrderedDict
+import sys
+
+from ros_buildfarm.common import get_ci_job_name
+from ros_buildfarm.common import get_ci_view_name
+from ros_buildfarm.common import get_default_node_label
+from ros_buildfarm.common import get_node_label
+from ros_buildfarm.common \
+    import get_repositories_and_script_generating_key_files
+from ros_buildfarm.common import JobValidationError
+from ros_buildfarm.common import write_groovy_script_and_configs
+from ros_buildfarm.config import get_ci_build_files
+from ros_buildfarm.config import get_distribution_file
+from ros_buildfarm.config import get_index as get_config_index
+from ros_buildfarm.git import get_repository
+from ros_buildfarm.templates import expand_template
+from rosdistro import get_index
+
+
+def configure_ci_jobs(
+        config_url, rosdistro_name, ci_build_name,
+        groovy_script=None, dry_run=False):
+    """
+    Configure all Jenkins CI jobs.
+    """
+    config = get_config_index(config_url)
+    build_files = get_ci_build_files(config, rosdistro_name)
+    build_file = build_files[ci_build_name]
+
+    index = get_index(config.rosdistro_index_url)
+
+    # get targets
+    targets = []
+    for os_name in build_file.targets.keys():
+        for os_code_name in build_file.targets[os_name].keys():
+            for arch in build_file.targets[os_name][os_code_name]:
+                targets.append((os_name, os_code_name, arch))
+    print('The build file contains the following targets:')
+    for os_name, os_code_name, arch in targets:
+        print('  -', os_name, os_code_name, arch)
+
+    dist_file = get_distribution_file(index, rosdistro_name, build_file)
+    if not dist_file:
+        print('No distribution file matches the build file')
+        return
+
+    ci_view_name = get_ci_view_name(rosdistro_name)
+
+    # all further configuration will be handled by either the Jenkins API
+    # or by a generated groovy script
+    from ros_buildfarm.jenkins import connect
+    jenkins = connect(config.jenkins_url) if groovy_script is None else False
+
+    view_configs = {}
+    views = {
+        ci_view_name: configure_ci_view(
+            jenkins, ci_view_name, dry_run=dry_run)
+    }
+    if not jenkins:
+        view_configs.update(views)
+    groovy_data = {
+        'dry_run': dry_run,
+        'expected_num_views': len(view_configs),
+    }
+
+    ci_job_names = []
+    job_configs = OrderedDict()
+
+    is_disabled = False
+
+    for os_name, os_code_name, arch in targets:
+        try:
+            job_name, job_config = configure_ci_job(
+                config_url, rosdistro_name, ci_build_name,
+                os_name, os_code_name, arch, 'nightly',
+                config=config, build_file=build_file,
+                index=index, dist_file=dist_file,
+                jenkins=jenkins, views=views,
+                is_disabled=is_disabled,
+                groovy_script=groovy_script,
+                dry_run=dry_run,
+                trigger_timer=build_file.jenkins_job_schedule)
+            ci_job_names.append(job_name)
+            if groovy_script is not None:
+                print("Configuration for job '%s'" % job_name)
+                job_configs[job_name] = job_config
+        except JobValidationError as e:
+            print(e.message, file=sys.stderr)
+
+    for os_name, os_code_name, arch in targets:
+        try:
+            nightly_job_name = get_ci_job_name(
+                rosdistro_name, os_name, os_code_name, arch, 'nightly')
+            job_name, job_config = configure_ci_job(
+                config_url, rosdistro_name, ci_build_name,
+                os_name, os_code_name, arch, 'overlay',
+                config=config, build_file=build_file,
+                index=index, dist_file=dist_file,
+                jenkins=jenkins, views=views,
+                is_disabled=is_disabled,
+                groovy_script=groovy_script,
+                dry_run=dry_run,
+                underlay_source_job=nightly_job_name,
+                underlay_source_paths=['$UNDERLAY_JOB_SPACE'])
+            ci_job_names.append(job_name)
+            if groovy_script is not None:
+                print("Configuration for job '%s'" % job_name)
+                job_configs[job_name] = job_config
+        except JobValidationError as e:
+            print(e.message, file=sys.stderr)
+
+    groovy_data['expected_num_jobs'] = len(job_configs)
+    groovy_data['job_prefixes_and_names'] = {}
+
+    if groovy_script is not None:
+        print(
+            "Writing groovy script '%s' to reconfigure %d jobs" %
+            (groovy_script, len(job_configs)))
+        content = expand_template(
+            'snippet/reconfigure_jobs.groovy.em', groovy_data)
+        write_groovy_script_and_configs(
+            groovy_script, content, job_configs, view_configs)
+
+
+def configure_ci_job(
+        config_url, rosdistro_name, ci_build_name,
+        os_name, os_code_name, arch, job_type,
+        config=None, build_file=None,
+        index=None, dist_file=None,
+        jenkins=None, views=None,
+        is_disabled=False,
+        groovy_script=None,
+        build_targets=None,
+        dry_run=False,
+        underlay_source_job=None,
+        underlay_source_paths=None,
+        trigger_timer=None):
+    """
+    Configure a single Jenkins CI job.
+
+    This includes the following steps:
+    - clone the ros_buildfarm repository
+    - write the distribution repository keys into files
+    - invoke the ci/run_ci_job.py script
+    """
+    if config is None:
+        config = get_config_index(config_url)
+    if build_file is None:
+        build_files = get_ci_build_files(config, rosdistro_name)
+        build_file = build_files[ci_build_name]
+    # Overwrite build_file.targets if build_targets is specified
+    if build_targets is not None:
+        build_file.targets = build_targets
+
+    if index is None:
+        index = get_index(config.rosdistro_index_url)
+    if dist_file is None:
+        dist_file = get_distribution_file(index, rosdistro_name, build_file)
+        if not dist_file:
+            raise JobValidationError(
+                'No distribution file matches the build file')
+
+    if os_name not in build_file.targets.keys():
+        raise JobValidationError(
+            "Invalid OS name '%s' " % os_name +
+            'choose one of the following: ' +
+            ', '.join(sorted(build_file.targets.keys())))
+    if os_code_name not in build_file.targets[os_name].keys():
+        raise JobValidationError(
+            "Invalid OS code name '%s' " % os_code_name +
+            'choose one of the following: ' +
+            ', '.join(sorted(build_file.targets[os_name].keys())))
+    if arch not in build_file.targets[os_name][os_code_name]:
+        raise JobValidationError(
+            "Invalid architecture '%s' " % arch +
+            'choose one of the following: %s' % ', '.join(sorted(
+                build_file.targets[os_name][os_code_name])))
+
+    if jenkins is None:
+        from ros_buildfarm.jenkins import connect
+        jenkins = connect(config.jenkins_url)
+    if views is None:
+        view_name = get_ci_view_name(rosdistro_name)
+        configure_ci_view(jenkins, view_name, dry_run=dry_run)
+
+    job_name = get_ci_job_name(
+        rosdistro_name, os_name, os_code_name, arch, job_type)
+
+    job_config = _get_ci_job_config(
+        index, rosdistro_name, build_file, os_name,
+        os_code_name, arch,
+        build_file.repos_files,
+        underlay_source_job,
+        underlay_source_paths,
+        trigger_timer,
+        is_disabled=is_disabled)
+    # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
+    if isinstance(jenkins, object) and jenkins is not False:
+        from ros_buildfarm.jenkins import configure_job
+        configure_job(jenkins, job_name, job_config, dry_run=dry_run)
+
+    return job_name, job_config
+
+
+def configure_ci_view(jenkins, view_name, dry_run=False):
+    from ros_buildfarm.jenkins import configure_view
+    return configure_view(
+        jenkins, view_name, include_regex='%s__.+' % view_name,
+        template_name='dashboard_view_devel_jobs.xml.em', dry_run=dry_run)
+
+
+def _get_ci_job_config(
+        index, rosdistro_name, build_file, os_name,
+        os_code_name, arch,
+        repos_files, underlay_source_job,
+        underlay_source_paths, trigger_timer,
+        is_disabled=False):
+    template_name = 'ci/ci_job.xml.em'
+
+    repository_args, script_generating_key_files = \
+        get_repositories_and_script_generating_key_files(build_file=build_file)
+
+    build_environment_variables = []
+    if build_file.build_environment_variables:
+        build_environment_variables = [
+            '%s=%s' % (var, value)
+            for var, value in build_file.build_environment_variables.items()]
+
+    distribution_type = index.distributions[rosdistro_name] \
+        .get('distribution_type', 'ros1')
+    assert distribution_type in ('ros1', 'ros2')
+    ros_version = 1 if distribution_type == 'ros1' else 2
+
+    if underlay_source_job is not None:
+        assert '$UNDERLAY_JOB_SPACE' in underlay_source_paths
+
+    job_data = {
+        'job_priority': build_file.jenkins_job_priority,
+        'node_label': get_node_label(
+            build_file.jenkins_job_label,
+            get_default_node_label('%s_%s' % (
+                rosdistro_name, 'ci'))),
+
+        'disabled': is_disabled,
+
+        'ros_buildfarm_repository': get_repository(),
+
+        'script_generating_key_files': script_generating_key_files,
+
+        'rosdistro_name': rosdistro_name,
+        'os_name': os_name,
+        'os_code_name': os_code_name,
+        'arch': arch,
+        'repository_args': repository_args,
+        'build_tool': build_file.build_tool,
+        'ros_version': ros_version,
+        'build_environment_variables': build_environment_variables,
+
+        'timeout_minutes': build_file.jenkins_job_timeout,
+
+        'repos_file_urls': repos_files,
+
+        'build_ignore': build_file.build_ignore,
+        'skip_rosdep_keys': build_file.skip_rosdep_keys,
+        'install_packages': build_file.install_packages,
+
+        'underlay_source_job': underlay_source_job,
+        'underlay_source_paths': underlay_source_paths,
+        'trigger_timer': trigger_timer,
+    }
+    job_config = expand_template(template_name, job_data)
+    return job_config

--- a/ros_buildfarm/colcon.py
+++ b/ros_buildfarm/colcon.py
@@ -1,0 +1,42 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+
+
+def locate_packages(
+    source_space, packages_select=None, packages_up_to=None,
+    packages_above_depth=None
+):
+    cmd = ['colcon', 'list', '--base-paths', source_space]
+    if packages_select:
+        cmd.append('--packages-select')
+        cmd.extend(packages_select)
+    if packages_up_to:
+        cmd.append('--packages-up-to')
+        cmd.extend(packages_up_to)
+    if packages_above_depth:
+        cmd.append('--packages-above-depth')
+        cmd.extend(packages_above_depth)
+
+    output = subprocess.check_output(cmd).decode()
+
+    packages = {}
+    for line in output.splitlines():
+        # Format is: NAME PATH (TYPE)
+        name_path = line.rsplit(None, 1)[0]
+        name, path = name_path.split(None, 1)
+        packages[name] = path
+
+    return packages

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -146,6 +146,17 @@ def get_binary_package_versions(apt_cache, debian_pkg_names):
     return versions
 
 
+def get_ci_job_name(rosdistro_name, os_name, os_code_name, arch, job_type):
+    view_name = get_ci_view_name(rosdistro_name)
+    job_name = '%s__%s_%s_%s_%s' % (view_name, job_type, os_name, os_code_name, arch)
+    return job_name
+
+
+def get_ci_view_name(rosdistro_name):
+    view_name = '%sci' % rosdistro_name[0].upper()
+    return view_name
+
+
 def get_debian_package_name_prefix(rosdistro_name):
     return 'ros-%s-' % rosdistro_name
 

--- a/ros_buildfarm/templates/ci/ci_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/ci_create_reconfigure_task.Dockerfile.em
@@ -1,0 +1,58 @@
+# generated from @template_name
+
+FROM ubuntu:xenial
+
+VOLUME ["/var/cache/apt/archives"]
+
+ENV DEBIAN_FRONTEND noninteractive
+
+@(TEMPLATE(
+    'snippet/setup_locale.Dockerfile.em',
+    timezone=timezone,
+))@
+
+RUN useradd -u @uid -m buildfarm
+
+@(TEMPLATE(
+    'snippet/add_distribution_repositories.Dockerfile.em',
+    distribution_repository_keys=distribution_repository_keys,
+    distribution_repository_urls=distribution_repository_urls,
+    os_name='ubuntu',
+    os_code_name='xenial',
+    add_source=False,
+))@
+
+@(TEMPLATE(
+    'snippet/add_wrapper_scripts.Dockerfile.em',
+    wrapper_scripts=wrapper_scripts,
+))@
+
+# automatic invalidation once every day
+RUN echo "@today_str"
+
+@(TEMPLATE(
+    'snippet/install_python3.Dockerfile.em',
+    os_name='ubuntu',
+    os_code_name='xenial',
+))@
+
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-pip python3-rosdistro-modules python3-yaml
+RUN pip3 install jenkinsapi
+
+USER buildfarm
+ENTRYPOINT ["sh", "-c"]
+@{
+cmd = \
+    'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \
+    ' /tmp/ros_buildfarm/scripts/ci/generate_ci_jobs.py' + \
+    ' ' + config_url + \
+    ' ' + rosdistro_name + \
+    ' ' + ci_build_name
+if groovy_script:
+    cmd += ' --groovy-script ' + groovy_script
+if dry_run:
+    cmd += ' --dry-run'
+if repository_names:
+    cmd += ' --repository-names ' + ' '.join(repository_names)
+}@
+CMD ["@cmd"]

--- a/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
@@ -1,8 +1,4 @@
 # generated from @template_name
-@{
-global os
-import os
-}@
 
 @(TEMPLATE(
     'snippet/from_base_image.Dockerfile.em',
@@ -14,12 +10,6 @@ import os
 VOLUME ["/var/cache/apt/archives"]
 
 ENV DEBIAN_FRONTEND noninteractive
-
-@(TEMPLATE(
-    'snippet/old_release_set.Dockerfile.em',
-    os_name=os_name,
-    os_code_name=os_code_name,
-))@
 
 @(TEMPLATE(
     'snippet/setup_locale.Dockerfile.em',
@@ -38,13 +28,6 @@ RUN useradd -u @uid -m buildfarm
 ))@
 
 @(TEMPLATE(
-    'snippet/add_additional_repositories.Dockerfile.em',
-    os_name=os_name,
-    os_code_name=os_code_name,
-    arch=arch,
-))@
-
-@(TEMPLATE(
     'snippet/add_wrapper_scripts.Dockerfile.em',
     wrapper_scripts=wrapper_scripts,
 ))@
@@ -58,48 +41,52 @@ RUN echo "@today_str"
     os_code_name=os_code_name,
 ))@
 
-@(TEMPLATE(
-    'snippet/set_environment_variables.Dockerfile.em',
-    environment_variables=build_environment_variables,
-))@
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-apt python3-empy
 
-@(TEMPLATE(
-    'snippet/install_dependencies.Dockerfile.em',
-    dependencies=dependencies,
-    dependency_versions=dependency_versions,
-))@
-
-@(TEMPLATE(
-    'snippet/rosdep_init.Dockerfile.em',
-    custom_rosdep_urls=custom_rosdep_urls,
-))@
+# always invalidate to actually have the latest apt and rosdep state
+RUN echo "@now_str"
+RUN python3 -u /tmp/wrapper_scripts/apt.py update
 
 USER buildfarm
+
 ENTRYPOINT ["sh", "-c"]
 @{
-install_paths = [os.path.join(root, 'install_isolated') for root in workspace_root[0:-1]]
-base_paths = [path for root in install_paths for path in (os.path.join(root, '*', 'share'), os.path.join(root, 'share'))] + [workspace_root[-1]]
+args = \
+    ' ' + rosdistro_name + \
+    ' ' + os_name + \
+    ' ' + os_code_name + \
+    ' ' + arch + \
+    ' --workspace-root ' + ' '.join(workspace_mount_point) + \
+    ' --distribution-repository-urls ' + ' '.join(distribution_repository_urls) + \
+    ' --distribution-repository-key-files ' + ' ' .join(['/tmp/keys/%d.key' % i for i in range(len(distribution_repository_keys))]) + \
+    ' --env-vars ' + ' ' .join(env_vars)
+build_args = args + \
+    ' --build-tool ' + build_tool + \
+    ' --ros-version ' + str(ros_version) + \
+    ' --install-packages ' + ' '.join(install_packages)
 cmds = [
-    'rosdep update',
-
     'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \
-    ' /tmp/ros_buildfarm/scripts/ci/create_workspace.py' + \
-    ' --workspace-root ' + workspace_root[-1] + \
+    ' /tmp/ros_buildfarm/scripts/ci/create_workspace_task_generator.py' + \
+    args + \
+    ' --dockerfile-dir /tmp/docker_create_workspace' + \
     ' --repos-file-urls ' + ' '.join(repos_file_urls) + \
     ' --test-branch "%s"' % (test_branch) + \
+    ' --skip-rosdep-keys ' + ' '.join(skip_rosdep_keys) + \
     ' --build-ignore ' + ' '.join(build_ignore) + \
     ' --above-depth %d' % above_depth + \
     (' --build-up-to' if build_up_to else '') + \
     ' --packages-select ' + ' '.join(packages_select),
 
     'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \
-    ' /tmp/ros_buildfarm/scripts/ci/generate_install_lists.py' + \
-    ' ' + rosdistro_name + \
-    ' ' + os_name + \
-    ' ' + os_code_name + \
-    ' --package-root ' + ' '.join(base_paths) + \
-    ' --output-dir ' + workspace_root[-1] + \
-    ' --skip-rosdep-keys ' + ' '.join(skip_rosdep_keys),
+    ' /tmp/ros_buildfarm/scripts/ci/build_task_generator.py' + \
+    build_args + \
+    ' --dockerfile-dir /tmp/docker_build_and_install',
+
+    'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \
+    ' /tmp/ros_buildfarm/scripts/ci/build_task_generator.py' + \
+    build_args + \
+    ' --testing' + \
+    ' --dockerfile-dir /tmp/docker_build_and_test',
 ]
 cmd = ' && '.join(cmds).replace('\\', '\\\\').replace('"', '\\"')
 }@

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -1,0 +1,417 @@
+<project>
+  <actions/>
+  <description>Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'@
+@[if disabled]
+but disabled since the package is blacklisted (or not whitelisted) in the configuration file@
+@[end if]@
+@ </description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+@(SNIPPET(
+    'property_log-rotator',
+    days_to_keep=730,
+    num_to_keep=100,
+))@
+@[if job_priority is not None]@
+@(SNIPPET(
+    'property_job-priority',
+    priority=job_priority,
+))@
+@[end if]@
+@(SNIPPET(
+    'property_requeue-job',
+))@
+@{
+parameters = [
+    {
+        'type': 'boolean',
+        'name': 'skip_cleanup',
+        'description': 'Skip cleanup of build artifacts as well as rosdoc index',
+    },
+    {
+        'type': 'string',
+        'name': 'install_packages',
+        'default_value': ' '.join(install_packages),
+        'description': 'Package(s) to be installed prior to any packages detected for installation by rosdep (space-separated)',
+    },
+    {
+        'type': 'string',
+        'name': 'repos_file_urls',
+        'default_value': ' '.join(repos_file_urls),
+        'description': 'URL(s) of repos file(s) containing the list of packages to be built (space-separated)',
+    },
+    {
+        'type': 'string',
+        'name': 'test_branch',
+        'default_value': '',
+        'description': 'Branch to attempt to checkout before doing batch job',
+    },
+    {
+        'type': 'string',
+        'name': 'build_ignore',
+        'default_value': ' '.join(build_ignore),
+        'description': 'Package name(s) which should be excluded from the build (space-separated)',
+    },
+    {
+        'type': 'string',
+        'name': 'packages_select',
+        'default_value': '',
+        'description': 'Package(s) to be built (space-separated), or blank for ALL',
+    },
+    {
+        'type': 'boolean',
+        'name': 'build_up_to',
+        'description': 'Include all forward dependencies of the selected package(s) which are present in the workspace',
+    },
+    {
+        'type': 'string',
+        'name': 'above_depth',
+        'default_value': '0',
+        'description': 'Number of reverse dependencies of selected packages to be include in scope',
+    },
+]
+}@
+@(SNIPPET(
+    'property_parameters-definition',
+    parameters=parameters,
+))@
+  </properties>
+  <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
+  <assignedNode>@(node_label)</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>@('true' if disabled else 'false')</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+@[if trigger_timer is not None]@
+@(SNIPPET(
+    'trigger_timer',
+    spec=trigger_timer,
+))@
+@[end if]@
+  </triggers>
+  <concurrentBuild>true</concurrentBuild>
+  <builders>
+@(SNIPPET(
+    'builder_system-groovy_check-free-disk-space',
+))@
+@(SNIPPET(
+    'builder_shell_docker-info',
+))@
+@(SNIPPET(
+    'builder_check-docker',
+    os_name=os_name,
+    os_code_name=os_code_name,
+    arch=arch,
+))@
+@(SNIPPET(
+    'builder_shell_clone-ros-buildfarm',
+    ros_buildfarm_repository=ros_buildfarm_repository,
+    wrapper_scripts=wrapper_scripts,
+))@
+@(SNIPPET(
+    'builder_shell_key-files',
+    script_generating_key_files=script_generating_key_files,
+))@
+@[if underlay_source_job is not None]@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'echo "# BEGIN SECTION: Prepare package underlay"',
+    ]),
+))@
+@(SNIPPET(
+    'copy_artifacts',
+    artifacts=[
+      '*.tar.bz2',
+    ],
+    project=underlay_source_job,
+    target_directory='$WORKSPACE/underlay',
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'tar -xjf $WORKSPACE/underlay/*.tar.bz2 -C $WORKSPACE/underlay',
+        'echo "# END SECTION"',
+    ]),
+))@
+@[end if]@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'rm -fr $WORKSPACE/docker_generating_dockers',
+        'mkdir -p $WORKSPACE/docker_generating_dockers',
+        '',
+        '# monitor all subprocesses and enforce termination',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/subprocess_reaper.py $$ --cid-file $WORKSPACE/docker_generating_dockers/docker.cid > $WORKSPACE/docker_generating_dockers/subprocess_reaper.log 2>&1 &',
+        '# sleep to give python time to startup',
+        'sleep 1',
+        '',
+        '# create a unique dockerfile name prefix',
+        'export DOCKER_IMAGE_PREFIX=$(date +%s.%N)',
+        '',
+        '# generate Dockerfile, build and run it',
+        '# generating the Dockerfiles for the actual CI tasks',
+        'echo "# BEGIN SECTION: Generate Dockerfile - CI tasks"',
+        'export TZ="%s"' % timezone,
+        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
+        'if [ "$build_up_to" = "true" ]; then BUILD_UP_TO_FLAG="--build-up-to"; fi',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/ci/run_ci_job.py' +
+        ' ' + rosdistro_name +
+        ' ' + os_name +
+        ' ' + os_code_name +
+        ' ' + arch +
+        ' ' + ' '.join(repository_args) +
+        ' --build-tool ' + build_tool +
+        ' --ros-version ' + str(ros_version) +
+        ' --env-vars ' + ' '.join([v.replace('$', '\\$',) for v in build_environment_variables]) +
+        ' --dockerfile-dir $WORKSPACE/docker_generating_dockers' +
+        ' --repos-file-urls $repos_file_urls' +
+        ' --test-branch "$test_branch"' +
+        ' --skip-rosdep-keys ' + ' '.join(skip_rosdep_keys) +
+        ' --build-ignore $build_ignore' +
+        ' --install-packages $install_packages' +
+        ' --workspace-mount-point' +
+        (' /tmp/ws' if not underlay_source_paths else \
+         ''.join([' /tmp/ws%s' % (i or '') for i in range(len(underlay_source_paths))]) +
+         ' /tmp/ws_overlay') +
+        ' --above-depth $above_depth' +
+        ' $BUILD_UP_TO_FLAG' +
+        ' --packages-select $packages_select',
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: Build Dockerfile - generating CI tasks"',
+        'cd $WORKSPACE/docker_generating_dockers',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
+        'docker build --force-rm -t $DOCKER_IMAGE_PREFIX.ci_task_generation.%s .' % (rosdistro_name),
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: Run Dockerfile - generating CI tasks"',
+        'rm -fr $WORKSPACE/docker_create_workspace',
+        'rm -fr $WORKSPACE/docker_build_and_install',
+        'rm -fr $WORKSPACE/docker_build_and_test',
+        'mkdir -p $WORKSPACE/docker_create_workspace',
+        'mkdir -p $WORKSPACE/docker_build_and_install',
+        'mkdir -p $WORKSPACE/docker_build_and_test',
+        'docker run' +
+        ' --rm ' +
+        ' --cidfile=$WORKSPACE/docker_generating_dockers/docker.cid' +
+        ' -e=HOME=/home/buildfarm' +
+        ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
+        ' -v $WORKSPACE/docker_create_workspace:/tmp/docker_create_workspace' +
+        ' -v $WORKSPACE/docker_build_and_install:/tmp/docker_build_and_install' +
+        ' -v $WORKSPACE/docker_build_and_test:/tmp/docker_build_and_test' +
+        ' $DOCKER_IMAGE_PREFIX.ci_task_generation.%s' % (rosdistro_name),
+        'cd -',  # restore pwd when used in scripts
+        'echo "# END SECTION"',
+    ]),
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        '# monitor all subprocesses and enforce termination',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/subprocess_reaper.py $$ --cid-file $WORKSPACE/docker_create_workspace/docker.cid > $WORKSPACE/docker_create_workspace/subprocess_reaper.log 2>&1 &',
+        '# sleep to give python time to startup',
+        'sleep 1',
+        '',
+        '# create a unique dockerfile name prefix',
+        'export DOCKER_IMAGE_PREFIX=$(date +%s.%N)',
+        '',
+        'echo "# BEGIN SECTION: Build Dockerfile - create workspace"',
+        '# build and run create_workspace Dockerfile',
+        'cd $WORKSPACE/docker_create_workspace',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
+        'docker build --force-rm -t $DOCKER_IMAGE_PREFIX.ci_create_workspace.%s .' % (rosdistro_name),
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: Run Dockerfile - create workspace"',
+        'export UNDERLAY_JOB_SPACE=$WORKSPACE/underlay/ros%d-linux' % (ros_version),
+        'rm -fr $WORKSPACE/ws/src',
+        'mkdir -p $WORKSPACE/ws/src',
+        '\n'.join(['mkdir -p %s' % (dir) for dir in underlay_source_paths or []]),
+        'docker run' +
+        ' --rm ' +
+        ' --cidfile=$WORKSPACE/docker_create_workspace/docker.cid' +
+        ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
+        (' -v $WORKSPACE/ws:/tmp/ws' if not underlay_source_paths else \
+         ''.join([' -v %s:/tmp/ws%s/install_isolated' % (space, i or '') for i, space in enumerate(underlay_source_paths)]) +
+         ' -v $WORKSPACE/ws:/tmp/ws_overlay') +
+        ' $DOCKER_IMAGE_PREFIX.ci_create_workspace.%s' % (rosdistro_name),
+        'cd -',  # restore pwd when used in scripts
+        'echo "# END SECTION"',
+    ]),
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'echo "# BEGIN SECTION: Copy dependency list"',
+        '/bin/cp -f $WORKSPACE/ws/install_list_build.txt $WORKSPACE/docker_build_and_install/install_list_build.txt',
+        '/bin/cp -f $WORKSPACE/ws/install_list_build.txt $WORKSPACE/docker_build_and_test/install_list_build.txt',
+        '/bin/cp -f $WORKSPACE/ws/install_list_test.txt $WORKSPACE/docker_build_and_test/install_list_test.txt',
+        'echo "# END SECTION"',
+    ]),
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        '# monitor all subprocesses and enforce termination',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/subprocess_reaper.py $$ --cid-file $WORKSPACE/docker_build_and_install/docker.cid > $WORKSPACE/docker_build_and_install/subprocess_reaper.log 2>&1 &',
+        '# sleep to give python time to startup',
+        'sleep 1',
+        '',
+        '# create a unique dockerfile name prefix',
+        'export DOCKER_IMAGE_PREFIX=$(date +%s.%N)',
+        '',
+        'echo "# BEGIN SECTION: Build Dockerfile - build and install"',
+        '# build and run build and install Dockerfile',
+        'cd $WORKSPACE/docker_build_and_install',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
+        'docker build --force-rm -t $DOCKER_IMAGE_PREFIX.ci_build_and_install.%s .' % (rosdistro_name),
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: ccache stats (before)"',
+        'mkdir -p $HOME/.ccache',
+        'docker run' +
+        ' --rm ' +
+        ' --cidfile=$WORKSPACE/docker_build_and_install/docker_ccache_before.cid' +
+        ' -e CCACHE_DIR=/home/buildfarm/.ccache' +
+        ' -v $HOME/.ccache:/home/buildfarm/.ccache' +
+        ' $DOCKER_IMAGE_PREFIX.ci_build_and_install.%s' % (rosdistro_name) +
+        ' "ccache -s"',
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: Run Dockerfile - build and install"',
+        'export UNDERLAY_JOB_SPACE=$WORKSPACE/underlay/ros%d-linux' % (ros_version),
+        'docker run' +
+        ' --rm ' +
+        ' --cidfile=$WORKSPACE/docker_build_and_install/docker.cid' +
+        ' -e CCACHE_DIR=/home/buildfarm/.ccache' +
+        ' -v $HOME/.ccache:/home/buildfarm/.ccache' +
+        ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
+        (' -v $WORKSPACE/ws:/tmp/ws' if not underlay_source_paths else \
+         ''.join([' -v %s:/tmp/ws%s/install_isolated' % (space, i or '') for i, space in enumerate(underlay_source_paths)]) +
+         ' -v $WORKSPACE/ws:/tmp/ws_overlay') +
+        ' $DOCKER_IMAGE_PREFIX.ci_build_and_install.%s' % (rosdistro_name),
+        'cd -',  # restore pwd when used in scripts
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: ccache stats (after)"',
+        'docker run' +
+        ' --rm ' +
+        ' --cidfile=$WORKSPACE/docker_build_and_install/docker_ccache_after.cid' +
+        ' -e CCACHE_DIR=/home/buildfarm/.ccache' +
+        ' -v $HOME/.ccache:/home/buildfarm/.ccache' +
+        ' $DOCKER_IMAGE_PREFIX.ci_build_and_install.%s' % (rosdistro_name) +
+        ' "ccache -s"',
+        'echo "# END SECTION"',
+    ]),
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'echo "# BEGIN SECTION: Compress install space"',
+        'tar -cjf $WORKSPACE/ros%d-%s-linux-%s-%s-ci.tar.bz2 ' % (ros_version, rosdistro_name, os_code_name, arch) +
+        ' -C $WORKSPACE/ws' +
+        ' --transform "s/^install_isolated/ros%d-linux/"' % (ros_version) +
+        ' install_isolated',
+        'echo "# END SECTION"',
+    ]),
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        '# monitor all subprocesses and enforce termination',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/subprocess_reaper.py $$ --cid-file $WORKSPACE/docker_build_and_test/docker.cid > $WORKSPACE/docker_build_and_test/subprocess_reaper.log 2>&1 &',
+        '# sleep to give python time to startup',
+        'sleep 1',
+        '',
+        '# create a unique dockerfile name prefix',
+        'export DOCKER_IMAGE_PREFIX=$(date +%s.%N)',
+        '',
+        'echo "# BEGIN SECTION: Build Dockerfile - build and test"',
+        '# build and run build and test Dockerfile',
+        'cd $WORKSPACE/docker_build_and_test',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
+        'docker build --force-rm -t $DOCKER_IMAGE_PREFIX.ci_build_and_test.%s .' % (rosdistro_name),
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: ccache stats (before)"',
+        'mkdir -p $HOME/.ccache',
+        'docker run' +
+        ' --rm ' +
+        ' --cidfile=$WORKSPACE/docker_build_and_test/docker_ccache_before.cid' +
+        ' -e CCACHE_DIR=/home/buildfarm/.ccache' +
+        ' -v $HOME/.ccache:/home/buildfarm/.ccache' +
+        ' $DOCKER_IMAGE_PREFIX.ci_build_and_test.%s' % (rosdistro_name) +
+        ' "ccache -s"',
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: Run Dockerfile - build and test"',
+        'export UNDERLAY_JOB_SPACE=$WORKSPACE/underlay/ros%d-linux' % (ros_version),
+        'rm -fr $WORKSPACE/ws/test_results',
+        'mkdir -p $WORKSPACE/ws/test_results',
+        'docker run' +
+        ' --rm ' +
+        ' --cidfile=$WORKSPACE/docker_build_and_test/docker.cid' +
+        ' -e CCACHE_DIR=/home/buildfarm/.ccache' +
+        ' -v $HOME/.ccache:/home/buildfarm/.ccache' +
+        ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
+        (' -v $WORKSPACE/ws:/tmp/ws' if not underlay_source_paths else \
+         ''.join([' -v %s:/tmp/ws%s/install_isolated' % (space, i or '') for i, space in enumerate(underlay_source_paths)]) +
+         ' -v $WORKSPACE/ws:/tmp/ws_overlay') +
+        ' $DOCKER_IMAGE_PREFIX.ci_build_and_test.%s' % (rosdistro_name),
+        'cd -',  # restore pwd when used in scripts
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: ccache stats (after)"',
+        'docker run' +
+        ' --rm ' +
+        ' --cidfile=$WORKSPACE/docker_build_and_test/docker_ccache_after.cid' +
+        ' -e CCACHE_DIR=/home/buildfarm/.ccache' +
+        ' -v $HOME/.ccache:/home/buildfarm/.ccache' +
+        ' $DOCKER_IMAGE_PREFIX.ci_build_and_test.%s' % (rosdistro_name) +
+        ' "ccache -s"',
+        'echo "# END SECTION"',
+    ]),
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'if [ "$skip_cleanup" = "false" ]; then',
+        'echo "# BEGIN SECTION: Clean up to save disk space on agents"',
+        'rm -fr ws/build_isolated',
+        'rm -fr ws/devel_isolated',
+        'rm -fr ws/install_isolated',
+        'echo "# END SECTION"',
+        'fi',
+    ]),
+))@
+  </builders>
+  <publishers>
+@(SNIPPET(
+    'publisher_warnings',
+    unstable_threshold='',
+))@
+@(SNIPPET(
+    'archive_artifacts',
+    artifacts=[
+      'ros%d-%s-linux-%s-%s-ci.tar.bz2' % (ros_version, rosdistro_name, os_code_name, arch),
+    ],
+))@
+@(SNIPPET(
+    'publisher_xunit',
+    pattern='ws/test_results/**/*.xml',
+))@
+  </publishers>
+  <buildWrappers>
+@[if timeout_minutes is not None]@
+@(SNIPPET(
+    'build-wrapper_build-timeout',
+    timeout_minutes=timeout_minutes,
+))@
+@[end if]@
+@(SNIPPET(
+    'build-wrapper_timestamper',
+))@
+  </buildWrappers>
+</project>

--- a/ros_buildfarm/templates/ci/ci_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_reconfigure-jobs_job.xml.em
@@ -1,0 +1,137 @@
+<project>
+  <actions/>
+  <description>Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+@(SNIPPET(
+    'property_log-rotator',
+    days_to_keep=100,
+    num_to_keep=100,
+))@
+@(SNIPPET(
+    'property_job-priority',
+    priority=30,
+))@
+@(SNIPPET(
+    'property_requeue-job',
+))@
+@(SNIPPET(
+    'property_parameters-definition',
+    parameters=[
+        {
+            'type': 'boolean',
+            'name': 'dry_run',
+            'description': 'Skip the actual reconfiguration but show the diffs',
+        },
+    ],
+))@
+  </properties>
+@(SNIPPET(
+    'scm_git',
+    url=ros_buildfarm_repository.url,
+    branch_name=ros_buildfarm_repository.version or 'master',
+    relative_target_dir='ros_buildfarm',
+    refspec=None,
+))@
+  <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
+  <assignedNode>agent_on_master</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+@(SNIPPET(
+    'trigger_timer',
+    spec='0 23 * * *',
+))@
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+@(SNIPPET(
+    'builder_system-groovy',
+    command=
+"""// USE PARAMETER FOR BUILD DESCRIPTION
+repository_names = build.buildVariableResolver.resolve('repository_names')
+if (repository_names) {
+  build.setDescription(repository_names)
+}
+""",
+    script_file=None,
+))@
+@(SNIPPET(
+    'builder_shell_docker-info',
+))@
+@(SNIPPET(
+    'builder_shell_key-files',
+    script_generating_key_files=script_generating_key_files,
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'rm -fr $WORKSPACE/docker_generate_ci_jobs',
+        'rm -fr $WORKSPACE/reconfigure_jobs',
+        'mkdir -p $WORKSPACE/docker_generate_ci_jobs',
+        'mkdir -p $WORKSPACE/reconfigure_jobs',
+        '',
+        '# monitor all subprocesses and enforce termination',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/subprocess_reaper.py $$ --cid-file $WORKSPACE/docker_generate_ci_jobs/docker.cid > $WORKSPACE/docker_generate_ci_jobs/subprocess_reaper.log 2>&1 &',
+        '# sleep to give python time to startup',
+        'sleep 1',
+        '',
+        '# generate Dockerfile, build and run it',
+        '# generating the Dockerfiles for the actual CI tasks',
+        'echo "# BEGIN SECTION: Generate Dockerfile - reconfigure jobs"',
+        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
+        'if [ "$dry_run" = "true" ]; then DRY_RUN_FLAG="--dry-run"; fi',
+        'if [ "$repository_names" != "" ]; then REPOSITORY_NAMES_FLAG="--repository-names $repository_names"; fi',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/ci/run_ci_reconfigure_job.py' +
+        ' ' + config_url +
+        ' ' + rosdistro_name +
+        ' ' + ci_build_name +
+        ' ' + ' '.join(repository_args) +
+        ' --groovy-script /tmp/reconfigure_jobs/reconfigure_jobs.groovy' +
+        ' --dockerfile-dir $WORKSPACE/docker_generate_ci_jobs' +
+        ' $DRY_RUN_FLAG' +
+        ' $REPOSITORY_NAMES_FLAG',
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: Build Dockerfile - reconfigure jobs"',
+        'cd $WORKSPACE/docker_generate_ci_jobs',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
+        'docker build --force-rm -t ci_reconfigure_jobs .',
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: Run Dockerfile - reconfigure jobs"',
+        '# -e=GIT_BRANCH= is required since Jenkins leaves the wc in detached state',
+        'docker run' +
+        ' --rm ' +
+        ' --cidfile=$WORKSPACE/docker_generate_ci_jobs/docker.cid' +
+        ' -e=GIT_BRANCH=$GIT_BRANCH' +
+        ' --net=host' +
+        ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
+        ' -v %s:%s:ro' % (credentials_src, credentials_dst) +
+        ' -v $WORKSPACE/reconfigure_jobs:/tmp/reconfigure_jobs' +
+        ' ci_reconfigure_jobs',
+        'echo "# END SECTION"',
+    ]),
+))@
+@(SNIPPET(
+    'builder_system-groovy',
+    command=None,
+    script_file='$WORKSPACE/reconfigure_jobs/reconfigure_jobs.groovy',
+))@
+  </builders>
+  <publishers>
+@(SNIPPET(
+    'publisher_mailer',
+    recipients=recipients,
+    dynamic_recipients=[],
+    send_to_individuals=False,
+))@
+  </publishers>
+  <buildWrappers>
+@(SNIPPET(
+    'build-wrapper_timestamper',
+))@
+  </buildWrappers>
+</project>

--- a/ros_buildfarm/templates/ci/ci_script.sh.em
+++ b/ros_buildfarm/templates/ci/ci_script.sh.em
@@ -1,0 +1,58 @@
+#!/usr/bin/env sh
+@{
+import os
+}@
+
+# fail script if any single command fails
+set -e
+
+echo "CI job: @ci_job_name"
+echo ""
+echo "By default this script will not return an error code if any tests fail."
+echo "If you want the script to return a non-zero return code in that case"
+echo "you can set the environment variable ABORT_ON_TEST_FAILURE=1."
+echo ""
+
+export WORKSPACE=`pwd`
+echo "Use workspace: $WORKSPACE"
+echo ""
+
+@(TEMPLATE(
+    'devel/devel_script_check.sh.em',
+))@
+
+@(TEMPLATE(
+    'ci/ci_script_set_parameters.sh.em',
+    parameters=parameters,
+))@
+
+echo ""
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:start:ci-clone-and-build"
+@[end if]@
+echo "Clone Repositories and Build workspace"
+echo ""
+
+@(TEMPLATE(
+    'devel/devel_script_build.sh.em',
+    scripts=scripts,
+))@
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:end:ci-clone-and-build"
+@[end if]@
+
+echo ""
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:start:ci-test-results"
+@[end if]@
+echo "Test results"
+echo ""
+
+@(TEMPLATE(
+    'devel/devel_script_test_results.sh.em',
+    build_tool=build_tool,
+    workspace_path='ws',
+))@
+@[if os.environ.get('TRAVIS') == 'true']@
+echo "travis_fold:end:ci-test-results"
+@[end if]@

--- a/ros_buildfarm/templates/ci/ci_script_set_parameters.sh.em
+++ b/ros_buildfarm/templates/ci/ci_script_set_parameters.sh.em
@@ -1,0 +1,4 @@
+# set default parameter values
+@[for key, val in sorted(parameters.items())]@
+@key="@val.replace('"', '\\"')"
+@[end for]@

--- a/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
@@ -1,0 +1,66 @@
+# generated from @template_name
+
+@(TEMPLATE(
+    'snippet/from_base_image.Dockerfile.em',
+    os_name=os_name,
+    os_code_name=os_code_name,
+    arch=arch,
+))@
+
+VOLUME ["/var/cache/apt/archives"]
+
+ENV DEBIAN_FRONTEND noninteractive
+
+@(TEMPLATE(
+    'snippet/old_release_set.Dockerfile.em',
+    os_name=os_name,
+    os_code_name=os_code_name,
+))@
+
+@(TEMPLATE(
+    'snippet/setup_locale.Dockerfile.em',
+    timezone=timezone,
+))@
+
+RUN useradd -u @uid -m buildfarm
+
+@(TEMPLATE(
+    'snippet/add_distribution_repositories.Dockerfile.em',
+    distribution_repository_keys=distribution_repository_keys,
+    distribution_repository_urls=distribution_repository_urls,
+    os_name=os_name,
+    os_code_name=os_code_name,
+    add_source=False,
+))@
+
+@(TEMPLATE(
+    'snippet/add_additional_repositories.Dockerfile.em',
+    os_name=os_name,
+    os_code_name=os_code_name,
+    arch=arch,
+))@
+
+@(TEMPLATE(
+    'snippet/add_wrapper_scripts.Dockerfile.em',
+    wrapper_scripts=wrapper_scripts,
+))@
+
+# automatic invalidation once every day
+RUN echo "@today_str"
+
+@(TEMPLATE(
+    'snippet/install_python3.Dockerfile.em',
+    os_name=os_name,
+    os_code_name=os_code_name,
+))@
+
+USER buildfarm
+ENTRYPOINT ["sh", "-c"]
+@{
+cmd = \
+    'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u'
+cmd += ' /tmp/ros_buildfarm/scripts/ci/create_workspace.py' + \
+    ' --workspace-root /tmp/workspace' + \
+    ' --repos-file-urls ' + ' '.join(repos_file_urls)
+}@
+CMD ["@cmd"]

--- a/ros_buildfarm/templates/snippet/archive_artifacts.xml.em
+++ b/ros_buildfarm/templates/snippet/archive_artifacts.xml.em
@@ -1,0 +1,8 @@
+    <hudson.tasks.ArtifactArchiver>
+      <artifacts>@(','.join(artifacts))</artifacts>
+      <allowEmptyArchive>false</allowEmptyArchive>
+      <onlyIfSuccessful>false</onlyIfSuccessful>
+      <fingerprint>false</fingerprint>
+      <defaultExcludes>true</defaultExcludes>
+      <caseSensitive>true</caseSensitive>
+    </hudson.tasks.ArtifactArchiver>

--- a/ros_buildfarm/templates/snippet/copy_artifacts.xml.em
+++ b/ros_buildfarm/templates/snippet/copy_artifacts.xml.em
@@ -1,0 +1,8 @@
+    <hudson.plugins.copyartifact.CopyArtifact plugin="copyartifact@@1.38.1">
+      <project>@(project)</project>
+      <filter>@(','.join(artifacts))</filter>
+      <target>@(target_directory)</target>
+      <excludes />
+      <selector class="hudson.plugins.copyartifact.StatusBuildSelector" />
+      <doNotFingerprintArtifacts>false</doNotFingerprintArtifacts>
+    </hudson.plugins.copyartifact.CopyArtifact>

--- a/ros_buildfarm/vcs.py
+++ b/ros_buildfarm/vcs.py
@@ -1,0 +1,36 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+
+
+def import_repositories(source_space, repository_file, target_branch):
+    cmd = ['vcs', 'import', source_space, '--force', '--retry', '5', '--input', repository_file]
+    subprocess.check_call(cmd)
+
+    if target_branch:
+        cmd = ['vcs', 'custom', source_space, '--git', '--args', 'checkout', '-b', '__ci_default']
+        subprocess.check_call(cmd)
+
+        cmd = ['vcs', 'custom', source_space, '--args', 'checkout',
+               '-b', target_branch, '--track', 'origin/%s' % target_branch]
+        subprocess.call(cmd)
+
+        cmd = ['vcs', 'custom', source_space, '--git', '--args', 'merge', '__ci_default']
+        subprocess.check_call(cmd)
+
+
+def export_repositories(source_space):
+    cmd = ['vcs', 'export', '--exact', source_space]
+    subprocess.check_call(cmd)

--- a/scripts/ci/build_task_generator.py
+++ b/scripts/ci/build_task_generator.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import sys
+
+from apt import Cache
+from ros_buildfarm.argument import add_argument_arch
+from ros_buildfarm.argument import add_argument_build_tool
+from ros_buildfarm.argument import \
+    add_argument_distribution_repository_key_files
+from ros_buildfarm.argument import add_argument_distribution_repository_urls
+from ros_buildfarm.argument import add_argument_dockerfile_dir
+from ros_buildfarm.argument import add_argument_env_vars
+from ros_buildfarm.argument import add_argument_install_packages
+from ros_buildfarm.argument import add_argument_os_code_name
+from ros_buildfarm.argument import add_argument_os_name
+from ros_buildfarm.argument import add_argument_ros_version
+from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.argument import add_argument_testing
+from ros_buildfarm.argument import check_len_action
+from ros_buildfarm.common import get_binary_package_versions
+from ros_buildfarm.common import get_distribution_repository_keys
+from ros_buildfarm.common import get_user_id
+from ros_buildfarm.templates import create_dockerfile
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Generate a 'Dockerfile' for the CI job")
+
+    # Positional
+    add_argument_rosdistro_name(parser)
+    add_argument_os_name(parser)
+    add_argument_os_code_name(parser)
+    add_argument_arch(parser)
+
+    add_argument_build_tool(parser, required=True)
+    add_argument_distribution_repository_key_files(parser)
+    add_argument_distribution_repository_urls(parser)
+    add_argument_dockerfile_dir(parser)
+    add_argument_env_vars(parser)
+    add_argument_install_packages(parser)
+    add_argument_ros_version(parser)
+    add_argument_testing(parser)
+    parser.add_argument(
+        '--workspace-root', nargs='*',
+        action=check_len_action(1, 2),
+        help='The root path of the workspace to compile')
+    args = parser.parse_args(argv)
+
+    apt_cache = Cache()
+
+    debian_pkg_names = set(['build-essential'])
+    debian_pkg_names.update(args.install_packages)
+    if args.build_tool == 'colcon':
+        debian_pkg_names.update([
+            'python3-catkin-pkg-modules',
+            'python3-colcon-ros',
+            'python3-colcon-test-result',
+            'python3-rosdistro-modules',
+        ])
+
+    print('Always install the following generic dependencies:')
+    for debian_pkg_name in sorted(debian_pkg_names):
+        print('  -', debian_pkg_name)
+
+    install_list = 'install_list.txt'
+    write_install_list(
+        os.path.join(args.dockerfile_dir, install_list),
+        debian_pkg_names, apt_cache)
+    install_lists = [install_list, 'install_list_build.txt']
+    if args.testing:
+        install_lists.append('install_list_test.txt')
+
+    # generate Dockerfile
+    data = {
+        'os_name': args.os_name,
+        'os_code_name': args.os_code_name,
+        'arch': args.arch,
+
+        'distribution_repository_urls': args.distribution_repository_urls,
+        'distribution_repository_keys': get_distribution_repository_keys(
+            args.distribution_repository_urls,
+            args.distribution_repository_key_files),
+
+        'rosdistro_name': args.rosdistro_name,
+
+        'uid': get_user_id(),
+
+        'build_tool': args.build_tool,
+        'ros_version': args.ros_version,
+
+        'build_environment_variables': args.env_vars,
+
+        'install_lists': install_lists,
+        'dependencies': [],
+        'dependency_versions': [],
+
+        'testing': args.testing,
+        'prerelease_overlay': len(args.workspace_root) > 1,
+    }
+    create_dockerfile(
+        'devel/devel_task.Dockerfile.em', data, args.dockerfile_dir)
+
+    # output hints about necessary volumes to mount
+    ros_buildfarm_basepath = os.path.normpath(
+        os.path.join(os.path.dirname(__file__), '..', '..'))
+    print('Mount the following volumes when running the container:')
+    print('  -v %s:/tmp/ros_buildfarm:ro' % ros_buildfarm_basepath)
+    if len(args.workspace_root) == 1:
+        print('  -v %s:/tmp/ws' % args.workspace_root[0])
+    else:
+        for i, workspace_root in enumerate(args.workspace_root[0:-1]):
+            print('  -v %s:/tmp/ws%s' % (workspace_root, i or ''))
+        print('  -v %s:/tmp/ws_overlay' % args.workspace_root[-1])
+
+
+def write_install_list(install_list_path, debian_pkg_names, apt_cache):
+    debian_pkg_versions = get_binary_package_versions(apt_cache, debian_pkg_names)
+    with open(install_list_path, 'w') as out_file:
+        for pkg, pkg_version in sorted(debian_pkg_versions.items()):
+            out_file.write('%s=%s\n' % (pkg, pkg_version))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/ci/create_workspace.py
+++ b/scripts/ci/create_workspace.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import sys
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Create a colcon workspace from vcs repos files.")
+    parser.add_argument(
+        '--workspace-root',
+        help='The path of the desired workspace',
+        required=True)
+    parser.add_argument(
+        '--repos-file-urls',
+        help='URLs of repos files to import with vcs.',
+        nargs='*',
+        required=True)
+    args = parser.parse_args(argv)
+
+    if not os.path.isdir(args.workspace_root):
+        # TODO(nuclearsandwich) proper error out
+        print('no workspace')
+        sys.exit(1)
+    # get all repos files a la https://github.com/ros2/ci/pull/66/files#diff-dcc9b88c6bfa21d6151296e463494a16R395
+    # vcs import each of them
+    # Run vcs export --exact to get exact commit ids.
+
+
+if __name__ == '__main__':
+    sys.exit(main())
+
+

--- a/scripts/ci/create_workspace.py
+++ b/scripts/ci/create_workspace.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2018 Open Source Robotics Foundation, Inc.
+# Copyright 2019 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,32 +16,102 @@
 
 import argparse
 import os
+from pathlib import Path
 import sys
+from urllib.request import urlretrieve
+
+from ros_buildfarm.argument import add_argument_above_depth
+from ros_buildfarm.argument import add_argument_build_ignore
+from ros_buildfarm.argument import add_argument_build_up_to
+from ros_buildfarm.argument import add_argument_packages_select
+from ros_buildfarm.argument import add_argument_repos_file_urls
+from ros_buildfarm.argument import add_argument_test_branch
+from ros_buildfarm.colcon import locate_packages
+from ros_buildfarm.common import Scope
+from ros_buildfarm.vcs import export_repositories, import_repositories
+from ros_buildfarm.workspace import ensure_workspace_exists
+
 
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
-        description="Create a colcon workspace from vcs repos files.")
+        description='Create a workspace from vcs repos files.')
+    add_argument_above_depth(parser)
+    add_argument_build_ignore(parser)
+    add_argument_build_up_to(parser)
+    add_argument_packages_select(parser)
+    add_argument_repos_file_urls(parser, required=True)
+    add_argument_test_branch(parser)
     parser.add_argument(
         '--workspace-root',
         help='The path of the desired workspace',
         required=True)
-    parser.add_argument(
-        '--repos-file-urls',
-        help='URLs of repos files to import with vcs.',
-        nargs='*',
-        required=True)
     args = parser.parse_args(argv)
 
-    if not os.path.isdir(args.workspace_root):
-        # TODO(nuclearsandwich) proper error out
-        print('no workspace')
-        sys.exit(1)
-    # get all repos files a la https://github.com/ros2/ci/pull/66/files#diff-dcc9b88c6bfa21d6151296e463494a16R395
-    # vcs import each of them
-    # Run vcs export --exact to get exact commit ids.
+    ensure_workspace_exists(args.workspace_root)
+
+    os.chdir(args.workspace_root)
+
+    with Scope('SUBSECTION', 'fetch repos files(s)'):
+        repos_files = []
+        for repos_file_url in args.repos_file_urls:
+            repos_file = os.path.join(args.workspace_root, os.path.basename(repos_file_url))
+            print('Fetching \'%s\' to \'%s\'' % (repos_file_url, repos_file))
+            urlretrieve(repos_file_url, repos_file)
+            repos_files += [repos_file]
+
+    with Scope('SUBSECTION', 'import repositories'):
+        source_space = os.path.join(args.workspace_root, 'src')
+        for repos_file in repos_files:
+            print('Importing repositories from \'%s\'' % (repos_file))
+            import_repositories(source_space, repos_file, args.test_branch)
+
+    with Scope('SUBSECTION', 'vcs export --exact'):
+        export_repositories(args.workspace_root)
+
+    with Scope('SUBSECTION', 'mark package(s) to ignore'):
+        if args.build_ignore:
+            source_space = os.path.join(args.workspace_root, 'src')
+            packages = locate_packages(source_space, args.build_ignore)
+            for package_name, package_root in packages.items():
+                print("Ignoring package '%s'" % (package_name,))
+                Path(package_root, 'COLCON_IGNORE').touch()
+
+    with Scope('SUBSECTION', 'select target package(s) in workspace'):
+        packages = locate_packages(source_space)
+        if args.packages_select:
+            selected_packages = set()
+            print('Selecting %d packages by name' % len(args.packages_select))
+            if args.above_depth:
+                packages_above_depth = [str(args.above_depth)] + \
+                    args.packages_select
+                after = locate_packages(
+                    source_space,
+                    packages_above_depth=packages_above_depth).keys()
+                print('Selecting %d packages after current selection' %
+                      (len(after) - len(args.packages_select)))
+                selected_packages |= after
+            if args.build_up_to:
+                packages_up_to = selected_packages or args.packages_select
+                up_to = locate_packages(
+                    source_space,
+                    packages_up_to=packages_up_to).keys()
+                print('Selecting %d dependencies of current selection' %
+                      (len(up_to) - len(packages_up_to)))
+                selected_packages |= up_to
+            if not selected_packages:
+                selected_packages = locate_packages(
+                    source_space,
+                    packages_select=args.packages_select).keys()
+
+            to_ignore = packages.keys() - selected_packages
+            print('Ignoring %d packages to scope workspace' % len(to_ignore))
+            for package in to_ignore:
+                package_root = packages.pop(package)
+                Path(package_root, 'COLCON_IGNORE').touch()
+
+        print('There are %d packages which meet selection criteria' %
+              len(packages))
 
 
 if __name__ == '__main__':
     sys.exit(main())
-
-

--- a/scripts/ci/create_workspace_task_generator.py
+++ b/scripts/ci/create_workspace_task_generator.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+
+from apt import Cache
+from ros_buildfarm.argument import add_argument_above_depth
+from ros_buildfarm.argument import add_argument_arch
+from ros_buildfarm.argument import add_argument_build_ignore
+from ros_buildfarm.argument import add_argument_build_up_to
+from ros_buildfarm.argument import \
+    add_argument_distribution_repository_key_files
+from ros_buildfarm.argument import add_argument_distribution_repository_urls
+from ros_buildfarm.argument import add_argument_dockerfile_dir
+from ros_buildfarm.argument import add_argument_env_vars
+from ros_buildfarm.argument import add_argument_os_code_name
+from ros_buildfarm.argument import add_argument_os_name
+from ros_buildfarm.argument import add_argument_packages_select
+from ros_buildfarm.argument import add_argument_repos_file_urls
+from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.argument import add_argument_skip_rosdep_keys
+from ros_buildfarm.argument import add_argument_test_branch
+from ros_buildfarm.common import get_binary_package_versions
+from ros_buildfarm.common import get_distribution_repository_keys
+from ros_buildfarm.common import get_user_id
+from ros_buildfarm.templates import create_dockerfile
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Generate a 'Dockerfile' for the CI job")
+
+    # Positional
+    add_argument_rosdistro_name(parser)
+    add_argument_os_name(parser)
+    add_argument_os_code_name(parser)
+    add_argument_arch(parser)
+
+    add_argument_above_depth(parser)
+    add_argument_build_ignore(parser)
+    add_argument_build_up_to(parser)
+    add_argument_distribution_repository_key_files(parser)
+    add_argument_distribution_repository_urls(parser)
+    add_argument_dockerfile_dir(parser)
+    add_argument_env_vars(parser)
+    add_argument_packages_select(parser)
+    add_argument_repos_file_urls(parser, required=True)
+    add_argument_skip_rosdep_keys(parser)
+    add_argument_test_branch(parser)
+    parser.add_argument(
+        '--workspace-root',
+        nargs='+',
+        help='The root path of the workspace to compile')
+    args = parser.parse_args(argv)
+
+    debian_pkg_names = [
+        'git',
+        'python3-apt',
+        'python3-colcon-common-extensions',
+        'python3-rosdep',
+        'python3-vcstool',
+    ]
+
+    # get versions for build dependencies
+    apt_cache = Cache()
+    debian_pkg_versions = get_binary_package_versions(
+        apt_cache, debian_pkg_names)
+
+    # generate Dockerfile
+    data = {
+        'os_name': args.os_name,
+        'os_code_name': args.os_code_name,
+        'arch': args.arch,
+
+        'distribution_repository_urls': args.distribution_repository_urls,
+        'distribution_repository_keys': get_distribution_repository_keys(
+            args.distribution_repository_urls,
+            args.distribution_repository_key_files),
+
+        'rosdistro_name': args.rosdistro_name,
+
+        'custom_rosdep_urls': [],
+
+        'uid': get_user_id(),
+
+        'build_environment_variables': args.env_vars,
+
+        'dependencies': debian_pkg_names,
+        'dependency_versions': debian_pkg_versions,
+
+        'repos_file_urls': args.repos_file_urls,
+        'test_branch': args.test_branch,
+
+        'skip_rosdep_keys': args.skip_rosdep_keys,
+        'build_ignore': args.build_ignore,
+
+        'above_depth': args.above_depth,
+        'build_up_to': args.build_up_to,
+        'packages_select': args.packages_select,
+
+        'workspace_root': args.workspace_root,
+    }
+    create_dockerfile(
+        'ci/create_workspace.Dockerfile.em', data, args.dockerfile_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/ci/generate_ci_job.py
+++ b/scripts/ci/generate_ci_job.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+
+from ros_buildfarm.argument import add_argument_arch
+from ros_buildfarm.argument import add_argument_build_name
+from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_os_code_name
+from ros_buildfarm.argument import add_argument_os_name
+from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.ci_job import configure_ci_job
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Generate a 'CI' job on Jenkins")
+
+    # Positional
+    add_argument_config_url(parser)
+    add_argument_rosdistro_name(parser)
+    add_argument_build_name(parser, 'ci')
+    add_argument_os_name(parser)
+    add_argument_os_code_name(parser)
+    add_argument_arch(parser)
+    args = parser.parse_args(argv)
+
+    configure_ci_job(
+        args.config_url, args.rosdistro_name, args.ci_build_name,
+        args.os_name, args.os_code_name, args.arch)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/ci/generate_ci_jobs.py
+++ b/scripts/ci/generate_ci_jobs.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+
+from ros_buildfarm.argument import add_argument_build_name
+from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_dry_run
+from ros_buildfarm.argument import add_argument_groovy_script
+from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.ci_job import configure_ci_jobs
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Generate the 'CI' jobs on Jenkins")
+
+    # Positional
+    add_argument_config_url(parser)
+    add_argument_rosdistro_name(parser)
+    add_argument_build_name(parser, 'ci')
+
+    add_argument_dry_run(parser)
+    add_argument_groovy_script(parser)
+    args = parser.parse_args(argv)
+
+    return configure_ci_jobs(
+        args.config_url, args.rosdistro_name, args.ci_build_name,
+        groovy_script=args.groovy_script, dry_run=args.dry_run)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/ci/generate_ci_maintenance_jobs.py
+++ b/scripts/ci/generate_ci_maintenance_jobs.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import sys
+
+from ros_buildfarm.argument import add_argument_build_name
+from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_dry_run
+from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.common import get_ci_view_name
+from ros_buildfarm.common import \
+    get_repositories_and_script_generating_key_files
+from ros_buildfarm.config import get_ci_build_files
+from ros_buildfarm.config import get_index
+from ros_buildfarm.git import get_repository
+from ros_buildfarm.jenkins import configure_job
+from ros_buildfarm.jenkins import configure_management_view
+from ros_buildfarm.jenkins import connect
+from ros_buildfarm.jenkins_credentials import get_relative_credential_path
+from ros_buildfarm.templates import expand_template
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Generate the 'CI' management jobs on Jenkins")
+
+    # Positional
+    add_argument_config_url(parser)
+    add_argument_rosdistro_name(parser)
+    add_argument_build_name(parser, 'ci')
+
+    add_argument_dry_run(parser)
+    args = parser.parse_args(argv)
+
+    config = get_index(args.config_url)
+    build_files = get_ci_build_files(config, args.rosdistro_name)
+    build_file = build_files[args.ci_build_name]
+
+    jenkins = connect(config.jenkins_url)
+    configure_management_view(jenkins, dry_run=args.dry_run)
+    group_name = get_ci_view_name(args.rosdistro_name)
+
+    configure_reconfigure_jobs_job(
+        jenkins, group_name, args, config, build_file, dry_run=args.dry_run)
+
+
+def configure_reconfigure_jobs_job(
+        jenkins, group_name, args, config, build_file, dry_run=False):
+    job_config = get_reconfigure_jobs_job_config(args, config, build_file)
+    job_name = '%s_%s' % (group_name, 'reconfigure-jobs')
+    configure_job(jenkins, job_name, job_config, dry_run=dry_run)
+
+
+def get_reconfigure_jobs_job_config(args, config, build_file):
+    template_name = 'ci/ci_reconfigure-jobs_job.xml.em'
+
+    repository_args, script_generating_key_files = \
+        get_repositories_and_script_generating_key_files(config=config)
+
+    job_data = {
+        'script_generating_key_files': script_generating_key_files,
+
+        'config_url': args.config_url,
+        'rosdistro_name': args.rosdistro_name,
+        'ci_build_name': args.ci_build_name,
+        'repository_args': repository_args,
+
+        'ros_buildfarm_repository': get_repository(),
+
+        'credentials_src': os.path.join(
+            '~', os.path.dirname(get_relative_credential_path())),
+        'credentials_dst': os.path.join(
+            '/home/buildfarm',
+            os.path.dirname(get_relative_credential_path())),
+
+        'recipients': build_file.notify_emails,
+    }
+    job_config = expand_template(template_name, job_data)
+    return job_config
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/ci/generate_ci_script.py
+++ b/scripts/ci/generate_ci_script.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import sys
+
+from em import BANGPATH_OPT
+from em import Hook
+from ros_buildfarm.argument import add_argument_above_depth
+from ros_buildfarm.argument import add_argument_arch
+from ros_buildfarm.argument import add_argument_build_ignore
+from ros_buildfarm.argument import add_argument_build_name
+from ros_buildfarm.argument import add_argument_build_tool
+from ros_buildfarm.argument import add_argument_build_up_to
+from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_os_code_name
+from ros_buildfarm.argument import add_argument_os_name
+from ros_buildfarm.argument import add_argument_packages_select
+from ros_buildfarm.argument import add_argument_repos_file_urls
+from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.argument import add_argument_skip_cleanup
+from ros_buildfarm.argument import add_argument_test_branch
+from ros_buildfarm.ci_job import configure_ci_job
+from ros_buildfarm.common import get_ci_job_name
+from ros_buildfarm.config import get_ci_build_files
+from ros_buildfarm.config import get_index as get_config_index
+from ros_buildfarm.templates import expand_template
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Generate a 'CI' script")
+
+    # Positional
+    add_argument_config_url(parser)
+    add_argument_rosdistro_name(parser)
+    add_argument_build_name(parser, 'ci')
+    add_argument_os_name(parser)
+    add_argument_os_code_name(parser)
+    add_argument_arch(parser)
+
+    add_argument_above_depth(parser)
+    add_argument_build_ignore(parser)
+    add_argument_build_tool(parser)
+    add_argument_build_up_to(parser)
+    add_argument_packages_select(parser)
+    add_argument_repos_file_urls(parser)
+    add_argument_skip_cleanup(parser)
+    add_argument_test_branch(parser)
+    parser.add_argument(
+        '--underlay-source-path', nargs='*', metavar='DIR_NAME',
+        help='Path to one or more install spaces to use as an underlay')
+    args = parser.parse_args(argv)
+
+    # collect all template snippets of specific types
+    class IncludeHook(Hook):
+
+        def __init__(self):
+            Hook.__init__(self)
+            self.scms = []
+            self.scripts = []
+            self.parameters = {}
+
+            if args.skip_cleanup:
+                self.parameters['skip_cleanup'] = 'true'
+            if args.repos_file_urls is not None:
+                self.parameters['repos_file_urls'] = ' '.join(args.repos_file_urls)
+            if args.test_branch is not None:
+                self.parameters['test_branch'] = args.test_branch
+            if args.build_ignore is not None:
+                self.parameters['build_ignore'] = ' '.join(args.build_ignore)
+            if args.packages_select is not None:
+                self.parameters['packages_select'] = ' '.join(args.packages_select)
+            if args.above_depth is not None:
+                self.parameters['above_depth'] = str(args.above_depth)
+            if args.build_up_to is not None:
+                self.parameters['build_up_to'] = 'true' if args.build_up_to else 'false'
+
+        def beforeInclude(self, *_, **kwargs):
+            template_path = kwargs['file'].name
+            if template_path.endswith('/snippet/scm.xml.em'):
+                self.scms.append(
+                    (kwargs['locals']['repo_spec'], kwargs['locals']['path']))
+            if template_path.endswith('/snippet/builder_shell.xml.em'):
+                script = kwargs['locals']['script']
+                # reuse existing ros_buildfarm folder if it exists
+                if 'Clone ros_buildfarm' in script:
+                    lines = script.splitlines()
+                    lines.insert(0, 'if [ ! -d "ros_buildfarm" ]; then')
+                    lines += [
+                        'else',
+                        'echo "Using existing ros_buildfarm folder"',
+                        'fi',
+                    ]
+                    script = '\n'.join(lines)
+                if args.build_tool and ' --build-tool ' in script:
+                    script = script.replace(
+                        ' --build-tool catkin_make_isolated',
+                        ' --build-tool ' + args.build_tool)
+                self.scripts.append(script)
+            if template_path.endswith('/snippet/property_parameters-definition.xml.em'):
+                for parameter in reversed(kwargs['locals']['parameters']):
+                    name = parameter['name']
+                    value_type = parameter['type']
+                    if value_type in ['string', 'text']:
+                        default_value = parameter['default_value']
+                    elif value_type == 'boolean':
+                        default_value = 'true' if parameter.get(
+                            'default_value', False) else 'false'
+                    else:
+                        continue
+
+                    self.parameters.setdefault(name, default_value)
+
+    hook = IncludeHook()
+    from ros_buildfarm import templates
+    templates.template_hooks = [hook]
+
+    config = get_config_index(args.config_url)
+    build_files = get_ci_build_files(config, args.rosdistro_name)
+    build_file = build_files[args.ci_build_name]
+
+    underlay_source_paths = [os.path.abspath(p) for p in args.underlay_source_path or []]
+
+    configure_ci_job(
+        args.config_url, args.rosdistro_name, args.ci_build_name,
+        args.os_name, args.os_code_name, args.arch,
+        config=config, build_file=build_file, jenkins=False, views=False,
+        job_type='script',
+        underlay_source_paths=underlay_source_paths)
+
+    templates.template_hooks = None
+
+    ci_job_name = get_ci_job_name(
+        args.rosdistro_name, args.os_name,
+        args.os_code_name, args.arch, 'script')
+
+    value = expand_template(
+        'ci/ci_script.sh.em', {
+            'ci_job_name': ci_job_name,
+            'scms': hook.scms,
+            'scripts': hook.scripts,
+            'build_tool': args.build_tool or build_file.build_tool,
+            'parameters': hook.parameters},
+        options={BANGPATH_OPT: False})
+    value = value.replace('python3 ', sys.executable + ' ')
+    print(value)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/ci/generate_install_lists.py
+++ b/scripts/ci/generate_install_lists.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import sys
+
+from apt import Cache
+from catkin_pkg.packages import find_packages
+from ros_buildfarm.argument import add_argument_os_code_name
+from ros_buildfarm.argument import add_argument_os_name
+from ros_buildfarm.argument import add_argument_output_dir
+from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.argument import add_argument_skip_rosdep_keys
+from ros_buildfarm.common import get_binary_package_versions
+from ros_buildfarm.common import Scope
+from rosdep2 import create_default_installer_context
+from rosdep2.catkin_support import get_catkin_view
+from rosdep2.catkin_support import resolve_for_os
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description='Lists available binary packages and versions which are'
+                    'needed to satisfy rosdep keys for ROS packages in the workspace')
+
+    # Positional
+    add_argument_rosdistro_name(parser)
+    add_argument_os_name(parser)
+    add_argument_os_code_name(parser)
+
+    add_argument_output_dir(parser)
+    add_argument_skip_rosdep_keys(parser)
+    parser.add_argument(
+        '--package-root',
+        nargs='+',
+        help='The path to the directory containing packages')
+    args = parser.parse_args(argv)
+
+    with Scope('SUBSECTION', 'Enumerating packages needed to build'):
+        # find all of the underlay packages
+        underlay_pkgs = {}
+        for package_root in args.package_root[0:-1]:
+            print("Crawling for packages in '%s'" % package_root)
+            underlay_pkgs.update(find_packages(package_root))
+
+        underlay_pkg_names = [pkg.name for pkg in underlay_pkgs.values()]
+        print('Found the following underlay packages:')
+        for pkg_name in sorted(underlay_pkg_names):
+            print('  -', pkg_name)
+
+        # get direct build dependencies
+        package_root = args.package_root[-1]
+        print("Crawling for packages in '%s'" % package_root)
+        pkgs = find_packages(package_root)
+
+        pkg_names = [pkg.name for pkg in pkgs.values()]
+        print('Found the following packages:')
+        for pkg_name in sorted(pkg_names):
+            print('  -', pkg_name)
+
+        # get build dependencies and map them to binary packages
+        all_pkgs = set(pkgs.values()).union(underlay_pkgs.values())
+
+        for pkg in all_pkgs:
+            pkg.evaluate_conditions(os.environ)
+        for pkg in all_pkgs:
+            for group_depend in pkg.group_depends:
+                if group_depend.evaluated_condition:
+                    group_depend.extract_group_members(all_pkgs)
+
+        dependency_keys_build = get_dependencies(
+            all_pkgs, 'build', _get_build_and_recursive_run_dependencies,
+            pkgs.values())
+
+        dependency_keys_test = get_dependencies(
+            all_pkgs, 'run and test', _get_test_and_recursive_run_dependencies,
+            pkgs.values())
+
+        if args.skip_rosdep_keys:
+            dependency_keys_build.difference_update(args.skip_rosdep_keys)
+            dependency_keys_test.difference_update(args.skip_rosdep_keys)
+
+        context = initialize_resolver(
+            args.rosdistro_name, args.os_name, args.os_code_name)
+
+        os_pkg_names_build = resolve_names(dependency_keys_build, **context)
+        os_pkg_names_test = resolve_names(dependency_keys_test, **context)
+
+        os_pkg_names_test -= os_pkg_names_build
+
+    with Scope('SUBSECTION', 'Resolving packages versions using apt cache'):
+        apt_cache = Cache()
+        os_pkg_versions = get_binary_package_versions(
+            apt_cache, os_pkg_names_build | os_pkg_names_test)
+
+    with open(os.path.join(args.output_dir, 'install_list_build.txt'), 'w') as out_file:
+        for package in sorted(os_pkg_names_build):
+            out_file.write('%s=%s\n' % (package, os_pkg_versions[package]))
+
+    with open(os.path.join(args.output_dir, 'install_list_test.txt'), 'w') as out_file:
+        for package in sorted(os_pkg_names_test):
+            out_file.write('%s=%s\n' % (package, os_pkg_versions[package]))
+
+
+def get_dependencies(pkgs, label, get_dependencies_callback, target_pkgs):
+    pkg_names = [pkg.name for pkg in pkgs]
+    depend_names = set([])
+    for pkg in target_pkgs:
+        depend_names.update(
+            [d for d in get_dependencies_callback(pkg, pkgs)
+             if d not in pkg_names])
+    print('Identified the following %s dependencies ' % label +
+          '(ignoring packages available from source):')
+    for depend_name in sorted(depend_names):
+        print('  -', depend_name)
+    return depend_names
+
+
+def _get_build_and_recursive_run_dependencies(pkg, pkgs):
+    depends = [d.name for d in pkg.build_depends + pkg.buildtool_depends]
+    # include recursive run dependencies on other pkgs in the workspace
+    # if pkg A in the workspace build depends on pkg B in the workspace
+    # then the recursive run dependencies of pkg B need to be installed
+    # in order to build the workspace
+    other_pkgs_by_names = \
+        dict([(p.name, p) for p in pkgs if p.name != pkg.name])
+    run_depends_in_pkgs = \
+        set([d for d in depends if d in other_pkgs_by_names])
+    while run_depends_in_pkgs:
+        # pick first element from sorted order to ensure deterministic results
+        pkg_name = sorted(run_depends_in_pkgs).pop(0)
+        pkg = other_pkgs_by_names[pkg_name]
+        other_pkgs_by_names.pop(pkg_name)
+        run_depends_in_pkgs.remove(pkg_name)
+
+        # append run dependencies
+        run_depends = [d.name for d in pkg.build_export_depends +
+                       pkg.buildtool_export_depends + pkg.exec_depends]
+
+        # append group dependencies
+        run_depends += [member for group in pkg.group_depends for member in group.members]
+
+        depends += run_depends
+
+        # consider recursive dependencies
+        run_depends_in_pkgs.update(
+            [d for d in run_depends if d in other_pkgs_by_names])
+
+    return depends
+
+
+def _get_test_and_recursive_run_dependencies(pkg, pkgs):
+    depends = [d.name for d in pkg.build_export_depends +
+               pkg.buildtool_export_depends + pkg.exec_depends +
+               pkg.test_depends]
+    # include recursive run dependencies on other pkgs in the workspace
+    # if pkg A in the workspace test depends on pkg B in the workspace
+    # then the recursive run dependencies of pkg B need to be installed
+    # in order to test the workspace
+    other_pkgs_by_names = \
+        dict([(p.name, p) for p in pkgs if p.name != pkg.name])
+    run_depends_in_pkgs = \
+        set([d for d in depends if d in other_pkgs_by_names])
+    while run_depends_in_pkgs:
+        # pick first element from sorted order to ensure deterministic results
+        pkg_name = sorted(run_depends_in_pkgs).pop(0)
+        pkg = other_pkgs_by_names[pkg_name]
+        other_pkgs_by_names.pop(pkg_name)
+        run_depends_in_pkgs.remove(pkg_name)
+
+        # append run dependencies
+        run_depends = [d.name for d in pkg.build_export_depends +
+                       pkg.buildtool_export_depends + pkg.exec_depends]
+
+        # append group dependencies
+        run_depends += [member for group in pkg.group_depends for member in group.members]
+
+        depends += run_depends
+
+        # consider recursive dependencies
+        run_depends_in_pkgs.update(
+            [d for d in run_depends if d in other_pkgs_by_names])
+
+    return depends
+
+
+def _get_run_and_test_dependencies(pkg, pkgs):
+    return pkg.build_export_depends + pkg.buildtool_export_depends + \
+        pkg.exec_depends + pkg.test_depends
+
+
+def initialize_resolver(rosdistro_name, os_name, os_code_name):
+    # resolve rosdep keys into binary package names
+    ctx = create_default_installer_context()
+    try:
+        installer_key = ctx.get_default_os_installer_key(os_name)
+    except KeyError:
+        raise RuntimeError(
+            "Could not determine the rosdep installer for '%s'" % os_name)
+    installer = ctx.get_installer(installer_key)
+    view = get_catkin_view(rosdistro_name, os_name, os_code_name, update=False)
+    return {
+        'os_name': os_name,
+        'os_code_name': os_code_name,
+        'installer': installer,
+        'view': view,
+    }
+
+
+def resolve_names(rosdep_keys, os_name, os_code_name, view, installer):
+    debian_pkg_names = set([])
+    for rosdep_key in sorted(rosdep_keys):
+        try:
+            resolved_names = resolve_for_os(
+                rosdep_key, view, installer, os_name, os_code_name)
+        except KeyError:
+            raise RuntimeError(
+                "Could not resolve the rosdep key '%s'" % rosdep_key)
+        debian_pkg_names.update(resolved_names)
+    print('Resolved the dependencies to the following binary packages:')
+    for debian_pkg_name in sorted(debian_pkg_names):
+        print('  -', debian_pkg_name)
+    return debian_pkg_names
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/ci/run_ci_job.py
+++ b/scripts/ci/run_ci_job.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import copy
+import sys
+
+from ros_buildfarm.argument import add_argument_above_depth
+from ros_buildfarm.argument import add_argument_arch
+from ros_buildfarm.argument import add_argument_build_ignore
+from ros_buildfarm.argument import add_argument_build_tool
+from ros_buildfarm.argument import add_argument_build_up_to
+from ros_buildfarm.argument import \
+    add_argument_distribution_repository_key_files
+from ros_buildfarm.argument import add_argument_distribution_repository_urls
+from ros_buildfarm.argument import add_argument_dockerfile_dir
+from ros_buildfarm.argument import add_argument_env_vars
+from ros_buildfarm.argument import add_argument_install_packages
+from ros_buildfarm.argument import add_argument_os_code_name
+from ros_buildfarm.argument import add_argument_os_name
+from ros_buildfarm.argument import add_argument_packages_select
+from ros_buildfarm.argument import add_argument_repos_file_urls
+from ros_buildfarm.argument import add_argument_ros_version
+from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.argument import add_argument_skip_rosdep_keys
+from ros_buildfarm.argument import add_argument_test_branch
+from ros_buildfarm.common import get_distribution_repository_keys
+from ros_buildfarm.common import get_user_id
+from ros_buildfarm.templates import create_dockerfile
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Run the 'CI' job")
+
+    # Positional
+    add_argument_rosdistro_name(parser)
+    add_argument_os_name(parser)
+    add_argument_os_code_name(parser)
+    add_argument_arch(parser)
+
+    add_argument_above_depth(parser)
+    add_argument_build_ignore(parser)
+    add_argument_build_tool(parser, required=True)
+    add_argument_build_up_to(parser)
+    add_argument_distribution_repository_key_files(parser)
+    add_argument_distribution_repository_urls(parser)
+    add_argument_dockerfile_dir(parser)
+    add_argument_env_vars(parser)
+    add_argument_install_packages(parser)
+    add_argument_packages_select(parser)
+    add_argument_repos_file_urls(parser, required=True)
+    add_argument_ros_version(parser)
+    add_argument_skip_rosdep_keys(parser)
+    add_argument_test_branch(parser)
+    parser.add_argument(
+        '--workspace-mount-point', nargs='*',
+        help='Locations within the docker image where the workspace(s) '
+             'will be mounted when the docker image is run.')
+    args = parser.parse_args(argv)
+
+    data = copy.deepcopy(args.__dict__)
+    data.update({
+        'distribution_repository_urls': args.distribution_repository_urls,
+        'distribution_repository_keys': get_distribution_repository_keys(
+            args.distribution_repository_urls,
+            args.distribution_repository_key_files),
+        'uid': get_user_id(),
+    })
+    create_dockerfile(
+        'ci/ci_create_tasks.Dockerfile.em', data, args.dockerfile_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/ci/run_ci_reconfigure_job.py
+++ b/scripts/ci/run_ci_reconfigure_job.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import copy
+import sys
+
+from ros_buildfarm.argument import add_argument_build_name
+from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import \
+    add_argument_distribution_repository_key_files
+from ros_buildfarm.argument import add_argument_distribution_repository_urls
+from ros_buildfarm.argument import add_argument_dockerfile_dir
+from ros_buildfarm.argument import add_argument_dry_run
+from ros_buildfarm.argument import add_argument_groovy_script
+from ros_buildfarm.argument import add_argument_repository_names
+from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.common import get_distribution_repository_keys
+from ros_buildfarm.common import get_user_id
+from ros_buildfarm.templates import create_dockerfile
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Run the 'CI' reconfigure job")
+
+    # Positional
+    add_argument_config_url(parser)
+    add_argument_rosdistro_name(parser)
+    add_argument_build_name(parser, 'ci')
+
+    add_argument_distribution_repository_key_files(parser)
+    add_argument_distribution_repository_urls(parser)
+    add_argument_dockerfile_dir(parser)
+    add_argument_dry_run(parser)
+    add_argument_groovy_script(parser)
+    add_argument_repository_names(parser)
+    args = parser.parse_args(argv)
+
+    data = copy.deepcopy(args.__dict__)
+    data.update({
+        'distribution_repository_urls': args.distribution_repository_urls,
+        'distribution_repository_keys': get_distribution_repository_keys(
+            args.distribution_repository_urls,
+            args.distribution_repository_key_files),
+
+        'uid': get_user_id(),
+    })
+    create_dockerfile(
+        'ci/ci_create_reconfigure_task.Dockerfile.em',
+        data, args.dockerfile_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/generate_all_jobs.py
+++ b/scripts/generate_all_jobs.py
@@ -20,6 +20,7 @@ import os
 import sys
 
 from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.config import get_ci_build_files
 from ros_buildfarm.config import get_doc_build_files
 from ros_buildfarm.config import get_index
 from ros_buildfarm.config import get_release_build_files
@@ -108,6 +109,12 @@ def main(argv=sys.argv[1:]):
         for source_build_name in source_build_files.keys():
             generate_devel_maintenance_jobs(
                 args.config_url, ros_distro_name, source_build_name,
+                dry_run=not args.commit)
+
+        ci_build_files = get_ci_build_files(config, ros_distro_name)
+        for ci_build_name in ci_build_files.keys():
+            generate_ci_maintenance_jobs(
+                args.config_url, ros_distro_name, ci_build_name,
                 dry_run=not args.commit)
 
         doc_build_files = get_doc_build_files(config, ros_distro_name)
@@ -235,6 +242,19 @@ def generate_release_maintenance_jobs(
         config_url,
         ros_distro_name,
         release_build_name,
+    ]
+    if dry_run:
+        cmd.append('--dry-run')
+    _check_call(cmd)
+
+
+def generate_ci_maintenance_jobs(
+        config_url, ros_distro_name, ci_build_name, dry_run=False):
+    cmd = [
+        _resolve_script('ci', 'generate_ci_maintenance_jobs.py'),
+        config_url,
+        ros_distro_name,
+        ci_build_name,
     ]
     if dry_run:
         cmd.append('--dry-run')


### PR DESCRIPTION
TODO list for this feature:
- [x] Workspace bringup
- [x] Colcon build and test
- [x] Docker invalidation based on
  - Changes in the repos file
  - Changes in the rosdep index
  - Changes in the base OS' package versions
- [x] Output artifact for use as underlay for subsequent job
- [x] ccache
- [x] Jenkins parameters
- [x] Lots of other `ros_buildfarm_config` values (priority, etc)
- [x] Scheduling
- [x] Overlay job
- [x] Documentation
  - [x] Build file / Configuration - [configuration_options.rst](https://github.com/ros-infrastructure/ros_buildfarm/blob/ci-builds/doc/configuration_options.rst#specific-options-in-ci-build-files)
  - [x] Usage - [ci_jobs.rst](https://github.com/ros-infrastructure/ros_buildfarm/blob/ci-builds/doc/jobs/ci_jobs.rst)
- [x] Catkin support
- [x] Package selection
- [x] Non-Jenkins / Script support
- [x] Travis CI entry invoking the script version of the job
- [x] Solve the installed package enumeration issue in Colcon (remove the hacky workaround)
    This may not be as complicated as I thought - at least some of the issues I was trying to work around are actually package bugs that can be fixed.
- [x] Support for overlay job on the script version of the job (and subsequent Travis entry)
- [x] Solve or work around the locals vs globals issue in template expansion.
    This is needed to support referencing other variables in generator expressions.
- [x] Explore concurrency challenges on workers
    After discussing this, I think there will be some work to do here.