### PR TITLE
make order of build env vars deterministic

### DIFF
--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -249,7 +249,7 @@ def _get_ci_job_config(
     if build_file.build_environment_variables:
         build_environment_variables = [
             '%s=%s' % (var, value)
-            for var, value in build_file.build_environment_variables.items()]
+            for var, value in sorted(build_file.build_environment_variables.items())]
 
     distribution_type = index.distributions[rosdistro_name] \
         .get('distribution_type', 'ros1')

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -332,7 +332,7 @@ def _get_devel_job_config(
     if build_file.build_environment_variables:
         build_environment_variables = [
             '%s=%s' % (var, value)
-            for var, value in build_file.build_environment_variables.items()]
+            for var, value in sorted(build_file.build_environment_variables.items())]
 
     maintainer_emails = set([])
     if build_file.notify_maintainers and dist_cache and repo_name and \

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -666,7 +666,7 @@ def _get_binarydeb_job_config(
     if build_file.build_environment_variables:
         build_environment_variables = [
             '%s=%s' % (var, value)
-            for var, value in build_file.build_environment_variables.items()]
+            for var, value in sorted(build_file.build_environment_variables.items())]
 
     sync_to_testing_job_name = [get_sync_packages_to_testing_job_name(
         rosdistro_name, os_code_name, arch)]


### PR DESCRIPTION
Avoid unnecessary shuffling of the `build_environment_variables` on every reconfigure job (e.g. http://build.ros2.org/job/Dci_reconfigure-jobs/117/).