### PR TITLE
remove trusty, utopic, vivid, wily from list of suites

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -10,7 +10,7 @@ Depends: python-argparse, python-catkin-pkg-modules, python-ros-buildfarm-module
 Depends3: python3-catkin-pkg-modules, python3-ros-buildfarm-modules (>= 3.0.0), python3-rosdistro-modules, python3-yaml
 Conflicts: python3-ros-buildfarm
 Conflicts3: python-ros-buildfarm
-Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic
+Suite: xenial yakkety zesty artful bionic
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
 [ros_buildfarm_modules]
@@ -20,5 +20,5 @@ Conflicts: python-ros-buildfarm (<< 1.3.0)
 Conflicts3: python3-ros-buildfarm (<< 1.3.0)
 Replaces: python-ros-buildfarm (<< 1.3.0)
 Replaces3: python3-ros-buildfarm (<< 1.3.0)
-Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic
+Suite: xenial yakkety zesty artful bionic
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
Making the latest not-EOL LTS - Xenial - the lowest watermark.