### PR TITLE
prerelease: correct pre-seeded workspace name.

### DIFF
--- a/doc/jobs/prerelease_jobs.rst
+++ b/doc/jobs/prerelease_jobs.rst
@@ -150,7 +150,7 @@ The following commands are all it takes to run a prerelease job for a custom rep
 .. code:: sh
 
   mkdir /tmp/prerelease && cd /tmp/prerelease
-  git clone -b dummy_package https://github.com/ros-infrastructure/ros_buildfarm ws/src/ros_buildfarm
+  git clone -b dummy_package https://github.com/ros-infrastructure/ros_buildfarm catkin_workspace/src/ros_buildfarm
   generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml kinetic default ubuntu xenial amd64 --output-dir .
   # the argument -y suppresses the question if you want to continue with content already present in the workspace
   ./prerelease.sh -y


### PR DESCRIPTION
As per subject.

Fix #626.
