### PR TITLE
environment: update virtual env setup instructions.

### DIFF
--- a/doc/environment.rst
+++ b/doc/environment.rst
@@ -19,21 +19,16 @@ The easiest way is to use a Python virtual environment.
 This avoids collisions between the required Python 3 packages and already
 installed Python 2 packages used by ROS.
 
-The following commands can be used on Ubuntu Trusty::
+The following commands can be used on Ubuntu Xenial and newer::
 
-  sudo apt update && sudo apt install python3 python3-all python3-pip
+  sudo apt update && sudo apt install python3 python3-all python3-pip python3-venv
 
   mkdir /tmp/deploy_ros_buildfarm
   cd /tmp/deploy_ros_buildfarm
 
-  # the option '--without-pip' is used to work around a Python bug:
-  # https://bugs.launchpad.net/ubuntu/+source/python3.4/+bug/1290847
-  pyvenv-3.4 --without-pip venv
+  python3 -m venv venv
 
   . venv/bin/activate
-
-  # necessary because of '--without-pip'
-  curl https://bootstrap.pypa.io/get-pip.py | python3
 
   pip3 install empy
   pip3 install jenkinsapi


### PR DESCRIPTION
As per subject. Fixes #657.

The situation around `venv`, `pyvenv`, `pyenv`, `virtualenv` and friends appears to be a bit nebulous, but apparently the `venv` module is the way to go (at least according to [this](https://www.reddit.com/r/learnpython/comments/4hsudz/pyvenv_vs_virtualenv/) and [this](https://stackoverflow.com/questions/41573587) discussion).

It's part of the standard-library for Python 3 as well (but has to be installed separately on Ubuntu for reasons unknown) so should be available on all targeted systems.

I've removed the mention of Trusty as that is no longer a supported platform.
