### PR TITLE
Use separate file for passing package lists to Dockerfiles

### DIFF
--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -70,9 +70,8 @@ RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
 ))@
 
 @(TEMPLATE(
-    'snippet/install_dependencies.Dockerfile.em',
-    dependencies=dependencies,
-    dependency_versions=dependency_versions,
+    'snippet/install_dependencies_from_file.Dockerfile.em',
+    install_lists=install_lists,
 ))@
 
 USER buildfarm

--- a/ros_buildfarm/templates/snippet/install_dependencies_from_file.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/install_dependencies_from_file.Dockerfile.em
@@ -1,0 +1,4 @@
+@[for install_list in install_lists]@
+COPY @(install_list) .
+RUN xargs -a @(install_list) python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y -o Debug::pkgProblemResolver=yes
+@[end for]@


### PR DESCRIPTION
The contents of these files are hashed as part of the dockerfile builds, so the behavior isn't changing. Using the install list dramatically reduces the complexity of the dockerfile, and allows the list to be
modified or created after generation, but before build.

Spin-off from #590