### PR TITLE
Use --no-log-init to prevent Docker build from hanging

### DIFF
--- a/ros_buildfarm/templates/ci/ci_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/ci_create_reconfigure_task.Dockerfile.em
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
@@ -16,7 +16,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
@@ -26,7 +26,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/devel/devel_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_reconfigure_task.Dockerfile.em
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
@@ -16,7 +16,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -22,7 +22,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/doc/doc_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_create_reconfigure_task.Dockerfile.em
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/doc/doc_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_create_task.Dockerfile.em
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/doc/doc_independent_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_independent_task.Dockerfile.em
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/doc/doc_metadata_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_metadata_task.Dockerfile.em
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/doc/doc_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_task.Dockerfile.em
@@ -22,7 +22,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/misc/rosdistro_cache_task.Dockerfile.em
+++ b/ros_buildfarm/templates/misc/rosdistro_cache_task.Dockerfile.em
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
@@ -23,7 +23,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ))@
 
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
@@ -23,7 +23,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/release/release_check_sync_criteria_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_check_sync_criteria_task.Dockerfile.em
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/release/release_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_create_reconfigure_task.Dockerfile.em
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/release/release_create_trigger_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_create_trigger_task.Dockerfile.em
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/release/sourcedeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/sourcedeb_task.Dockerfile.em
@@ -17,7 +17,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/status/blocked_releases_page_task.Dockerfile.em
+++ b/ros_buildfarm/templates/status/blocked_releases_page_task.Dockerfile.em
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/status/release_compare_page_task.Dockerfile.em
+++ b/ros_buildfarm/templates/status/release_compare_page_task.Dockerfile.em
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',

--- a/ros_buildfarm/templates/status/release_status_page_task.Dockerfile.em
+++ b/ros_buildfarm/templates/status/release_status_page_task.Dockerfile.em
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
-RUN useradd -u @uid -m buildfarm
+RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',


### PR DESCRIPTION
Fixes #654.

This implements the workaround found here: https://forums.docker.com/t/run-adduser-seems-to-hang-with-large-uid/27371/2