### PR TITLE
add link to ci_jobs.rst

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -111,3 +111,9 @@ Optimization
 If you are going to be running one or more jobs on any machine we recommend `using squid-in-a-can <https://github.com/jpetazzo/squid-in-a-can>`_ to cache downloads.
 It can greatly speed up download times and saves a lot of bandwidth.
 It's used by all our developers as well as on all the build machines.
+
+*CI* Jobs
+-------
+
+`*CI* jobs <jobs/ci_jobs.rst>`_ is used for continuous integration across repositories. It builds the code and runs the tests to check for regressions. The document includes Entry points for CI jobs, Run the *CI* job locally and Run the *CI* job on Travis.
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,7 +14,9 @@ they work.
 
 * `release jobs <jobs/release_jobs.rst>`_ generate binary packages
 
-* `devel jobs <jobs/devel_jobs.rst>`_ build and test ROS repositories
+* `devel jobs <jobs/devel_jobs.rst>`_ build and test ROS packages within a single repository
+
+* `CI jobs <jobs/ci_jobs.rst>`_ build and test ROS packages across repositories with the option of using artifacts from other CI jobs to speed up the build
 
 * `doc jobs <jobs/doc_jobs.rst>`_ generate the API documentation of packages
   and extract information from the manifests
@@ -22,8 +24,6 @@ they work.
 * `miscellaneous jobs <jobs/miscellaneous_jobs.rst>`_ perform maintenance tasks
   and generate informational data to visualize the status of the build farm and
   its generated artifacts
-
-* `*CI* jobs <jobs/ci_jobs.rst>`_ is used for continuous integration across repositories
 
 Configuration
 -------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,6 +23,7 @@ they work.
   and generate informational data to visualize the status of the build farm and
   its generated artifacts
 
+* `*CI* jobs <jobs/ci_jobs.rst>`_ is used for continuous integration across repositories
 
 Configuration
 -------------
@@ -111,9 +112,3 @@ Optimization
 If you are going to be running one or more jobs on any machine we recommend `using squid-in-a-can <https://github.com/jpetazzo/squid-in-a-can>`_ to cache downloads.
 It can greatly speed up download times and saves a lot of bandwidth.
 It's used by all our developers as well as on all the build machines.
-
-*CI* Jobs
--------
-
-`*CI* jobs <jobs/ci_jobs.rst>`_ is used for continuous integration across repositories. It builds the code and runs the tests to check for regressions. The document includes Entry points for CI jobs, Run the *CI* job locally and Run the *CI* job on Travis.
-

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,6 +25,7 @@ they work.
   and generate informational data to visualize the status of the build farm and
   its generated artifacts
 
+
 Configuration
 -------------
 


### PR DESCRIPTION
https://github.com/ros-infrastructure/ros_buildfarm/commit/f9b642052a9b6c4f7546380c8672e81b73341a56#diff-e4e925e2589c82160f0c5eac2275d155 has beed added, but not linked from anywhere.