### PR TITLE
Fix CI job generation when called from generate_all_jobs

### DIFF
--- a/scripts/generate_all_jobs.py
+++ b/scripts/generate_all_jobs.py
@@ -254,7 +254,6 @@ def generate_ci_maintenance_jobs(
         _resolve_script('ci', 'generate_ci_maintenance_jobs.py'),
         config_url,
         ros_distro_name,
-        ci_build_name,
     ]
     if dry_run:
         cmd.append('--dry-run')


### PR DESCRIPTION
This bug has been present since the CI jobs were introduced. It is the result of a mid-review design change that didn't get propagated completely.

Currently, `generate_all_jobs.py` will fail if any CI jobs are present in the buildfarm configuration.

Here are the positional arguments for the script that is being called here:
https://github.com/ros-infrastructure/ros_buildfarm/blob/610dace9fd1ab7b9febf15cb876c1ba4994c02a3/scripts/ci/generate_ci_maintenance_jobs.py#L41-L44