### PR TITLE
fix logic to ignore packages in CI builds

### DIFF
--- a/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
@@ -86,8 +86,7 @@ cmds = [
     ' /tmp/ros_buildfarm/scripts/ci/create_workspace.py' + \
     ' --workspace-root ' + workspace_root[-1] + \
     ' --repos-file-urls ' + ' '.join(repos_file_urls) + \
-    ' --test-branch "%s"' % (test_branch) + \
-    ' --package-selection-args ' + ' '.join(package_selection_args),
+    ' --test-branch "%s"' % (test_branch),
 
     'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \
     ' /tmp/ros_buildfarm/scripts/ci/generate_install_lists.py' + \
@@ -96,7 +95,8 @@ cmds = [
     ' ' + os_code_name + \
     ' --package-root ' + ' '.join(base_paths) + \
     ' --output-dir ' + workspace_root[-1] + \
-    ' --skip-rosdep-keys ' + ' '.join(skip_rosdep_keys),
+    ' --skip-rosdep-keys ' + ' '.join(skip_rosdep_keys) + \
+    ' --package-selection-args ' + ' '.join(package_selection_args),
 ]
 cmd = ' && '.join(cmds).replace('\\', '\\\\').replace('"', '\\"')
 }@


### PR DESCRIPTION
When packages from the workspace are not selected an ignore marker is generated in the package folder. If other packages depend on that package though these dependencies are still satisfied by installing Debian packages.

Since that is undesired (to skip e.g. all packages related to OpenSplice) all ignored packages should be considered as implicitly skipped rosdep keys.