### PR TITLE
install colcon-metadata to get metadata from colcon.pkg files

### DIFF
--- a/scripts/ci/build_task_generator.py
+++ b/scripts/ci/build_task_generator.py
@@ -72,6 +72,7 @@ def main(argv=sys.argv[1:]):
     if args.build_tool == 'colcon':
         debian_pkg_names.update([
             'python3-catkin-pkg-modules',
+            'python3-colcon-metadata',
             'python3-colcon-output',
             'python3-colcon-parallel-executor',
             'python3-colcon-ros',

--- a/scripts/ci/create_workspace_task_generator.py
+++ b/scripts/ci/create_workspace_task_generator.py
@@ -64,6 +64,7 @@ def main(argv=sys.argv[1:]):
     debian_pkg_names = [
         'git',
         'python3-apt',
+        'python3-colcon-metadata',
         'python3-colcon-package-information',
         'python3-colcon-package-selection',
         'python3-colcon-recursive-crawl',

--- a/scripts/devel/create_devel_task_generator.py
+++ b/scripts/devel/create_devel_task_generator.py
@@ -115,6 +115,7 @@ def main(argv=sys.argv[1:]):
     ]
     if args.build_tool == 'colcon':
         debian_pkg_names += [
+            'python3-colcon-metadata',
             'python3-colcon-output',
             'python3-colcon-parallel-executor',
             'python3-colcon-ros',


### PR DESCRIPTION
Before: [![Build Status](http://build.ros2.org/buildStatus/icon?job=Eci__nightly-fastrtps_ubuntu_bionic_amd64&build=45)](http://build.ros2.org/job/Eci__nightly-fastrtps_ubuntu_bionic_amd64/45/)
After: [![Build Status](http://build.ros2.org/buildStatus/icon?job=Eci__nightly-fastrtps_ubuntu_bionic_amd64&build=46)](http://build.ros2.org/job/Eci__nightly-fastrtps_ubuntu_bionic_amd64/46/) (failing at a later stage due to another unrelated problem)