### PR TITLE
Support expression of dependencies via install list file

### DIFF
--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -75,6 +75,11 @@ RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
     dependency_versions=dependency_versions,
 ))@
 
+@(TEMPLATE(
+    'snippet/install_dependencies_from_file.Dockerfile.em',
+    install_lists=install_lists,
+))@
+
 USER buildfarm
 ENTRYPOINT ["sh", "-c"]
 @{

--- a/ros_buildfarm/templates/doc/doc_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_task.Dockerfile.em
@@ -66,6 +66,11 @@ RUN pip3 install -U setuptools
     dependency_versions=dependency_versions,
 ))@
 
+@(TEMPLATE(
+    'snippet/install_dependencies_from_file.Dockerfile.em',
+    install_lists=install_lists,
+))@
+
 @[if os_name == 'ubuntu' and os_code_name[0] == 't']@
 # Doxygen version 1.8.6 seems to generate excessive tagfiles when cross referencing,
 # overriding with older package (1.7.6) from Precise

--- a/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
@@ -78,6 +78,11 @@ RUN echo "@today_str"
     dependency_versions=dependency_versions,
 ))@
 
+@(TEMPLATE(
+    'snippet/install_dependencies_from_file.Dockerfile.em',
+    install_lists=install_lists,
+))@
+
 USER buildfarm
 ENTRYPOINT ["sh", "-c"]
 @{

--- a/ros_buildfarm/templates/snippet/install_dependencies_from_file.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/install_dependencies_from_file.Dockerfile.em
@@ -1,0 +1,4 @@
+@[for install_list in install_lists]@
+COPY @(install_list) .
+RUN xargs -a @(install_list) python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y -o Debug::pkgProblemResolver=yes
+@[end for]@

--- a/scripts/devel/create_devel_task_generator.py
+++ b/scripts/devel/create_devel_task_generator.py
@@ -160,6 +160,7 @@ def main(argv=sys.argv[1:]):
 
         'dependencies': debian_pkg_names,
         'dependency_versions': debian_pkg_versions,
+        'install_lists': [],
 
         'testing': args.testing,
         'prerelease_overlay': len(args.workspace_root) > 1,

--- a/scripts/doc/create_doc_task_generator.py
+++ b/scripts/doc/create_doc_task_generator.py
@@ -578,6 +578,7 @@ def main(argv=sys.argv[1:]):
 
             'dependencies': debian_pkg_names,
             'dependency_versions': debian_pkg_versions,
+            'install_lists': [],
 
             'canonical_base_url': doc_build_file.canonical_base_url,
 

--- a/scripts/release/create_binarydeb_task_generator.py
+++ b/scripts/release/create_binarydeb_task_generator.py
@@ -103,6 +103,7 @@ def main(argv=sys.argv[1:]):
 
         'dependencies': debian_pkg_names,
         'dependency_versions': debian_pkg_versions,
+        'install_lists': [],
 
         'rosdistro_name': args.rosdistro_name,
         'package_name': args.package_name,


### PR DESCRIPTION
This method makes it possible to enumerate dependencies after the Dockerfile has already been generated. It leverages xargs to avoid long lines, and allows Dockerfile layers to be generated by splitting dependencies between install list files.

Alternative to #605