### PR TITLE
Support any number of layered workspaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
       sudo: required
       services:
         - docker
-      env: JOB_TYPE=ci UNDERLAY1_PACKAGES="ament_flake8"  UNDERLAY2_PACKAGES="ament_pep257" OVERLAY_PACKAGES="ament_cmake_ros"
+      env: JOB_TYPE=ci UNDERLAY1_PACKAGES="ament_flake8" UNDERLAY2_PACKAGES="ament_pep257" OVERLAY_PACKAGES="ament_cmake_ros"
       before_script:
         # install colcon for test results
         - pip install colcon-core colcon-test-result

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,13 +65,13 @@ matrix:
         - mkdir job job/underlay1 job/underlay2 && cd job
         - ln -s .. ros_buildfarm
       script:
-        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly $OS_NAME $OS_CODE_NAME2 $ARCH --package-selection-args --packages-up-to $UNDERLAY_PACKAGES > job.sh
+        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly $OS_NAME $OS_CODE_NAME2 $ARCH --package-selection-args --packages-up-to $UNDERLAY1_PACKAGES > job.sh
         - (. job.sh -y; exit $test_result_RC)
         - tar -xjf ros2-$ROS2_DISTRO_NAME-linux-$OS_CODE_NAME2-$ARCH-ci.tar.bz2 -C underlay1
         - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly $OS_NAME $OS_CODE_NAME2 $ARCH --underlay-source-path underlay1/ros2-linux --package-selection-args --packages-skip-up-to $UNDERLAY1_PACKAGES --packages-up-to $UNDERLAY2_PACKAGES > job.sh
         - (. job.sh -y; exit $test_result_RC)
         - tar -xjf ros2-$ROS2_DISTRO_NAME-linux-$OS_CODE_NAME2-$ARCH-ci.tar.bz2 -C underlay2
-        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly $OS_NAME $OS_CODE_NAME2 $ARCH --underlay-source-path underlay/ros2-linux --package-selection-args --packages-skip-up-to $UNDERLAY2_PACKAGES --packages-up-to $OVERLAY_PACKAGES > job.sh
+        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly $OS_NAME $OS_CODE_NAME2 $ARCH --underlay-source-path underlay1/ros2-linux underlay2/ros2-linux --package-selection-args --packages-skip-up-to $UNDERLAY1_PACKAGES $UNDERLAY2_PACKAGES --packages-up-to $OVERLAY_PACKAGES > job.sh
         - (. job.sh -y; exit $test_result_RC)
     - language: python
       python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,18 +57,21 @@ matrix:
       sudo: required
       services:
         - docker
-      env: JOB_TYPE=ci UNDERLAY_PACKAGES="ament_flake8 ament_pep257" OVERLAY_PACKAGES="ament_cmake_ros"
+      env: JOB_TYPE=ci UNDERLAY1_PACKAGES="ament_flake8"  UNDERLAY2_PACKAGES="ament_pep257" OVERLAY_PACKAGES="ament_cmake_ros"
       before_script:
         # install colcon for test results
         - pip install colcon-core colcon-test-result
         - python setup.py install
-        - mkdir job job/underlay && cd job
+        - mkdir job job/underlay1 job/underlay2 && cd job
         - ln -s .. ros_buildfarm
       script:
         - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly $OS_NAME $OS_CODE_NAME2 $ARCH --package-selection-args --packages-up-to $UNDERLAY_PACKAGES > job.sh
         - (. job.sh -y; exit $test_result_RC)
-        - tar -xjf ros2-$ROS2_DISTRO_NAME-linux-$OS_CODE_NAME2-$ARCH-ci.tar.bz2 -C underlay
-        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly $OS_NAME $OS_CODE_NAME2 $ARCH --underlay-source-path underlay/ros2-linux --package-selection-args --packages-skip-up-to $UNDERLAY_PACKAGES --packages-up-to $OVERLAY_PACKAGES > job.sh
+        - tar -xjf ros2-$ROS2_DISTRO_NAME-linux-$OS_CODE_NAME2-$ARCH-ci.tar.bz2 -C underlay1
+        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly $OS_NAME $OS_CODE_NAME2 $ARCH --underlay-source-path underlay1/ros2-linux --package-selection-args --packages-skip-up-to $UNDERLAY1_PACKAGES --packages-up-to $UNDERLAY2_PACKAGES > job.sh
+        - (. job.sh -y; exit $test_result_RC)
+        - tar -xjf ros2-$ROS2_DISTRO_NAME-linux-$OS_CODE_NAME2-$ARCH-ci.tar.bz2 -C underlay2
+        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly $OS_NAME $OS_CODE_NAME2 $ARCH --underlay-source-path underlay/ros2-linux --package-selection-args --packages-skip-up-to $UNDERLAY2_PACKAGES --packages-up-to $OVERLAY_PACKAGES > job.sh
         - (. job.sh -y; exit $test_result_RC)
     - language: python
       python: "3.6"

--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -182,18 +182,12 @@ def configure_ci_job(
             'choose one of the following: %s' % ', '.join(sorted(
                 build_file.targets[os_name][os_code_name])))
 
-    if len(build_file.underlay_from_ci_jobs) > 1:
-        raise JobValidationError(
-            'Only a single underlay job is currently supported, but the ' +
-            'build file lists %d.' % len(build_file.underlay_from_ci_jobs))
-
-    underlay_source_job = None
-    if build_file.underlay_from_ci_jobs:
-        underlay_source_job = get_ci_job_name(
-            rosdistro_name, os_name, os_code_name, arch,
-            build_file.underlay_from_ci_jobs[0])
-        underlay_source_paths = (underlay_source_paths or []) + \
-            ['$UNDERLAY_JOB_SPACE']
+    underlay_source_jobs = [
+        get_ci_job_name(
+            rosdistro_name, os_name, os_code_name, arch, underlay_job)
+        for underlay_job in build_file.underlay_from_ci_jobs]
+    underlay_source_paths = (underlay_source_paths or []) + \
+        ['$UNDERLAY%d_JOB_SPACE' % (index + 1) for index in range(len(underlay_source_jobs))]
 
     trigger_jobs = [
         get_ci_job_name(
@@ -215,7 +209,7 @@ def configure_ci_job(
         os_code_name, arch,
         build_file.repos_files,
         build_file.repository_names,
-        underlay_source_job,
+        underlay_source_jobs,
         underlay_source_paths,
         trigger_timer, trigger_jobs,
         is_disabled=is_disabled)
@@ -237,7 +231,7 @@ def configure_ci_view(jenkins, view_name, dry_run=False):
 def _get_ci_job_config(
         index, rosdistro_name, build_file, os_name,
         os_code_name, arch,
-        repos_files, repository_names, underlay_source_job,
+        repos_files, repository_names, underlay_source_jobs,
         underlay_source_paths, trigger_timer,
         trigger_jobs, is_disabled=False):
     template_name = 'ci/ci_job.xml.em'
@@ -256,8 +250,8 @@ def _get_ci_job_config(
     assert distribution_type in ('ros1', 'ros2')
     ros_version = 1 if distribution_type == 'ros1' else 2
 
-    if underlay_source_job is not None:
-        assert '$UNDERLAY_JOB_SPACE' in underlay_source_paths
+    for index in range(len(underlay_source_jobs)):
+        assert '$UNDERLAY%d_JOB_SPACE' % (index + 1) in underlay_source_paths
 
     job_data = {
         'job_priority': build_file.jenkins_job_priority,
@@ -292,7 +286,7 @@ def _get_ci_job_config(
         'build_tool_args': build_file.build_tool_args,
         'test_branch': build_file.test_branch,
 
-        'underlay_source_job': underlay_source_job,
+        'underlay_source_jobs': underlay_source_jobs,
         'underlay_source_paths': underlay_source_paths,
         'trigger_timer': trigger_timer,
         'trigger_jobs': trigger_jobs,

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -128,13 +128,13 @@ parameters = [
       '*.tar.bz2',
     ],
     project=underlay_source_job,
-    target_directory='$WORKSPACE/underlay%s' % (i),
+    target_directory='$WORKSPACE/underlay%d' % (i),
 ))@
 @[end for]@
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
-        'tar -xjf $WORKSPACE/underlay%s/*.tar.bz2 -C $WORKSPACE/underlay%s' %
+        'tar -xjf $WORKSPACE/underlay%d/*.tar.bz2 -C $WORKSPACE/underlay%d' %
         (i + 1, i + 1) for i in range(len(underlay_source_jobs))
     ] + [
         'echo "# END SECTION"',
@@ -176,7 +176,7 @@ parameters = [
         ' --skip-rosdep-keys ' + ' '.join(skip_rosdep_keys) +
         ' --install-packages $install_packages' +
         ' --workspace-mount-point /tmp/ws' + ''.join([
-            ' /tmp/ws%s' % (i + 2) for i in range(len(underlay_source_paths))
+            ' /tmp/ws%d' % (i + 2) for i in range(len(underlay_source_paths))
         ]) +
         ' --package-selection-args $package_selection_args' +
         ' --build-tool-args $build_tool_args',

--- a/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
@@ -63,7 +63,7 @@ cmds = [
 ]
 workspace_root = '/tmp/ws'
 if prerelease_overlay:
-    workspace_root += ' /tmp/ws_overlay'
+    workspace_root += ' /tmp/ws2'
 cmd = \
     'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \
     ' /tmp/ros_buildfarm/scripts/devel/create_devel_task_generator.py' + \

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -94,20 +94,10 @@ else:
     cmd += \
         ' /tmp/ros_buildfarm/scripts/devel/build_and_test.py' + \
         ' --rosdistro-name %s' % rosdistro_name
-cmd += ' --build-tool ' + build_tool
-if not prerelease_overlay:
-    cmd += \
-        ' --workspace-root /tmp/ws'
-else:
-    parent_result_spaces = [
-        # also specify /opt/ros in case the install location has no setup files
-        # e.g. if the workspace contains no packages
-        '/opt/ros/%s' % rosdistro_name,
-        '/tmp/ws/install_isolated',
-    ]
-    cmd += \
-        ' --workspace-root /tmp/ws_overlay' + \
-        ' --parent-result-space %s' % ' '.join(parent_result_spaces)
+cmd += \
+    ' --build-tool ' + build_tool + \
+    ' --workspace-root ' + workspace_root + \
+    ' --parent-result-space' + ''.join([' %s/install_isolated' % (space) for space in parent_result_space])
 if vars().get('build_tool_args'):
     cmd += ' --build-tool-args ' + ' '.join(build_tool_args)
 }@

--- a/scripts/ci/build_task_generator.py
+++ b/scripts/ci/build_task_generator.py
@@ -60,8 +60,7 @@ def main(argv=sys.argv[1:]):
     add_argument_ros_version(parser)
     add_argument_testing(parser)
     parser.add_argument(
-        '--workspace-root', nargs='*',
-        action=check_len_action(1, 2),
+        '--workspace-root', nargs='+',
         help='The root path of the workspace to compile')
     args = parser.parse_args(argv)
 

--- a/scripts/ci/build_task_generator.py
+++ b/scripts/ci/build_task_generator.py
@@ -92,6 +92,10 @@ def main(argv=sys.argv[1:]):
     if args.testing:
         install_lists.append('install_list_test.txt')
 
+    mapped_workspaces = [
+        (workspace_root, '/tmp/ws%s' % (index if index > 1 else ''))
+        for index, workspace_root in enumerate(args.workspace_root, 1)]
+
     # generate Dockerfile
     data = {
         'os_name': args.os_name,
@@ -118,7 +122,8 @@ def main(argv=sys.argv[1:]):
         'dependency_versions': [],
 
         'testing': args.testing,
-        'prerelease_overlay': len(args.workspace_root) > 1,
+        'workspace_root': mapped_workspaces[-1][1],
+        'parent_result_space': [mapping[1] for mapping in mapped_workspaces[:-1]],
     }
     create_dockerfile(
         'devel/devel_task.Dockerfile.em', data, args.dockerfile_dir)
@@ -128,12 +133,8 @@ def main(argv=sys.argv[1:]):
         os.path.join(os.path.dirname(__file__), '..', '..'))
     print('Mount the following volumes when running the container:')
     print('  -v %s:/tmp/ros_buildfarm:ro' % ros_buildfarm_basepath)
-    if len(args.workspace_root) == 1:
-        print('  -v %s:/tmp/ws' % args.workspace_root[0])
-    else:
-        for i, workspace_root in enumerate(args.workspace_root[0:-1]):
-            print('  -v %s:/tmp/ws%s' % (workspace_root, i or ''))
-        print('  -v %s:/tmp/ws_overlay' % args.workspace_root[-1])
+    for mapping in mapped_workspaces:
+        print('  -v %s:%s' % mapping)
 
 
 def write_install_list(install_list_path, debian_pkg_names, apt_cache):

--- a/scripts/ci/build_task_generator.py
+++ b/scripts/ci/build_task_generator.py
@@ -33,7 +33,6 @@ from ros_buildfarm.argument import add_argument_os_name
 from ros_buildfarm.argument import add_argument_ros_version
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.argument import add_argument_testing
-from ros_buildfarm.argument import check_len_action
 from ros_buildfarm.common import get_binary_package_versions
 from ros_buildfarm.common import get_distribution_repository_keys
 from ros_buildfarm.common import get_user_id

--- a/scripts/prerelease/generate_prerelease_script.py
+++ b/scripts/prerelease/generate_prerelease_script.py
@@ -253,7 +253,7 @@ def main(argv=sys.argv[1:]):
         if mount_volume in script:
             script = script.replace(
                 mount_volume, mount_volume + ':ro ' + '-v $WORKSPACE/' +
-                'ws_overlay:/tmp/ws_overlay')
+                'ws_overlay:/tmp/ws2')
 
         # relocate all docker files
         docker_path = '$WORKSPACE/docker_'


### PR DESCRIPTION
Alternate approach to #665

This approach foregoes the idea that there are either:
1. A since workspace mounted at /tmp/ws
2. Two workspaces mounted at /tmp/ws and /tmp/ws_overlay

...and supports any number of workspaces, with the last one always being the target for building. For example, [/tmp/ws, /tmp/ws2, /tmp/ws3, ...]

As long as the workspaces used to build a particular workspace are included in the same order beneath the workspace when it is used as an underlay for another build, each workspace should always end up with the same mount point, which works around the current relocation challenges but also allows as many chained builds as we like.

Unfortunately, the /tmp/ws_overlay paradigm was hard-coded in quite a few spots, so I had to reach into several job types to move to the /tmp/ws# paradigm in the devel build tasks.