### PR TITLE
workarounds to get the Noetic CI jobs using Python 3 to turn over

### DIFF
--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -345,6 +345,11 @@ parameters = [
         ' "ccache -s"',
         'echo "# END SECTION"',
         '',
+    ] + ([
+        'echo "# BEGIN SECTION: Rewriting shebang lines in source files to use Python 3"',
+        'find $WORKSPACE/ws/src -not -path "*.git*" -type f -exec sed -i "1 s/^#![ ]*\/usr\/bin\/env python$/#!\/usr\/bin\/env python3/" "{}" ";"',
+        'echo "# END SECTION"',
+    ] if build_tool == 'catkin_make_isolated' and 'ROS_PYTHON_VERSION=3' in build_environment_variables else []) + [
         'echo "# BEGIN SECTION: Run Dockerfile - build and test"',
         'export UNDERLAY_JOB_SPACE=$WORKSPACE/underlay/ros%d-linux' % (ros_version),
         'rm -fr $WORKSPACE/ws/test_results',

--- a/ros_buildfarm/workspace.py
+++ b/ros_buildfarm/workspace.py
@@ -51,6 +51,8 @@ def call_build_tool(
     assert build_tool in ('catkin_make_isolated', 'colcon')
     script_name = build_tool
 
+    cmd = ['PYTHONIOENCODING=utf_8', 'PYTHONUNBUFFERED=1']
+
     # use script from source space if available
     if build_tool == 'catkin_make_isolated':
         source_space = os.path.join(workspace_root, 'src')
@@ -58,8 +60,11 @@ def call_build_tool(
             source_space, 'catkin', 'bin', script_name)
         if os.path.exists(script_from_source):
             script_name = script_from_source
-
-    cmd = ['PYTHONIOENCODING=utf_8', 'PYTHONUNBUFFERED=1', script_name]
+            ros_python_version = (env or os.environ).get('ROS_PYTHON_VERSION')
+            # override shebang line if necessary
+            if ros_python_version == '3':
+                cmd.append('python3')
+    cmd.append(script_name)
 
     if build_tool == 'colcon':
         cmd.append(colcon_verb)


### PR DESCRIPTION
* The first commit ensures that `python3` is used to invoke `catkin_make_isolated` when `ROS_PYTHON_VERSION=3` is set in the environment (in case the shebang line still references `python`).
* The second commit rewrites the shebang lines of source files to use `python3` instead of `python`
  * only when `catkin_make_isolated` is being used and
  * only in the build-and-test step of CI jobs

And again: the third commit specifying the custom branch should be reverted before merging this!