### PR TITLE
remove build_ignore option from CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ matrix:
         - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly $OS_NAME $OS_CODE_NAME2 $ARCH --package-selection-args --packages-up-to $UNDERLAY_PACKAGES > job.sh
         - (. job.sh -y; exit $test_result_RC)
         - tar -xjf ros2-$ROS2_DISTRO_NAME-linux-$OS_CODE_NAME2-$ARCH-ci.tar.bz2 -C underlay
-        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly $OS_NAME $OS_CODE_NAME2 $ARCH --build-ignore $UNDERLAY_PACKAGES --underlay-source-path underlay/ros2-linux --package-selection-args --packages-up-to $OVERLAY_PACKAGES > job.sh
+        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly $OS_NAME $OS_CODE_NAME2 $ARCH --underlay-source-path underlay/ros2-linux --package-selection-args --packages-skip-up-to $UNDERLAY_PACKAGES --packages-up-to $OVERLAY_PACKAGES > job.sh
         - (. job.sh -y; exit $test_result_RC)
     - language: python
       python: "3.6"

--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -408,9 +408,6 @@ The file format is specified by the following information:
 
 The following options are valid in version ``1`` (beside the generic options):
 
-* ``build_ignore``: a list of package names which should not be built, taking
-  precedence over any package selection options given at runtime.
-
 * ``build_tool``: the build tool to use.
   The following are valid values:
 

--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -316,12 +316,6 @@ def add_argument_install_pip_packages(parser):
         help='The list of packages to install with pip')
 
 
-def add_argument_build_ignore(parser):
-    parser.add_argument(
-        '--build-ignore', nargs='*', metavar='PKG_NAME',
-        help='Package name(s) which should be excluded from the build')
-
-
 def add_argument_install_packages(parser):
     parser.add_argument(
         '--install-packages', nargs='*',

--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -279,7 +279,6 @@ def _get_ci_job_config(
 
         'repos_file_urls': repos_files,
 
-        'build_ignore': build_file.build_ignore,
         'skip_rosdep_keys': build_file.skip_rosdep_keys,
         'install_packages': build_file.install_packages,
         'package_selection_args': build_file.package_selection_args,

--- a/ros_buildfarm/config/ci_build_file.py
+++ b/ros_buildfarm/config/ci_build_file.py
@@ -36,11 +36,6 @@ class CIBuildFile(BuildFile):
 
         super(CIBuildFile, self).__init__(name, data)
 
-        self.build_ignore = []
-        if 'build_ignore' in data:
-            self.build_ignore = data['build_ignore']
-            assert isinstance(self.build_ignore, list)
-
         self.build_tool = data.get('build_tool', 'colcon')
         assert self.build_tool in ('catkin_make_isolated', 'colcon')
 

--- a/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
@@ -73,7 +73,6 @@ cmds = [
     ' --repos-file-urls ' + ' '.join(repos_file_urls) + \
     ' --test-branch "%s"' % (test_branch) + \
     ' --skip-rosdep-keys ' + ' '.join(skip_rosdep_keys) + \
-    ' --build-ignore ' + ' '.join(build_ignore) + \
     ' --package-selection-args ' + ' '.join(package_selection_args),
 
     'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -48,12 +48,6 @@ parameters = [
     },
     {
         'type': 'string',
-        'name': 'build_ignore',
-        'default_value': ' '.join(build_ignore),
-        'description': 'Package name(s) which should be excluded from the build (space-separated)',
-    },
-    {
-        'type': 'string',
         'name': 'package_selection_args',
         'default_value': package_selection_args or '',
         'description': 'Package selection arguments passed to colcon to specify which packages should be built and tested, or blank for ALL',
@@ -163,7 +157,6 @@ parameters = [
         ' --repos-file-urls $repos_file_urls' +
         ' --test-branch "$test_branch"' +
         ' --skip-rosdep-keys ' + ' '.join(skip_rosdep_keys) +
-        ' --build-ignore $build_ignore' +
         ' --install-packages $install_packages' +
         ' --workspace-mount-point' +
         (' /tmp/ws' if not underlay_source_paths else \

--- a/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
@@ -87,7 +87,6 @@ cmds = [
     ' --workspace-root ' + workspace_root[-1] + \
     ' --repos-file-urls ' + ' '.join(repos_file_urls) + \
     ' --test-branch "%s"' % (test_branch) + \
-    ' --build-ignore ' + ' '.join(build_ignore) + \
     ' --package-selection-args ' + ' '.join(package_selection_args),
 
     'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \

--- a/scripts/ci/create_workspace_task_generator.py
+++ b/scripts/ci/create_workspace_task_generator.py
@@ -19,7 +19,6 @@ import sys
 
 from apt import Cache
 from ros_buildfarm.argument import add_argument_arch
-from ros_buildfarm.argument import add_argument_build_ignore
 from ros_buildfarm.argument import \
     add_argument_distribution_repository_key_files
 from ros_buildfarm.argument import add_argument_distribution_repository_urls
@@ -48,7 +47,6 @@ def main(argv=sys.argv[1:]):
     add_argument_os_code_name(parser)
     add_argument_arch(parser)
 
-    add_argument_build_ignore(parser)
     add_argument_distribution_repository_key_files(parser)
     add_argument_distribution_repository_urls(parser)
     add_argument_dockerfile_dir(parser)
@@ -102,7 +100,6 @@ def main(argv=sys.argv[1:]):
         'test_branch': args.test_branch,
 
         'skip_rosdep_keys': args.skip_rosdep_keys,
-        'build_ignore': args.build_ignore,
 
         'package_selection_args': args.package_selection_args,
 

--- a/scripts/ci/generate_ci_script.py
+++ b/scripts/ci/generate_ci_script.py
@@ -21,7 +21,6 @@ import sys
 from em import BANGPATH_OPT
 from em import Hook
 from ros_buildfarm.argument import add_argument_arch
-from ros_buildfarm.argument import add_argument_build_ignore
 from ros_buildfarm.argument import add_argument_build_name
 from ros_buildfarm.argument import add_argument_build_tool
 from ros_buildfarm.argument import add_argument_config_url
@@ -51,7 +50,6 @@ def main(argv=sys.argv[1:]):
     add_argument_os_code_name(parser)
     add_argument_arch(parser)
 
-    add_argument_build_ignore(parser)
     add_argument_build_tool(parser)
     add_argument_package_selection_args(parser)
     add_argument_repos_file_urls(parser)
@@ -77,8 +75,6 @@ def main(argv=sys.argv[1:]):
                 self.parameters['repos_file_urls'] = ' '.join(args.repos_file_urls)
             if args.test_branch is not None:
                 self.parameters['test_branch'] = args.test_branch
-            if args.build_ignore is not None:
-                self.parameters['build_ignore'] = ' '.join(args.build_ignore)
             if args.package_selection_args is not None:
                 self.parameters['package_selection_args'] = ' '.join(args.package_selection_args)
 

--- a/scripts/ci/run_ci_job.py
+++ b/scripts/ci/run_ci_job.py
@@ -19,7 +19,6 @@ import copy
 import sys
 
 from ros_buildfarm.argument import add_argument_arch
-from ros_buildfarm.argument import add_argument_build_ignore
 from ros_buildfarm.argument import add_argument_build_tool
 from ros_buildfarm.argument import add_argument_build_tool_args
 from ros_buildfarm.argument import \
@@ -52,7 +51,6 @@ def main(argv=sys.argv[1:]):
     add_argument_os_code_name(parser)
     add_argument_arch(parser)
 
-    add_argument_build_ignore(parser)
     add_argument_build_tool(parser, required=True)
     add_argument_distribution_repository_key_files(parser)
     add_argument_distribution_repository_urls(parser)


### PR DESCRIPTION
Follow up of #623.

Remove the `build_ignore` option in favor of the already existing more powerful `package_selection_args` option.