### PR TITLE
Handle relocation of externally-built workspaces

### DIFF
--- a/ros_buildfarm/workspace.py
+++ b/ros_buildfarm/workspace.py
@@ -117,11 +117,13 @@ def call_build_tool(
         setup_file = os.path.join(parent_result_space, 'setup.sh')
         if os.path.exists(setup_file):
             cmd = '. %s && %s' % (setup_file, cmd)
-            if os.path.isfile(os.path.join(
-                    parent_result_space, '.catkin')):
+            if os.path.isfile(
+                os.path.join(parent_result_space, '.catkin')
+            ):
                 cmd = '_CATKIN_SETUP_DIR=%s %s' % (parent_result_space, cmd)
-            if os.path.isfile(os.path.join(
-                    parent_result_space, '.colcon_install_layout')):
+            if os.path.isfile(
+                os.path.join(parent_result_space, '.colcon_install_layout')
+            ):
                 cmd = 'COLCON_CURRENT_PREFIX=%s %s' % (parent_result_space, cmd)
 
     print("Invoking '%s' in '%s'" % (cmd, workspace_root))

--- a/ros_buildfarm/workspace.py
+++ b/ros_buildfarm/workspace.py
@@ -117,6 +117,12 @@ def call_build_tool(
         setup_file = os.path.join(parent_result_space, 'setup.sh')
         if os.path.exists(setup_file):
             cmd = '. %s && %s' % (setup_file, cmd)
+            if os.path.isfile(os.path.join(
+                    parent_result_space, '.catkin')):
+                cmd = '_CATKIN_SETUP_DIR=%s %s' % (parent_result_space, cmd)
+            if os.path.isfile(os.path.join(
+                    parent_result_space, '.colcon_install_layout')):
+                cmd = 'COLCON_CURRENT_PREFIX=%s %s' % (parent_result_space, cmd)
 
     print("Invoking '%s' in '%s'" % (cmd, workspace_root))
     return subprocess.call(


### PR DESCRIPTION
The setup.sh can't reliably determine the location of the workspace, and will assume that the workspace is in the same location as it was initially built unless told otherwise.

This is a requirement of the build tool which built the workspace, not necessarily the build tool being used in the current build, so we should set the variable regardless of whether we're using catkin or colcon.

Spin-off from #590