### PR TITLE
Fix a regression in CI builds with no package selection args

### DIFF
--- a/scripts/ci/generate_install_lists.py
+++ b/scripts/ci/generate_install_lists.py
@@ -59,6 +59,7 @@ def main(argv=sys.argv[1:]):
 
     with Scope('SUBSECTION', 'mark packages with IGNORE files'):
         all_packages = locate_packages(workspace_root)
+        selected_packages = all_packages
         if args.package_selection_args:
             print(
                 'Using package selection arguments:',


### PR DESCRIPTION
Regression caused by #642

Example failure: http://build.ros2.org/view/Eci/job/Eci__nightly-extra-rmw-release_ubuntu_bionic_amd64/15/consoleFull#console-section-15
Example with fix: http://build.ros2.org/view/Eci/job/Eci__nightly-extra-rmw-release_ubuntu_bionic_amd64/17/consoleFull#console-section-15