### PR TITLE
Don't override MAKEFLAGS blindly

### DIFF
--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -66,7 +66,7 @@ def main(argv=sys.argv[1:]):
             if args.parent_result_space:
                 parent_result_spaces = args.parent_result_space
             env = dict(os.environ)
-            env['MAKEFLAGS'] = '-j1'
+            env.setdefault('MAKEFLAGS', '-j1')
             rc = call_build_tool(
                 args.build_tool, args.rosdistro_name, args.workspace_root,
                 cmake_args=['-DBUILD_TESTING=0', '-DCATKIN_SKIP_TESTING=1'],

--- a/scripts/devel/build_and_test.py
+++ b/scripts/devel/build_and_test.py
@@ -77,7 +77,7 @@ def main(argv=sys.argv[1:]):
             if args.build_tool == 'colcon':
                 additional_args = ['--test-result-base', test_results_dir]
             env = dict(os.environ)
-            env['MAKEFLAGS'] = '-j1'
+            env.setdefault('MAKEFLAGS', '-j1')
             rc = call_build_tool(
                 args.build_tool, args.rosdistro_name, args.workspace_root,
                 cmake_clean_cache=True,

--- a/scripts/doc/build_doc.py
+++ b/scripts/doc/build_doc.py
@@ -80,7 +80,7 @@ def main(argv=sys.argv[1:]):
 
     with Scope('SUBSECTION', 'build workspace in isolation and install'):
         env = dict(os.environ)
-        env['MAKEFLAGS'] = '-j1'
+        env.setdefault('MAKEFLAGS', '-j1')
         rc = call_build_tool(
             args.build_tool, args.rosdistro_name, args.workspace_root,
             cmake_args=['-DCATKIN_SKIP_TESTING=1'], install=True, env=env)


### PR DESCRIPTION
This will allow us to tweak the `MAKEFLAGS` environment variable in the CI jobs. The default behavior is unchanged.