### PR TITLE
update mailer plugin version to 1.23

### DIFF
--- a/ros_buildfarm/templates/snippet/publisher_mailer.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_mailer.xml.em
@@ -1,5 +1,5 @@
 @[if recipients or dynamic_recipients or send_to_individuals]@
-    <hudson.tasks.Mailer plugin="mailer@@1.22">
+    <hudson.tasks.Mailer plugin="mailer@@1.23">
       <recipients>@ESCAPE(' '.join(sorted(recipients)))@ESCAPE(('\t' + ' '.join(sorted(dynamic_recipients))) if dynamic_recipients else '')</recipients>
       <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
       <sendToIndividuals>@(send_to_individuals ? 'true' ! 'false')</sendToIndividuals>


### PR DESCRIPTION
Without this change reconfigure jobs are changing the job config back to an older version: e.g. http://build.ros.org/job/Mrel_dsv8_reconfigure-jobs/140/console