### PR TITLE
only consider same type distros when looking for previous distro

### DIFF
--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -696,6 +696,13 @@ def _get_blocked_releases_info(config_url, rosdistro_name, repo_names=None):
         rosdistro_name = valid_rosdistro_names[-1]
     print('Checking packages for "%s" distribution' % rosdistro_name)
 
+    # skip distributions with a different type if the information is available
+    distro_type = index.distributions[rosdistro_name].get('distribution_type')
+    if distro_type is not None:
+        valid_rosdistro_names = [
+            n for n in valid_rosdistro_names
+            if distro_type == index.distributions[n].get('distribution_type')]
+
     # Find the previous distribution to the current one
     try:
         i = valid_rosdistro_names.index(rosdistro_name)


### PR DESCRIPTION
Similar to ros-infrastructure/bloom#501.

When checking the previous distro for information for the compare status page only consider distros with the same type.

This will enable merging the two `rosdistro` databases without a side effect on the compare status pages.