### PR TITLE
add new dependency on xmlschema for rep repo

### DIFF
--- a/ros_buildfarm/templates/doc/doc_independent_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_independent_task.Dockerfile.em
@@ -38,7 +38,7 @@ RUN echo "@today_str"
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y make python-catkin-pkg-modules python-dateutil python-pip python-wstool python-yaml
 # Pin sphinx at 1.8.5 re: https://github.com/ros-infrastructure/ros_buildfarm/issues/614
-RUN pip install -U catkin-sphinx sphinx==1.8.5
+RUN pip install -U catkin-sphinx sphinx==1.8.5 xmlschema
 
 USER buildfarm
 


### PR DESCRIPTION
Added in https://github.com/ros-infrastructure/rep/pull/190

http://build.ros.org/job/doc_independent-packages/1207/console
```
14:35:57 python xsdValid.py
14:35:57 Traceback (most recent call last):
14:35:57   File "xsdValid.py", line 3, in <module>
14:35:57     import xmlschema
14:35:57 ImportError: No module named xmlschema
14:35:57 Makefile:26: recipe for target 'xsdvalid' failed
14:35:57 make[1]: *** [xsdvalid] Error 1
14:35:57 make[1]: Leaving directory '/tmp/repositories/rep'
14:35:57 Makefile:6: recipe for target 'html' failed
14:35:57 make: *** [html] Error 2
```