### PR TITLE
Always clean up CI workspace before populating

### DIFF
--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -212,7 +212,7 @@ parameters = [
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - create workspace"',
         'export UNDERLAY_JOB_SPACE=$WORKSPACE/underlay/ros%d-linux' % (ros_version),
-        'rm -fr $WORKSPACE/ws/src',
+        'rm -fr $WORKSPACE/ws',
         'mkdir -p $WORKSPACE/ws/src',
         '\n'.join(['mkdir -p %s' % (dir) for dir in underlay_source_paths or []]),
         'docker run' +


### PR DESCRIPTION
I've seen this issue manifest in two ways:
1. A failed build which never made it to the "build and test" phase reports test results from a previous run, or shows errors stating that the results are stale.
2. colcon crawls into an `install_isolated` directory left by a previously failed `catkin_make_isolated` CI job.