### PR TITLE
Support flake8 3.5.0 and fix various linter violations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 *.egg-info
 __pycache__
 *.pyc
+.pytest_cache

--- a/ros_buildfarm/config/build_file.py
+++ b/ros_buildfarm/config/build_file.py
@@ -21,7 +21,7 @@ class BuildFile(object):
         self.build_environment_variables = None
         if 'build_environment_variables' in data:
             self.build_environment_variables = \
-                    data['build_environment_variables']
+                data['build_environment_variables']
             assert(isinstance(self.build_environment_variables, dict))
 
         self.notify_emails = []

--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -155,7 +155,8 @@ def build_release_status_page(
     if not os.path.exists(yaml_folder):
         os.mkdir(yaml_folder)
 
-    yaml_filename = os.path.join(yaml_folder, 'ros_%s_%s.yaml' % (rosdistro_name, release_build_name))
+    yaml_filename = os.path.join(
+        yaml_folder, 'ros_%s_%s.yaml' % (rosdistro_name, release_build_name))
     write_yaml(yaml_filename, ordered_pkgs, repos_data)
 
 
@@ -1048,6 +1049,8 @@ def _compare_package_version(distros, pkg_name):
 
 
 REPOS_DATA_NAMES = ['build', 'test', 'main']
+
+
 def write_yaml(yaml_filename, ordered_pkgs, repos_data):
     print("Generating status yaml '%s':" % yaml_filename)
     summary = {}

--- a/scripts/devel/create_devel_task_generator.py
+++ b/scripts/devel/create_devel_task_generator.py
@@ -20,15 +20,14 @@ import sys
 
 from apt import Cache
 from catkin_pkg.packages import find_packages
+from ros_buildfarm.argument import add_argument_build_tool
 from ros_buildfarm.argument import \
     add_argument_distribution_repository_key_files
-from ros_buildfarm.argument import add_argument_build_tool
 from ros_buildfarm.argument import add_argument_distribution_repository_urls
 from ros_buildfarm.argument import add_argument_dockerfile_dir
 from ros_buildfarm.argument import add_argument_env_vars
 from ros_buildfarm.argument import add_argument_ros_version
 from ros_buildfarm.common import get_binary_package_versions
-from ros_buildfarm.common import get_debian_package_name
 from ros_buildfarm.common import get_distribution_repository_keys
 from ros_buildfarm.common import get_user_id
 from ros_buildfarm.templates import create_dockerfile

--- a/scripts/devel/run_devel_job.py
+++ b/scripts/devel/run_devel_job.py
@@ -30,9 +30,9 @@ from ros_buildfarm.argument import add_argument_env_vars
 from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
 from ros_buildfarm.argument import add_argument_repository_name
+from ros_buildfarm.argument import add_argument_ros_version
 from ros_buildfarm.argument import add_argument_rosdistro_index_url
 from ros_buildfarm.argument import add_argument_rosdistro_name
-from ros_buildfarm.argument import add_argument_ros_version
 from ros_buildfarm.common import get_distribution_repository_keys
 from ros_buildfarm.common import get_user_id
 from ros_buildfarm.templates import create_dockerfile

--- a/scripts/misc/generate_failing_jobs_job.py
+++ b/scripts/misc/generate_failing_jobs_job.py
@@ -26,6 +26,7 @@ from ros_buildfarm.jenkins import configure_management_view
 from ros_buildfarm.jenkins import connect
 from ros_buildfarm.templates import expand_template
 
+
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
         description="Generate the 'failing_jobs' job on Jenkins")

--- a/scripts/release/generate_release_trigger_upload_jobs.py
+++ b/scripts/release/generate_release_trigger_upload_jobs.py
@@ -19,8 +19,8 @@ import sys
 
 from ros_buildfarm.argument import add_argument_config_url
 from ros_buildfarm.argument import add_argument_dry_run
-from ros_buildfarm.common import JobValidationError
 from ros_buildfarm.common import get_release_job_prefix
+from ros_buildfarm.common import JobValidationError
 from ros_buildfarm.config import get_index
 from ros_buildfarm.config import get_release_build_files
 from ros_buildfarm.jenkins import configure_job

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -42,6 +42,8 @@ def get_style_guide(argv=None):
     # this is a fork of flake8.api.legacy.get_style_guide
     # to allow passing command line argument
     application = Application()
+    application.parse_preliminary_options_and_args(argv)
+    application.make_config_finder()
     application.find_plugins()
     application.register_plugin_options()
     application.parse_configuration_and_cli(argv)


### PR DESCRIPTION
The way the .travis.yml is configured, we aren't currently running the linters, and it looks like this has led to some buildup. This change doesn't get it 100% clean, but it makes progress to that end.

The flake8 3.5.0 change was taken from the `pytest_flake8` upstream: https://github.com/tholo/pytest-flake8/pull/35