### PR TITLE
Fix return codes from some job generation scripts

### DIFF
--- a/scripts/devel/generate_devel_job.py
+++ b/scripts/devel/generate_devel_job.py
@@ -39,7 +39,7 @@ def main(argv=sys.argv[1:]):
     add_argument_arch(parser)
     args = parser.parse_args(argv)
 
-    return configure_devel_job(
+    configure_devel_job(
         args.config_url, args.rosdistro_name, args.source_build_name,
         args.repository_name, args.os_name, args.os_code_name, args.arch)
 

--- a/scripts/doc/generate_doc_job.py
+++ b/scripts/doc/generate_doc_job.py
@@ -39,7 +39,7 @@ def main(argv=sys.argv[1:]):
     add_argument_arch(parser)
     args = parser.parse_args(argv)
 
-    return configure_doc_job(
+    configure_doc_job(
         args.config_url, args.rosdistro_name, args.doc_build_name,
         args.repository_name, args.os_name, args.os_code_name, args.arch)
 

--- a/scripts/release/generate_release_job.py
+++ b/scripts/release/generate_release_job.py
@@ -39,7 +39,7 @@ def main(argv=sys.argv[1:]):
     add_argument_arch(parser)
     args = parser.parse_args(argv)
 
-    return configure_release_job(
+    configure_release_job(
         args.config_url, args.rosdistro_name, args.release_build_name,
         args.package_name, args.os_name, args.os_code_name)
 


### PR DESCRIPTION
When the job objects are passed to `sys.exit`, it results in a non-zero return value from the program.

If you'd still like the job object to be printed to the console, I'd be happy to adjust this PR to do that.