### PR TITLE
Always update ccache symlinks in devel jobs.

### DIFF
--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -80,6 +80,13 @@ RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
     install_lists=install_lists,
 ))@
 
+# After all dependencies are installed, update ccache symlinks.
+# This command is supposed to be invoked whenever a new compiler is installed
+# but that isn't happening. So we invoke it here to make sure all compilers are
+# picked up.
+# TODO(nuclearsandwich) add link to Debian bug report when one is opened.
+RUN which update-ccache-symlinks >/dev/null 2>&1 && update-ccache-symlinks
+
 USER buildfarm
 ENTRYPOINT ["sh", "-c"]
 @{


### PR DESCRIPTION
This should affect the build_and_test and build_and_install containers
of all Devel, PR, and CI jobs.

This change was tested locally by running

```
mkdir /tmp/nci && cd /tmp/nci && generate_ci_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml noetic bionic-python2 ubuntu bionic amd64 | sh
```

I didn't let the build complete because I needed my CPU back but I did observe many snippets like the following:

```
=> Processing catkin package: 'xmlrpcpp'                  
==> Building with env: '/tmp/ws/devel_isolated/test_roslib_comm/env.sh'
==> cmake /tmp/ws/src/ros_comm/utilities/xmlrpcpp -DCATKIN_DEVEL_PREFIX=/tmp/ws/devel_isolated/xmlrpcpp -DCMAKE_INSTALL_PREFIX=/tmp/ws/install_isolated -DBUILD_TESTING=1 -DCATKIN_ENABLE_TESTING=1 -DCATKIN_SKIP_TESTING=0 -DCATKIN_TEST_RES
ULTS_DIR=/tmp/ws/test_results -G Unix Makefiles in '/tmp/ws/build_isolated/xmlrpcpp'                                  
-- The C compiler identification is GNU 7.4.0              
-- The CXX compiler identification is GNU 7.4.0            
-- Check for working C compiler: /usr/lib/ccache/cc                                                                   
-- Check for working C compiler: /usr/lib/ccache/cc -- works
-- Detecting C compiler ABI info                           
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done                                                                                
-- Check for working CXX compiler: /usr/lib/ccache/c++
-- Check for working CXX compiler: /usr/lib/ccache/c++ -- works

```

suggesting that the ccache symlinks are being used.