### PR TITLE
 allow 'vcs export --exact' to fail when merging a branch

### DIFF
--- a/ros_buildfarm/vcs.py
+++ b/ros_buildfarm/vcs.py
@@ -31,6 +31,6 @@ def import_repositories(source_space, repository_file, target_branch):
         subprocess.check_call(cmd)
 
 
-def export_repositories(source_space):
+def export_repositories(source_space, check=True):
     cmd = ['vcs', 'export', '--exact', source_space]
-    subprocess.check_call(cmd)
+    subprocess.run(cmd, check=check)

--- a/scripts/ci/create_workspace.py
+++ b/scripts/ci/create_workspace.py
@@ -54,7 +54,8 @@ def main(argv=sys.argv[1:]):
             import_repositories(source_space, repos_file, args.test_branch)
 
     with Scope('SUBSECTION', 'vcs export --exact'):
-        export_repositories(args.workspace_root)
+        # if a repo has been rebased against the default branch vcs can't detect the remote
+        export_repositories(args.workspace_root, check=not args.test_branch)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When merging a custom branch with the default branch the resulting commit might not be in any of the remotes. So the `vcs` invocation might fail which is intentional.

(Temporarily contains #646. Will be removed once it is merged.)