### PR TITLE
Arbitrary CI jobs instead of only Nightly/Overlay

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,10 +64,10 @@ matrix:
         - mkdir job job/underlay && cd job
         - ln -s .. ros_buildfarm
       script:
-        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME default $OS_NAME $OS_CODE_NAME2 $ARCH --package-selection-args --packages-up-to $UNDERLAY_PACKAGES > job.sh
+        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly $OS_NAME $OS_CODE_NAME2 $ARCH --package-selection-args --packages-up-to $UNDERLAY_PACKAGES > job.sh
         - (. job.sh -y; exit $test_result_RC)
         - tar -xjf ros2-$ROS2_DISTRO_NAME-linux-$OS_CODE_NAME2-$ARCH-ci.tar.bz2 -C underlay
-        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME default $OS_NAME $OS_CODE_NAME2 $ARCH --build-ignore $UNDERLAY_PACKAGES --underlay-source-path underlay/ros2-linux --package-selection-args --packages-up-to $OVERLAY_PACKAGES > job.sh
+        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly $OS_NAME $OS_CODE_NAME2 $ARCH --build-ignore $UNDERLAY_PACKAGES --underlay-source-path underlay/ros2-linux --package-selection-args --packages-up-to $OVERLAY_PACKAGES > job.sh
         - (. job.sh -y; exit $test_result_RC)
     - language: python
       python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,10 +64,10 @@ matrix:
         - mkdir job job/underlay && cd job
         - ln -s .. ros_buildfarm
       script:
-        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME default $OS_NAME $OS_CODE_NAME2 $ARCH --packages-select $UNDERLAY_PACKAGES --build-up-to > job.sh
+        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME default $OS_NAME $OS_CODE_NAME2 $ARCH --package-selection-args --packages-up-to $UNDERLAY_PACKAGES > job.sh
         - (. job.sh -y; exit $test_result_RC)
         - tar -xjf ros2-$ROS2_DISTRO_NAME-linux-$OS_CODE_NAME2-$ARCH-ci.tar.bz2 -C underlay
-        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME default $OS_NAME $OS_CODE_NAME2 $ARCH --packages-select $OVERLAY_PACKAGES --build-up-to --build-ignore $UNDERLAY_PACKAGES --underlay-source-path underlay/ros2-linux > job.sh
+        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME default $OS_NAME $OS_CODE_NAME2 $ARCH --build-ignore $UNDERLAY_PACKAGES --underlay-source-path underlay/ros2-linux --package-selection-args --packages-up-to $OVERLAY_PACKAGES > job.sh
         - (. job.sh -y; exit $test_result_RC)
     - language: python
       python: "3.6"

--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -445,3 +445,6 @@ The following options are valid in version ``1`` (beside the generic options):
 
 * ``test_branch``: branch to attempt to checkout and merge in each repository
   before running the job.
+
+* ``underlay_from_ci_jobs``: name(s) of other CI job(s) which should be used
+  as an underlay to this job.

--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -432,8 +432,16 @@ The following options are valid in version ``1`` (beside the generic options):
 
 * ``jenkins_job_timeout``: the job timeout for *CI* jobs.
 
+* ``package_selection_args``: package selection arguments passed to ``colcon``
+  to specify which packages should be built and tested.
+  Note that ``colcon`` is always used to select packages even when
+  ``build_tool`` specifies something other else.
+
 * ``repos_files``: the list of ``.repos`` files to use by default when creating
   a workspace to build.
 
 * ``skip_rosdep_keys``: a list of rosdep keys which should be ignored when
   rosdep is invoked to resolve package dependencies.
+
+* ``test_branch``: branch to attempt to checkout and merge in each repository
+  before running the job.

--- a/doc/jobs/ci_jobs.rst
+++ b/doc/jobs/ci_jobs.rst
@@ -108,7 +108,7 @@ from ROS *Crystal* for Ubuntu *Bionic* *amd64*:
 .. code:: sh
 
   mkdir /tmp/ci_job
-  generate_ci_script.py https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml crystal default ubuntu bionic amd64 --packages-select ament_cmake_ros --build-up-to > /tmp/ci_job/ci_job_crystal_ament_cmake_ros.sh
+  generate_ci_script.py https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml crystal default ubuntu bionic amd64 --package-selection-args --packages-up-to ament_cmake_ros > /tmp/ci_job/ci_job_crystal_ament_cmake_ros.sh
   cd /tmp/ci_job
   sh ci_job_crystal_ament_cmake_ros.sh
 
@@ -171,7 +171,7 @@ used:
     - mkdir -p $JOB_PATH/ws/src
     - cp -R $TRAVIS_BUILD_DIR $JOB_PATH/ws/src/
     # generate the script to run a CI job for that target and repo
-    - generate_ci_script.py https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH --packages-select $PACKAGE_SELECT --build-up-to > $JOB_PATH/ci_job.sh
+    - generate_ci_script.py https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH --package-selection-args --packages-up-to $PACKAGE_SELECT > $JOB_PATH/ci_job.sh
     - cd $JOB_PATH
     - cat ci_job.sh
     # run the actual job which involves Docker

--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -315,24 +315,10 @@ def add_argument_install_pip_packages(parser):
         help='The list of packages to install with pip')
 
 
-def add_argument_above_depth(parser):
-    parser.add_argument(
-        '--above-depth', type=int, metavar='DEPTH', default=0,
-        help='Number of reverse-dependent packages which ' +
-             'depend upon the targeted package(s).')
-
-
 def add_argument_build_ignore(parser):
     parser.add_argument(
         '--build-ignore', nargs='*', metavar='PKG_NAME',
         help='Package name(s) which should be excluded from the build')
-
-
-def add_argument_build_up_to(parser):
-    parser.add_argument(
-        '--build-up-to', action='store_true',
-        help='Include all forward dependencies of the selected ' +
-             'package(s) which are present in the workspace.')
 
 
 def add_argument_install_packages(parser):
@@ -342,10 +328,11 @@ def add_argument_install_packages(parser):
              'packages detected for installation by rosdep.')
 
 
-def add_argument_packages_select(parser):
+def add_argument_package_selection_args(parser):
     parser.add_argument(
-        '--packages-select', nargs='*', metavar='PKG_NAME',
-        help='Package(s) to be built')
+        '--package-selection-args', nargs=argparse.REMAINDER,
+        help='Package selection arguments passed to colcon '
+             'to specify which packages should be built and tested.')
 
 
 def add_argument_repos_file_urls(parser, required=False):

--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -277,6 +277,8 @@ def _get_ci_job_config(
         'build_ignore': build_file.build_ignore,
         'skip_rosdep_keys': build_file.skip_rosdep_keys,
         'install_packages': build_file.install_packages,
+        'package_selection_args': build_file.package_selection_args,
+        'test_branch': build_file.test_branch,
 
         'underlay_source_job': underlay_source_job,
         'underlay_source_paths': underlay_source_paths,

--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -36,9 +36,7 @@ from rosdistro import get_index
 def configure_ci_jobs(
         config_url, rosdistro_name, ci_build_name,
         groovy_script=None, dry_run=False):
-    """
-    Configure all Jenkins CI jobs.
-    """
+    """Configure all Jenkins CI jobs."""
     config = get_config_index(config_url)
     build_files = get_ci_build_files(config, rosdistro_name)
     build_file = build_files[ci_build_name]

--- a/ros_buildfarm/colcon.py
+++ b/ros_buildfarm/colcon.py
@@ -17,7 +17,7 @@ import subprocess
 
 def locate_packages(
     source_space, packages_select=None, packages_up_to=None,
-    packages_above_depth=None
+    packages_above_depth=None, extra_args=None
 ):
     cmd = ['colcon', 'list', '--base-paths', source_space]
     if packages_select:
@@ -29,6 +29,8 @@ def locate_packages(
     if packages_above_depth:
         cmd.append('--packages-above-depth')
         cmd.extend(packages_above_depth)
+    if extra_args:
+        cmd.extend(extra_args)
 
     output = subprocess.check_output(cmd).decode()
 

--- a/ros_buildfarm/config/ci_build_file.py
+++ b/ros_buildfarm/config/ci_build_file.py
@@ -79,3 +79,8 @@ class CIBuildFile(BuildFile):
         self.test_branch = None
         if 'test_branch' in data:
             self.test_branch = data['test_branch']
+
+        self.underlay_from_ci_jobs = []
+        if 'underlay_from_ci_jobs' in data:
+            self.underlay_from_ci_jobs = data['underlay_from_ci_jobs']
+            assert isinstance(self.underlay_from_ci_jobs, list)

--- a/ros_buildfarm/config/ci_build_file.py
+++ b/ros_buildfarm/config/ci_build_file.py
@@ -62,6 +62,10 @@ class CIBuildFile(BuildFile):
         if 'jenkins_job_timeout' in data:
             self.jenkins_job_timeout = int(data['jenkins_job_timeout'])
 
+        self.package_selection_args = None
+        if 'package_selection_args' in data:
+            self.package_selection_args = data['package_selection_args']
+
         self.repos_files = []
         if 'repos_files' in data:
             self.repos_files = data['repos_files']
@@ -71,3 +75,7 @@ class CIBuildFile(BuildFile):
         if 'skip_rosdep_keys' in data:
             self.skip_rosdep_keys = data['skip_rosdep_keys']
             assert isinstance(self.skip_rosdep_keys, list)
+
+        self.test_branch = None
+        if 'test_branch' in data:
+            self.test_branch = data['test_branch']

--- a/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
@@ -73,9 +73,7 @@ cmds = [
     ' --test-branch "%s"' % (test_branch) + \
     ' --skip-rosdep-keys ' + ' '.join(skip_rosdep_keys) + \
     ' --build-ignore ' + ' '.join(build_ignore) + \
-    ' --above-depth %d' % above_depth + \
-    (' --build-up-to' if build_up_to else '') + \
-    ' --packages-select ' + ' '.join(packages_select),
+    ' --package-selection-args ' + ' '.join(package_selection_args),
 
     'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \
     ' /tmp/ros_buildfarm/scripts/ci/build_task_generator.py' + \

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -43,7 +43,7 @@ parameters = [
     {
         'type': 'string',
         'name': 'test_branch',
-        'default_value': '',
+        'default_value': test_branch or '',
         'description': 'Branch to attempt to checkout before doing batch job',
     },
     {
@@ -54,20 +54,9 @@ parameters = [
     },
     {
         'type': 'string',
-        'name': 'packages_select',
-        'default_value': '',
-        'description': 'Package(s) to be built (space-separated), or blank for ALL',
-    },
-    {
-        'type': 'boolean',
-        'name': 'build_up_to',
-        'description': 'Include all forward dependencies of the selected package(s) which are present in the workspace',
-    },
-    {
-        'type': 'string',
-        'name': 'above_depth',
-        'default_value': '0',
-        'description': 'Number of reverse dependencies of selected packages to be include in scope',
+        'name': 'package_selection_args',
+        'default_value': package_selection_args or '',
+        'description': 'Package selection arguments passed to colcon to specify which packages should be built and tested, or blank for ALL',
     },
 ]
 }@
@@ -155,7 +144,6 @@ parameters = [
         'echo "# BEGIN SECTION: Generate Dockerfile - CI tasks"',
         'export TZ="%s"' % timezone,
         'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
-        'if [ "$build_up_to" = "true" ]; then BUILD_UP_TO_FLAG="--build-up-to"; fi',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/ci/run_ci_job.py' +
         ' ' + rosdistro_name +
         ' ' + os_name +
@@ -175,9 +163,7 @@ parameters = [
         (' /tmp/ws' if not underlay_source_paths else \
          ''.join([' /tmp/ws%s' % (i or '') for i in range(len(underlay_source_paths))]) +
          ' /tmp/ws_overlay') +
-        ' --above-depth $above_depth' +
-        ' $BUILD_UP_TO_FLAG' +
-        ' --packages-select $packages_select',
+        ' --package-selection-args $package_selection_args',
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Build Dockerfile - generating CI tasks"',

--- a/ros_buildfarm/templates/ci/ci_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_reconfigure-jobs_job.xml.em
@@ -65,6 +65,7 @@ if (repository_names) {
     'builder_shell_key-files',
     script_generating_key_files=script_generating_key_files,
 ))@
+@[for ci_build_name in ci_build_names]@
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
@@ -120,6 +121,7 @@ if (repository_names) {
     command=None,
     script_file='$WORKSPACE/reconfigure_jobs/reconfigure_jobs.groovy',
 ))@
+@[end for]@
   </builders>
   <publishers>
 @(SNIPPET(

--- a/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
@@ -88,9 +88,7 @@ cmds = [
     ' --repos-file-urls ' + ' '.join(repos_file_urls) + \
     ' --test-branch "%s"' % (test_branch) + \
     ' --build-ignore ' + ' '.join(build_ignore) + \
-    ' --above-depth %d' % above_depth + \
-    (' --build-up-to' if build_up_to else '') + \
-    ' --packages-select ' + ' '.join(packages_select),
+    ' --package-selection-args ' + ' '.join(package_selection_args),
 
     'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \
     ' /tmp/ros_buildfarm/scripts/ci/generate_install_lists.py' + \

--- a/scripts/ci/create_workspace.py
+++ b/scripts/ci/create_workspace.py
@@ -20,10 +20,8 @@ from pathlib import Path
 import sys
 from urllib.request import urlretrieve
 
-from ros_buildfarm.argument import add_argument_above_depth
 from ros_buildfarm.argument import add_argument_build_ignore
-from ros_buildfarm.argument import add_argument_build_up_to
-from ros_buildfarm.argument import add_argument_packages_select
+from ros_buildfarm.argument import add_argument_package_selection_args
 from ros_buildfarm.argument import add_argument_repos_file_urls
 from ros_buildfarm.argument import add_argument_test_branch
 from ros_buildfarm.colcon import locate_packages
@@ -35,10 +33,8 @@ from ros_buildfarm.workspace import ensure_workspace_exists
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
         description='Create a workspace from vcs repos files.')
-    add_argument_above_depth(parser)
     add_argument_build_ignore(parser)
-    add_argument_build_up_to(parser)
-    add_argument_packages_select(parser)
+    add_argument_package_selection_args(parser)
     add_argument_repos_file_urls(parser, required=True)
     add_argument_test_branch(parser)
     parser.add_argument(
@@ -78,32 +74,11 @@ def main(argv=sys.argv[1:]):
 
     with Scope('SUBSECTION', 'select target package(s) in workspace'):
         packages = locate_packages(source_space)
-        if args.packages_select:
-            selected_packages = set()
-            print('Selecting %d packages by name' % len(args.packages_select))
-            if args.above_depth:
-                packages_above_depth = [str(args.above_depth)] + \
-                    args.packages_select
-                after = locate_packages(
-                    source_space,
-                    packages_above_depth=packages_above_depth).keys()
-                print('Selecting %d packages after current selection' %
-                      (len(after) - len(args.packages_select)))
-                selected_packages |= after
-            if args.build_up_to:
-                packages_up_to = selected_packages or args.packages_select
-                up_to = locate_packages(
-                    source_space,
-                    packages_up_to=packages_up_to).keys()
-                print('Selecting %d dependencies of current selection' %
-                      (len(up_to) - len(packages_up_to)))
-                selected_packages |= up_to
-            if not selected_packages:
-                selected_packages = locate_packages(
-                    source_space,
-                    packages_select=args.packages_select).keys()
+        if args.package_selection_args:
+            selected_packages = locate_packages(
+                source_space, extra_args=args.package_selection_args)
 
-            to_ignore = packages.keys() - selected_packages
+            to_ignore = packages.keys() - selected_packages.keys()
             print('Ignoring %d packages to scope workspace' % len(to_ignore))
             for package in to_ignore:
                 package_root = packages.pop(package)

--- a/scripts/ci/create_workspace_task_generator.py
+++ b/scripts/ci/create_workspace_task_generator.py
@@ -18,10 +18,8 @@ import argparse
 import sys
 
 from apt import Cache
-from ros_buildfarm.argument import add_argument_above_depth
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_ignore
-from ros_buildfarm.argument import add_argument_build_up_to
 from ros_buildfarm.argument import \
     add_argument_distribution_repository_key_files
 from ros_buildfarm.argument import add_argument_distribution_repository_urls
@@ -29,7 +27,7 @@ from ros_buildfarm.argument import add_argument_dockerfile_dir
 from ros_buildfarm.argument import add_argument_env_vars
 from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
-from ros_buildfarm.argument import add_argument_packages_select
+from ros_buildfarm.argument import add_argument_package_selection_args
 from ros_buildfarm.argument import add_argument_repos_file_urls
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.argument import add_argument_skip_rosdep_keys
@@ -50,14 +48,12 @@ def main(argv=sys.argv[1:]):
     add_argument_os_code_name(parser)
     add_argument_arch(parser)
 
-    add_argument_above_depth(parser)
     add_argument_build_ignore(parser)
-    add_argument_build_up_to(parser)
     add_argument_distribution_repository_key_files(parser)
     add_argument_distribution_repository_urls(parser)
     add_argument_dockerfile_dir(parser)
     add_argument_env_vars(parser)
-    add_argument_packages_select(parser)
+    add_argument_package_selection_args(parser)
     add_argument_repos_file_urls(parser, required=True)
     add_argument_skip_rosdep_keys(parser)
     add_argument_test_branch(parser)
@@ -108,9 +104,7 @@ def main(argv=sys.argv[1:]):
         'skip_rosdep_keys': args.skip_rosdep_keys,
         'build_ignore': args.build_ignore,
 
-        'above_depth': args.above_depth,
-        'build_up_to': args.build_up_to,
-        'packages_select': args.packages_select,
+        'package_selection_args': args.package_selection_args,
 
         'workspace_root': args.workspace_root,
     }

--- a/scripts/ci/generate_ci_script.py
+++ b/scripts/ci/generate_ci_script.py
@@ -132,7 +132,6 @@ def main(argv=sys.argv[1:]):
         args.config_url, args.rosdistro_name, args.ci_build_name,
         args.os_name, args.os_code_name, args.arch,
         config=config, build_file=build_file, jenkins=False, views=False,
-        job_type='script',
         underlay_source_paths=underlay_source_paths)
 
     templates.template_hooks = None

--- a/scripts/ci/generate_ci_script.py
+++ b/scripts/ci/generate_ci_script.py
@@ -20,16 +20,14 @@ import sys
 
 from em import BANGPATH_OPT
 from em import Hook
-from ros_buildfarm.argument import add_argument_above_depth
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_ignore
 from ros_buildfarm.argument import add_argument_build_name
 from ros_buildfarm.argument import add_argument_build_tool
-from ros_buildfarm.argument import add_argument_build_up_to
 from ros_buildfarm.argument import add_argument_config_url
 from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
-from ros_buildfarm.argument import add_argument_packages_select
+from ros_buildfarm.argument import add_argument_package_selection_args
 from ros_buildfarm.argument import add_argument_repos_file_urls
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.argument import add_argument_skip_cleanup
@@ -53,11 +51,9 @@ def main(argv=sys.argv[1:]):
     add_argument_os_code_name(parser)
     add_argument_arch(parser)
 
-    add_argument_above_depth(parser)
     add_argument_build_ignore(parser)
     add_argument_build_tool(parser)
-    add_argument_build_up_to(parser)
-    add_argument_packages_select(parser)
+    add_argument_package_selection_args(parser)
     add_argument_repos_file_urls(parser)
     add_argument_skip_cleanup(parser)
     add_argument_test_branch(parser)
@@ -83,12 +79,8 @@ def main(argv=sys.argv[1:]):
                 self.parameters['test_branch'] = args.test_branch
             if args.build_ignore is not None:
                 self.parameters['build_ignore'] = ' '.join(args.build_ignore)
-            if args.packages_select is not None:
-                self.parameters['packages_select'] = ' '.join(args.packages_select)
-            if args.above_depth is not None:
-                self.parameters['above_depth'] = str(args.above_depth)
-            if args.build_up_to is not None:
-                self.parameters['build_up_to'] = 'true' if args.build_up_to else 'false'
+            if args.package_selection_args is not None:
+                self.parameters['package_selection_args'] = ' '.join(args.package_selection_args)
 
         def beforeInclude(self, *_, **kwargs):
             template_path = kwargs['file'].name

--- a/scripts/ci/run_ci_job.py
+++ b/scripts/ci/run_ci_job.py
@@ -18,11 +18,9 @@ import argparse
 import copy
 import sys
 
-from ros_buildfarm.argument import add_argument_above_depth
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_ignore
 from ros_buildfarm.argument import add_argument_build_tool
-from ros_buildfarm.argument import add_argument_build_up_to
 from ros_buildfarm.argument import \
     add_argument_distribution_repository_key_files
 from ros_buildfarm.argument import add_argument_distribution_repository_urls
@@ -31,7 +29,7 @@ from ros_buildfarm.argument import add_argument_env_vars
 from ros_buildfarm.argument import add_argument_install_packages
 from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
-from ros_buildfarm.argument import add_argument_packages_select
+from ros_buildfarm.argument import add_argument_package_selection_args
 from ros_buildfarm.argument import add_argument_repos_file_urls
 from ros_buildfarm.argument import add_argument_ros_version
 from ros_buildfarm.argument import add_argument_rosdistro_name
@@ -52,16 +50,14 @@ def main(argv=sys.argv[1:]):
     add_argument_os_code_name(parser)
     add_argument_arch(parser)
 
-    add_argument_above_depth(parser)
     add_argument_build_ignore(parser)
     add_argument_build_tool(parser, required=True)
-    add_argument_build_up_to(parser)
     add_argument_distribution_repository_key_files(parser)
     add_argument_distribution_repository_urls(parser)
     add_argument_dockerfile_dir(parser)
     add_argument_env_vars(parser)
     add_argument_install_packages(parser)
-    add_argument_packages_select(parser)
+    add_argument_package_selection_args(parser)
     add_argument_repos_file_urls(parser, required=True)
     add_argument_ros_version(parser)
     add_argument_skip_rosdep_keys(parser)


### PR DESCRIPTION
Two changes:
* Support more runtime options in CI build configuration file
  This is purely additive, and is useful even without the subsequent change.
* Support flexible CI jobs and connections between them

There is one big 'gotcha': we still can't support multiple underlays. There are still important packages which can't be relocated, meaning that we have to assume that the underlay should be relocated into the same spot where the overlay is typically built. I could pursue a strategy to allow multiple underlays and only relocate the first one if that is desired, but the best case scenario is that the non-relocatable packages are fixed and this code is changed to remove the workarounds to place the underlay in the same spot.

Even though we can't have more than one, I designed the build file change to allow a list of them, assuming that we fix the bugs sometime in the future. That way we won't need to create a new version of the build configuration file format.

This should be merged after ros2/ros_buildfarm_config#22, which demonstrates how the existing experience can be achieved when combined with this change.

Inspired by https://github.com/ros-infrastructure/ros_buildfarm/pull/590#pullrequestreview-221924019