### PR TITLE
Add CI config 'jenkins_job_upstream_trigger'

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -431,6 +431,9 @@ The following options are valid in version ``1`` (beside the generic options):
 
 * ``jenkins_job_timeout``: the job timeout for *CI* jobs.
 
+* ``jenkins_job_upstream_triggers``: name(s) of other CI job(s) which, when
+  built with a stable or unstable result, should trigger this job to be built.
+
 * ``package_selection_args``: package selection arguments passed to ``colcon``
   to specify which packages should be built and tested.
   Note that ``colcon`` is always used to select packages even when

--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -431,7 +431,7 @@ The following options are valid in version ``1`` (beside the generic options):
 
 * ``jenkins_job_timeout``: the job timeout for *CI* jobs.
 
-* ``jenkins_job_upstream_triggers``: name(s) of other CI job(s) which, when
+* ``jenkins_job_upstream_triggers``: names of other CI jobs which, when
   built with a stable or unstable result, should trigger this job to be built.
 
 * ``package_selection_args``: package selection arguments passed to ``colcon``
@@ -448,5 +448,5 @@ The following options are valid in version ``1`` (beside the generic options):
 * ``test_branch``: branch to attempt to checkout and merge in each repository
   before running the job.
 
-* ``underlay_from_ci_jobs``: name(s) of other CI job(s) which should be used
+* ``underlay_from_ci_jobs``: names of other CI jobs which should be used
   as an underlay to this job.

--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -195,6 +195,11 @@ def configure_ci_job(
         underlay_source_paths = (underlay_source_paths or []) + \
             ['$UNDERLAY_JOB_SPACE']
 
+    trigger_jobs = [
+        get_ci_job_name(
+            rosdistro_name, os_name, os_code_name, arch, trigger_job)
+        for trigger_job in build_file.jenkins_job_upstream_triggers]
+
     if jenkins is None:
         from ros_buildfarm.jenkins import connect
         jenkins = connect(config.jenkins_url)
@@ -211,7 +216,7 @@ def configure_ci_job(
         build_file.repos_files,
         underlay_source_job,
         underlay_source_paths,
-        trigger_timer,
+        trigger_timer, trigger_jobs,
         is_disabled=is_disabled)
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
     if isinstance(jenkins, object) and jenkins is not False:
@@ -233,7 +238,7 @@ def _get_ci_job_config(
         os_code_name, arch,
         repos_files, underlay_source_job,
         underlay_source_paths, trigger_timer,
-        is_disabled=False):
+        trigger_jobs, is_disabled=False):
     template_name = 'ci/ci_job.xml.em'
 
     repository_args, script_generating_key_files = \
@@ -288,6 +293,7 @@ def _get_ci_job_config(
         'underlay_source_job': underlay_source_job,
         'underlay_source_paths': underlay_source_paths,
         'trigger_timer': trigger_timer,
+        'trigger_jobs': trigger_jobs,
     }
     job_config = expand_template(template_name, job_data)
     return job_config

--- a/ros_buildfarm/config/ci_build_file.py
+++ b/ros_buildfarm/config/ci_build_file.py
@@ -60,6 +60,10 @@ class CIBuildFile(BuildFile):
         self.jenkins_job_timeout = None
         if 'jenkins_job_timeout' in data:
             self.jenkins_job_timeout = int(data['jenkins_job_timeout'])
+        self.jenkins_job_upstream_triggers = []
+        if 'jenkins_job_upstream_triggers' in data:
+            self.jenkins_job_upstream_triggers = data['jenkins_job_upstream_triggers']
+            assert isinstance(self.jenkins_job_upstream_triggers, list)
 
         self.package_selection_args = None
         if 'package_selection_args' in data:

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -72,6 +72,12 @@ parameters = [
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <triggers>
+@[if trigger_jobs]@
+@(SNIPPET(
+    'trigger_reverse-build',
+    upstream_projects=trigger_jobs,
+))@
+@[end if]@
 @[if trigger_timer is not None]@
 @(SNIPPET(
     'trigger_timer',


### PR DESCRIPTION
This configuration parameter will allow us to chain through CI jobs. We'll use this for the navigation2 prerequisite underlay.