### PR TITLE
Add all Ubuntu EOL distros back to boxturtle to old release template

### DIFF
--- a/ros_buildfarm/templates/snippet/old_release_set.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/old_release_set.Dockerfile.em
@@ -1,3 +1,5 @@
+@# Ubuntu raring and older are checked for official docker images generation
+@# https://github.com/osrf/docker_images/pull/273
 @[if os_name == 'ubuntu' and os_code_name in ['lucid', 'maverick', 'natty', 'oneiric', 'precise', 'quantal', 'raring', 'saucy', 'utopic', 'vivid', 'wily', 'yakkety', 'zesty', 'artful']]@
 RUN find /etc/apt/ -name *.list -exec sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' {} \;
 @[end if]@

--- a/ros_buildfarm/templates/snippet/old_release_set.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/old_release_set.Dockerfile.em
@@ -1,3 +1,3 @@
-@[if os_name == 'ubuntu' and os_code_name in ['saucy', 'utopic', 'vivid', 'wily', 'yakkety', 'zesty', 'artful']]@
+@[if os_name == 'ubuntu' and os_code_name in ['lucid', 'maverick', 'natty', 'oneiric', 'precise', 'quantal', 'raring', 'saucy', 'utopic', 'vivid', 'wily', 'yakkety', 'zesty', 'artful']]@
 RUN find /etc/apt/ -name *.list -exec sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' {} \;
 @[end if]@


### PR DESCRIPTION
Modify the `old_release_set.Dockerfile.em` template to behave as expected for all distros listed in the ROS snapshot repository.

Original motivation for this PR is to allow to reuse this template for the generation of the official docker images.

Related to https://github.com/osrf/docker_images/pull/273 and https://github.com/osrf/docker_templates/pull/65

Arguably this does not necessarily belong in the `ros_buildfarm` package as no buildfarm will be ran against these distros. If so a copy of this snippet can be hosted on https://github.com/osrf/docker_templates but would result in duplicating maintenance effort