### PR TITLE
Dirty support for multiple underlays in CI jobs

### DIFF
--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -182,18 +182,12 @@ def configure_ci_job(
             'choose one of the following: %s' % ', '.join(sorted(
                 build_file.targets[os_name][os_code_name])))
 
-    if len(build_file.underlay_from_ci_jobs) > 1:
-        raise JobValidationError(
-            'Only a single underlay job is currently supported, but the ' +
-            'build file lists %d.' % len(build_file.underlay_from_ci_jobs))
-
-    underlay_source_job = None
-    if build_file.underlay_from_ci_jobs:
-        underlay_source_job = get_ci_job_name(
-            rosdistro_name, os_name, os_code_name, arch,
-            build_file.underlay_from_ci_jobs[0])
-        underlay_source_paths = (underlay_source_paths or []) + \
-            ['$UNDERLAY_JOB_SPACE']
+    underlay_source_jobs = [
+        get_ci_job_name(
+            rosdistro_name, os_name, os_code_name, arch, underlay_job)
+        for underlay_job in build_file.underlay_from_ci_jobs]
+    underlay_source_paths = (underlay_source_paths or []) + \
+        ['$UNDERLAY_JOB_SPACE']
 
     trigger_jobs = [
         get_ci_job_name(
@@ -215,7 +209,7 @@ def configure_ci_job(
         os_code_name, arch,
         build_file.repos_files,
         build_file.repository_names,
-        underlay_source_job,
+        underlay_source_jobs,
         underlay_source_paths,
         trigger_timer, trigger_jobs,
         is_disabled=is_disabled)
@@ -237,7 +231,7 @@ def configure_ci_view(jenkins, view_name, dry_run=False):
 def _get_ci_job_config(
         index, rosdistro_name, build_file, os_name,
         os_code_name, arch,
-        repos_files, repository_names, underlay_source_job,
+        repos_files, repository_names, underlay_source_jobs,
         underlay_source_paths, trigger_timer,
         trigger_jobs, is_disabled=False):
     template_name = 'ci/ci_job.xml.em'
@@ -256,7 +250,7 @@ def _get_ci_job_config(
     assert distribution_type in ('ros1', 'ros2')
     ros_version = 1 if distribution_type == 'ros1' else 2
 
-    if underlay_source_job is not None:
+    if underlay_source_jobs is not None:
         assert '$UNDERLAY_JOB_SPACE' in underlay_source_paths
 
     job_data = {
@@ -292,7 +286,7 @@ def _get_ci_job_config(
         'build_tool_args': build_file.build_tool_args,
         'test_branch': build_file.test_branch,
 
-        'underlay_source_job': underlay_source_job,
+        'underlay_source_jobs': underlay_source_jobs,
         'underlay_source_paths': underlay_source_paths,
         'trigger_timer': trigger_timer,
         'trigger_jobs': trigger_jobs,

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -114,27 +114,30 @@ parameters = [
     'builder_shell_key-files',
     script_generating_key_files=script_generating_key_files,
 ))@
-@[if underlay_source_job is not None]@
+@[if underlay_source_jobs]@
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
         'echo "# BEGIN SECTION: Prepare package underlay"',
     ]),
 ))@
+@[for index, underlay_source_job in enumerate(underlay_source_jobs, 1)]@
 @(SNIPPET(
     'copy_artifacts',
     artifacts=[
       '*.tar.bz2',
     ],
     project=underlay_source_job,
-    target_directory='$WORKSPACE/underlay',
+    target_directory='$WORKSPACE/underlay%d' % (index),
 ))@
+@[end for]@
 @(SNIPPET(
     'builder_shell',
-    script='\n'.join([
-        'tar -xjf $WORKSPACE/underlay/*.tar.bz2 -C $WORKSPACE/underlay',
-        'echo "# END SECTION"',
-    ]),
+    script='\n'.join(
+        ['tar -xjf $WORKSPACE/underlay%d/*.tar.bz2 -C $WORKSPACE/underlay --overwrite' % (index + 1)
+         for index in range(len(underlay_source_jobs))] +
+        ['echo "# END SECTION"']
+    ),
 ))@
 @[end if]@
 @(SNIPPET(


### PR DESCRIPTION
This change implements support for multiple underlays by laying each underlay on top of the other in the same directory.

A better solution would be to source each underlay one at a time, but that would mean that each underlay is mounted at a different path within the container, and that is not currently supported since some packages are not currently relocatable.