### PR TITLE
Use globals to expose data values to templates

### DIFF
--- a/ros_buildfarm/templates/__init__.py
+++ b/ros_buildfarm/templates/__init__.py
@@ -73,10 +73,6 @@ def expand_template(template_name, data, options=None):
 
     output = StringIO()
     try:
-        interpreter = CachingInterpreter(output=output, options=options)
-        for template_hook in template_hooks or []:
-            interpreter.addHook(template_hook)
-        template_path = get_template_path(template_name)
         # create copy before manipulating
         data = dict(data)
         # add some generic information to context
@@ -93,11 +89,16 @@ def expand_template(template_name, data, options=None):
 
         _add_helper_functions(data)
 
+        interpreter = CachingInterpreter(output=output, options=options, globals=data)
+        for template_hook in template_hooks or []:
+            interpreter.addHook(template_hook)
+        template_path = get_template_path(template_name)
+
         with open(template_path, 'r') as h:
             content = h.read()
             interpreter.invoke(
-                'beforeFile', name=template_name, file=h, locals=data)
-        interpreter.string(content, template_path, locals=data)
+                'beforeFile', name=template_name, file=h, locals=None)
+        interpreter.string(content, template_path)
         interpreter.invoke('afterFile')
 
         value = output.getvalue()


### PR DESCRIPTION
The way local scope is handled in Python 2 vs Python 3 differs, and using locals to pass initial template data to EmPy results in unexpected behavior when a new local scope is created, for example, when a generator expression is used. While the current implementation works as expected in Python 2, in Python 3, the presence of locals during an `exec` can make variables appear undefined.

Take the following examples - the first passes only globals, the second locals and globals:
```python
exec("import os; foo = [os.path.join('a', str(baz)) for baz in range(0, 5)]; print(foo)", {})
exec("import os; foo = [os.path.join('a', str(baz)) for baz in range(0, 5)]; print(foo)", {}, {})
```
Both act the same in Python 2, but in Python 3, the second raises `NameError`.

This affects not only the data we're passing to the template, but also any values defined within the template itself, which can be very difficult to work around.

Since we know the values prior to processing, we can expose these values as globals instead.