### PR TITLE
Use Bourne shell / dash compatible shell condition.

### DIFF
--- a/ros_buildfarm/templates/snippet/add_additional_repositories.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/add_additional_repositories.Dockerfile.em
@@ -38,7 +38,7 @@ for component in ('contrib', 'non-free'):
 }@
 RUN @(' && '.join(commands))
 # Make sure to install apt-transport-https since some CloudFront mirrors are currently being redirected to https
-RUN for i in 1 2 3; do apt-get update && apt-get install -q -y apt-transport-https && apt-get clean && break || if [[ $i < 3 ]]; then sleep 5; else false; fi; done
+RUN for i in 1 2 3; do apt-get update && apt-get install -q -y apt-transport-https && apt-get clean && break || if [ $i -lt 3 ]; then sleep 5; else false; fi; done
 # Hit cloudfront mirror because of corrupted packages on fastly mirrors (https://github.com/ros-infrastructure/ros_buildfarm/issues/455)
 # You can remove this line to target the default mirror or replace this to use the mirror of your preference
 RUN sed -i 's/httpredir\.debian\.org/cloudfront.debian.net/' /etc/apt/sources.list

--- a/ros_buildfarm/templates/snippet/add_distribution_repositories.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/add_distribution_repositories.Dockerfile.em
@@ -9,7 +9,7 @@ ubuntu_before_bionic = (
 @[if os_name == 'debian' and os_code_name not in debian_before_stretch or os_name == 'ubuntu' and os_code_name not in ubuntu_before_bionic]@
 @# In Debian Stretch apt doesn't depend on gnupg anymore
 @# https://anonscm.debian.org/cgit/apt/apt.git/commit/?id=87d468fe355c87325c943c40043a0bb236b2407f
-RUN for i in 1 2 3; do apt-get update && apt-get install -q -y gnupg && apt-get clean && break || if [[ $i < 3 ]]; then sleep 5; else false; fi; done
+RUN for i in 1 2 3; do apt-get update && apt-get install -q -y gnupg && apt-get clean && break || if [ $i -lt 3 ]; then sleep 5; else false; fi; done
 @[end if]@
 @[for i, key in enumerate(distribution_repository_keys)]@
 RUN echo "@('\\n'.join(key.splitlines()))" > /tmp/keys/@(i).key && apt-key add /tmp/keys/@(i).key
@@ -22,5 +22,5 @@ RUN echo deb-src @url @os_code_name main | tee -a /etc/apt/sources.list.d/buildf
 @[end for]@
 @# On Ubuntu Trusty a newer version of dpkg is required to install Debian packages created by stdeb on newer distros
 @[if os_name == 'ubuntu' and os_code_name == 'trusty']@
-RUN for i in 1 2 3; do apt-get update && apt-get install -q -y dpkg && apt-get clean && break || if [[ $i < 3 ]]; then sleep 5; else false; fi; done
+RUN for i in 1 2 3; do apt-get update && apt-get install -q -y dpkg && apt-get clean && break || if [ $i -lt 3 ]; then sleep 5; else false; fi; done
 @[end if]@

--- a/ros_buildfarm/templates/snippet/install_python3.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/install_python3.Dockerfile.em
@@ -1,4 +1,4 @@
 @[if os_name == 'debian' or os_name == 'ubuntu' and os_code_name not in ['trusty', 'utopic']]@
 @# Ubuntu Saucy, Vivid and newer have neither Python 2 nor 3 installed by default
-RUN for i in 1 2 3; do apt-get update && apt-get install -q -y python3 && apt-get clean && break || if [[ $i < 3 ]]; then sleep 5; else false; fi; done
+RUN for i in 1 2 3; do apt-get update && apt-get install -q -y python3 && apt-get clean && break || if [ $i -lt 3 ]; then sleep 5; else false; fi; done
 @[end if]@

--- a/ros_buildfarm/templates/snippet/setup_locale.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/setup_locale.Dockerfile.em
@@ -1,4 +1,4 @@
-RUN for i in 1 2 3; do apt-get update && apt-get install -q -y locales && apt-get clean && break || if [[ $i < 3 ]]; then sleep 5; else false; fi; done
+RUN for i in 1 2 3; do apt-get update && apt-get install -q -y locales && apt-get clean && break || if [ $i -lt 3 ]; then sleep 5; else false; fi; done
 RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
The construct is used in dockerfile templates to retry failed apt install attempts.

An example of the retry logic failing is in: http://build.ros.org/view/Mbin_uB64/job/Msrc_uB__mbf_costmap_core__ubuntu_bionic__source/3

```
4.432  Step 4/23 : RUN for i in 1 2 3; do apt-get update && apt-get install -q -y locales && apt-get clean && break || if [[ $i < 3 ]]; then sleep 5; else false; fi; done
6.357   ---> Running in 7502b438c932
8.001  Get:1 http://security.ubuntu.com/ubuntu bionic-security InRelease [83.2 kB]
### Output elided ###
319.879  Err:1 http://archive.ubuntu.com/ubuntu bionic/main amd64 locales all 2.27-3ubuntu1
319.883    Connection failed [IP: 91.189.88.161 80]
319.883  E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/g/glibc/locales_2.27-3ubuntu1_all.deb  Connection failed [IP: 91.189.88.161 80]
319.883  E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
319.885  /bin/sh: 1: cannot open 3: No such file
319.885  /bin/sh: 1: [[: not found
```

The problematic command is this one from the Dockerfile template:

    RUN for i in 1 2 3; do apt-get update && \
    apt-get install -q -y locales && apt-get clean && \
    break || if [[ $i < 3 ]]; then sleep 5; else false; fi; done

This doesn't work in the /bin/sh implementation used by Debian and Ubuntu Docker images which use dash, the Debian Almquist Shell [1].

The `[[ $i < 3 ]]` construct is not valid Bourne shell, but easy to miss since it works in many current shell implementations. In Bourne shell it's an attempt to run the command `[[ $i` with the file `3` directed to
its stdin and is failing to find the command `[[`.

The changed version uses the [ alias of the test command and the arithmetic -lt less-than comparison. If a bash version is preferred we could wrap the entire thing in bash -c '...' but if we do so we should
change ``[[ $i < 3 ]]` to a `(( $i < 3 ))` to ensure arithmetic comparison rather than string comparison best illustrated by the following examples:

    bash -c 'if [[ 10 < 3 ]]; then echo yikes; else echo phew; fi'
    bash -c 'if (( 10 < 3 )); then echo yikes; else echo phew; fi'

[1]: https://en.wikipedia.org/wiki/Almquist_shell#dash:_Ubuntu,_Debian_and_POSIX_compliance_of_Linux_distributions