### PR TITLE
Manually inspect colcon index to find CI underlay packages

### DIFF
--- a/scripts/ci/generate_install_lists.py
+++ b/scripts/ci/generate_install_lists.py
@@ -84,7 +84,13 @@ def main(argv=sys.argv[1:]):
         for package_root in args.package_root[0:-1]:
             print("Crawling for packages in '%s'" % package_root)
             underlay_pkgs.update(find_packages(package_root))
-            all_underlay_pkg_names |= locate_packages(package_root).keys()
+
+            # Check for a colcon index for non-ROS package detection
+            colcon_index = os.path.join(package_root, 'colcon-core', 'packages')
+            try:
+                all_underlay_pkg_names.update(os.listdir(colcon_index))
+            except FileNotFoundError:
+                pass
 
         underlay_pkg_names = [pkg.name for pkg in underlay_pkgs.values()]
         print('Found the following ROS underlay packages:')


### PR DESCRIPTION
Using colcon to enumerate packages in the underlay is not sufficient to detect non-ROS packages which were installed there. However, this information was captured in colcon's index when the workspace was built.

We don't need to worry about this for catkin-built workspaces because all of the packages built there were ROS packages, which catkin_pkg can detect.

Resolves ros2/ros_buildfarm_config#30