### PR TITLE
Add scripts to build blocked source entries page

### DIFF
--- a/ros_buildfarm/templates/status/blocked_releases_page_job.xml.em
+++ b/ros_buildfarm/templates/status/blocked_releases_page_job.xml.em
@@ -18,8 +18,8 @@
   </properties>
 @(SNIPPET(
     'scm_git',
-    url='https://github.com/ros-infrastructure/ros_buildfarm',
-    branch_name='master',
+    url=ros_buildfarm_repository.url,
+    branch_name=ros_buildfarm_repository.version or 'master',
     relative_target_dir='ros_buildfarm',
     refspec=None,
 ))@

--- a/ros_buildfarm/templates/status/blocked_source_entries_page.html.em
+++ b/ros_buildfarm/templates/status/blocked_source_entries_page.html.em
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>@title - @start_time</title>
+  <meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
+
+  <script type="text/javascript" src="js/moment.min.js"></script>
+  <script type="text/javascript" src="js/zepto.min.js"></script>
+  <script type="text/javascript">
+    window.META_COLUMNS = 8;
+  </script>
+  <script type="text/javascript" src="js/setup.js?@(resource_hashes['setup.js'])"></script>
+  <script type="text/javascript">
+    var QUERY_TRANSFORMS = {
+      'id': 'id=".*"',
+      'label': 'label=".*"',
+    };
+
+    function encoded_query_a_tag(query, title, content) {
+      document.write('<a href="?q=' + encodeURIComponent(query) + '" title="' + title + '">' + content + "</a>")
+    }
+  </script>
+
+  <link rel="stylesheet" type="text/css" href="css/status_page.css?@(resource_hashes['status_page.css'])" />
+  <link rel="stylesheet" type="text/css" href="css/blocked_releases_page.css?@(resource_hashes['blocked_releases_page.css'])" />
+</head>
+<body>
+@{
+import time
+}@
+  <script type="text/javascript">
+    window.age_threshold_green = moment.duration(7, 'hours');
+    window.body_ready_with_age(moment.duration(moment() - moment("@(time.time())", "X")));
+  </script>
+  <div class="top logo">
+    <h1><img src="http://wiki.ros.org/custom/images/ros_org.png" alt="ROS.org" width="150" height="32" /></h1>
+    <h2>Repos blocked by other repos<br />@(rosdistro_name)</h2>
+  </div>
+  <div class="top search">
+    <form action="?">
+      <input type="text" name="q" id="q" title="A query string can contain multiple '+' separated parts which must all be satisfied. Each part can also be a RegExp (e.g. to combine two parts with 'OR': 'foo|bar'), but can't contain '+'." />
+      <p>
+        <a href="?q=" title="Show all repos">all</a>,
+        <script language="JavaScript">encoded_query_a_tag('label="RELEASED"', "Repositories that have already been released", "released")</script>,
+        <script language="JavaScript">encoded_query_a_tag('label="UNRELEASED"', "Repositories that have not been released", "unreleased")</script>,
+        <script language="JavaScript">encoded_query_a_tag('label="BLOCKED"', "Repositories that are blocked from being released because of unreleased dependencies", "blocked")</script>,
+        <script language="JavaScript">encoded_query_a_tag('label="UNBLOCKED"', "Repositories that can be released", "releasable")</script>,
+        <script language="JavaScript">encoded_query_a_tag('label="UNBLOCKED_BLOCKING"', "Repositories that can be released and are preventing others from being released", "releasable and blocking")</script>,
+        <script language="JavaScript">encoded_query_a_tag('label="UNBLOCKED_UNBLOCKING"', "Repositories that can be released and are not preventing others from being released", "releasable and not blocking")</script>,
+        <script language="JavaScript">encoded_query_a_tag('id="metapackages"', "Repositories that are dependencies of the metapackages repository", "metapackages")</script>
+      </p>
+      <p id="search-count"></p>
+    </form>
+  </div>
+
+  <div class="top age">
+    <p></p>
+  </div>
+
+  <div class="table-div">
+    <table>
+      <thead>
+        <tr>
+          <!-- warning: if titles run onto two lines, first row of table data may be affected -->
+          <th class="sortable"><div>Repository</div></th>
+          <th class="sortable"><div>Version</div></th>
+          <th class="sortable">
+            <div title="Number of unreleased repositories that are directly blocking this one">
+              # blocking release
+            </div>
+          </th>
+          <th class="sortable">
+            <div title="Unreleased repositories that are directly blocking this one">
+              Blocking repos
+            </div>
+          </th>
+          <th class="sortable">
+            <div title="Maintainers of the unreleased repositories that are directly blocking this one">
+              Maintainers of blocks
+            </div>
+          </th>
+          <th class="sortable">
+            <div title="Number of unreleased repositories that are directly or indirectly blocking this one">
+              # recursively blocked
+            </div>
+          </th>
+          <th class="sortable">
+            <div title="Number of repositories that are being directly blocked by this one">
+              # directly blocked
+            </div>
+          </th>
+          <th class="sortable">
+            <div title="Repositories that are being directly blocked by this one">
+              Directly blocked repos
+            </div>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- Originally sort the table by the repos with the most recursively blocked dependencies -->
+        <script type="text/javascript">window.sort=6; window.reverse=1;</script>
+        <script type="text/javascript">window.tbody_ready();</script>
+@[for row in repos_data]@
+        <tr>
+@[  for col in [
+      'name',
+      'version',
+      'num_repos_blocked_by',
+      'repos_blocked_by',
+      'maintainers_of_repos_blocked_by',
+      'num_repos_recursively_blocked',
+      'num_repos_blocked',
+      'repos_blocked',
+      ]]@
+          <td @(' class="thincol"' if col in ['version',] or col.startswith('num') else '')>@(row[col])</td>
+@[  end for]@
+        </tr>
+@[end for]@
+      </tbody>
+    </table>
+  </div>
+  <script type="text/javascript">window.body_done();</script>
+</body>
+</html>

--- a/ros_buildfarm/templates/status/blocked_source_entries_page.html.em
+++ b/ros_buildfarm/templates/status/blocked_source_entries_page.html.em
@@ -41,12 +41,12 @@ import time
       <input type="text" name="q" id="q" title="A query string can contain multiple '+' separated parts which must all be satisfied. Each part can also be a RegExp (e.g. to combine two parts with 'OR': 'foo|bar'), but can't contain '+'." />
       <p>
         <a href="?q=" title="Show all repos">all</a>,
-        <script language="JavaScript">encoded_query_a_tag('label="RELEASED"', "Repositories that have already been released", "released")</script>,
-        <script language="JavaScript">encoded_query_a_tag('label="UNRELEASED"', "Repositories that have not been released", "unreleased")</script>,
-        <script language="JavaScript">encoded_query_a_tag('label="BLOCKED"', "Repositories that are blocked from being released because of unreleased dependencies", "blocked")</script>,
-        <script language="JavaScript">encoded_query_a_tag('label="UNBLOCKED"', "Repositories that can be released", "releasable")</script>,
-        <script language="JavaScript">encoded_query_a_tag('label="UNBLOCKED_BLOCKING"', "Repositories that can be released and are preventing others from being released", "releasable and blocking")</script>,
-        <script language="JavaScript">encoded_query_a_tag('label="UNBLOCKED_UNBLOCKING"', "Repositories that can be released and are not preventing others from being released", "releasable and not blocking")</script>,
+        <script language="JavaScript">encoded_query_a_tag('label="RELEASED"', "Repositories that have a source entry", "released")</script>,
+        <script language="JavaScript">encoded_query_a_tag('label="UNRELEASED"', "Repositories that do not have a source entry", "unreleased")</script>,
+        <script language="JavaScript">encoded_query_a_tag('label="BLOCKED"', "Repositories that are do not have a source entry because their dependencies do not have a source entry", "blocked")</script>,
+        <script language="JavaScript">encoded_query_a_tag('label="UNBLOCKED"', "Repositories for which a source entry can be added", "releasable")</script>,
+        <script language="JavaScript">encoded_query_a_tag('label="UNBLOCKED_BLOCKING"', "Repositories that could have a source entry and are blocking others from having a source entry", "releasable and blocking")</script>,
+        <script language="JavaScript">encoded_query_a_tag('label="UNBLOCKED_UNBLOCKING"', "Repositories that could have a source entry and are not preventing others from having one", "releasable and not blocking")</script>,
         <script language="JavaScript">encoded_query_a_tag('id="metapackages"', "Repositories that are dependencies of the metapackages repository", "metapackages")</script>
       </p>
       <p id="search-count"></p>
@@ -63,24 +63,24 @@ import time
         <tr>
           <!-- warning: if titles run onto two lines, first row of table data may be affected -->
           <th class="sortable"><div>Repository</div></th>
-          <th class="sortable"><div>Version</div></th>
+          <th class="sortable"><div>Has Source Entry?</div></th>
           <th class="sortable">
-            <div title="Number of unreleased repositories that are directly blocking this one">
-              # blocking release
+            <div title="Number of repositories without source entries that are directly blocking this one">
+              # blocking source entry
             </div>
           </th>
           <th class="sortable">
-            <div title="Unreleased repositories that are directly blocking this one">
+            <div title="Repositories that are directly blocking this one">
               Blocking repos
             </div>
           </th>
           <th class="sortable">
-            <div title="Maintainers of the unreleased repositories that are directly blocking this one">
+            <div title="Maintainers of the repositories that are directly blocking this one">
               Maintainers of blocks
             </div>
           </th>
           <th class="sortable">
-            <div title="Number of unreleased repositories that are directly or indirectly blocking this one">
+            <div title="Number of repositories that are directly or indirectly blocking this one">
               # recursively blocked
             </div>
           </th>

--- a/ros_buildfarm/templates/status/blocked_source_entries_page_job.xml.em
+++ b/ros_buildfarm/templates/status/blocked_source_entries_page_job.xml.em
@@ -47,42 +47,42 @@
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
-        'rm -fr $WORKSPACE/docker_generate_blocked_releases_page',
-        'mkdir -p $WORKSPACE/docker_generate_blocked_releases_page',
+        'rm -fr $WORKSPACE/docker_generate_blocked_source_entries_page',
+        'mkdir -p $WORKSPACE/docker_generate_blocked_source_entries_page',
         '',
         '# monitor all subprocesses and enforce termination',
-        'python3 -u $WORKSPACE/ros_buildfarm/scripts/subprocess_reaper.py $$ --cid-file $WORKSPACE/docker_generate_blocked_releases_page/docker.cid > $WORKSPACE/docker_generate_blocked_releases_page/subprocess_reaper.log 2>&1 &',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/subprocess_reaper.py $$ --cid-file $WORKSPACE/docker_generate_blocked_source_entries_page/docker.cid > $WORKSPACE/docker_generate_blocked_source_entries_page/subprocess_reaper.log 2>&1 &',
         '# sleep to give python time to startup',
         'sleep 1',
         '',
         '# generate Dockerfile, build and run it',
-        '# generating the blocked_releases page',
-        'echo "# BEGIN SECTION: Generate Dockerfile - blocked_releases page"',
+        '# generating the blocked_source_entries page',
+        'echo "# BEGIN SECTION: Generate Dockerfile - blocked_source_entries page"',
         'export TZ="%s"' % timezone,
         'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
-        'python3 -u $WORKSPACE/ros_buildfarm/scripts/status/run_blocked_releases_page_job.py' +
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/status/run_blocked_source_entries_page_job.py' +
         ' ' + config_url +
         ' ' + rosdistro_name +
         ' ' + ' '.join(repository_args) +
-        ' --dockerfile-dir $WORKSPACE/docker_generate_blocked_releases_page',
+        ' --dockerfile-dir $WORKSPACE/docker_generate_blocked_source_entries_page',
         'echo "# END SECTION"',
         '',
-        'echo "# BEGIN SECTION: Build Dockerfile - blocked_releases page"',
-        'cd $WORKSPACE/docker_generate_blocked_releases_page',
+        'echo "# BEGIN SECTION: Build Dockerfile - blocked_source_entries page"',
+        'cd $WORKSPACE/docker_generate_blocked_source_entries_page',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
-        'docker build -t blocked_releases_page_generation .',
+        'docker build -t blocked_source_entries_page_generation .',
         'echo "# END SECTION"',
         '',
-        'echo "# BEGIN SECTION: Run Dockerfile - blocked_releases page"',
-        'rm -fr $WORKSPACE/blocked_releases_page',
-        'mkdir -p $WORKSPACE/blocked_releases_page',
+        'echo "# BEGIN SECTION: Run Dockerfile - blocked_source_entries page"',
+        'rm -fr $WORKSPACE/blocked_source_entries_page',
+        'mkdir -p $WORKSPACE/blocked_source_entries_page',
         'docker run' +
         ' --rm ' +
-        ' --cidfile=$WORKSPACE/docker_generate_blocked_releases_page/docker.cid' +
+        ' --cidfile=$WORKSPACE/docker_generate_blocked_source_entries_page/docker.cid' +
         ' --net=host' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
-        ' -v $WORKSPACE/blocked_releases_page:/tmp/blocked_releases_page' +
-        ' blocked_releases_page_generation',
+        ' -v $WORKSPACE/blocked_source_entries_page:/tmp/blocked_source_entries_page' +
+        ' blocked_source_entries_page_generation',
         'echo "# END SECTION"',
     ]),
 ))@
@@ -92,8 +92,8 @@
     'publisher_publish-over-ssh',
     config_name='status_page',
     remote_directory='',
-    source_files=['blocked_releases_page/**'],
-    remove_prefix='blocked_releases_page',
+    source_files=['blocked_source_entries_page/**'],
+    remove_prefix='blocked_source_entries_page',
 ))@
 @(SNIPPET(
     'publisher_mailer',

--- a/ros_buildfarm/templates/status/blocked_source_entries_page_job.xml.em
+++ b/ros_buildfarm/templates/status/blocked_source_entries_page_job.xml.em
@@ -1,0 +1,110 @@
+<project>
+  <actions/>
+  <description>Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+@(SNIPPET(
+    'property_log-rotator',
+    days_to_keep=100,
+    num_to_keep=100,
+))@
+@(SNIPPET(
+    'property_job-priority',
+    priority=20,
+))@
+@(SNIPPET(
+    'property_requeue-job',
+))@
+  </properties>
+@(SNIPPET(
+    'scm_git',
+    url=ros_buildfarm_repository.url,
+    branch_name=ros_buildfarm_repository.version or 'master',
+    relative_target_dir='ros_buildfarm',
+    refspec=None,
+))@
+  <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
+  <assignedNode>agent_on_master</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+@(SNIPPET(
+    'trigger_timer',
+    spec='5 */6 * * *',
+))@
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+@(SNIPPET(
+    'builder_shell_docker-info',
+))@
+@(SNIPPET(
+    'builder_shell_key-files',
+    script_generating_key_files=script_generating_key_files,
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'rm -fr $WORKSPACE/docker_generate_blocked_releases_page',
+        'mkdir -p $WORKSPACE/docker_generate_blocked_releases_page',
+        '',
+        '# monitor all subprocesses and enforce termination',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/subprocess_reaper.py $$ --cid-file $WORKSPACE/docker_generate_blocked_releases_page/docker.cid > $WORKSPACE/docker_generate_blocked_releases_page/subprocess_reaper.log 2>&1 &',
+        '# sleep to give python time to startup',
+        'sleep 1',
+        '',
+        '# generate Dockerfile, build and run it',
+        '# generating the blocked_releases page',
+        'echo "# BEGIN SECTION: Generate Dockerfile - blocked_releases page"',
+        'export TZ="%s"' % timezone,
+        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/status/run_blocked_releases_page_job.py' +
+        ' ' + config_url +
+        ' ' + rosdistro_name +
+        ' ' + ' '.join(repository_args) +
+        ' --dockerfile-dir $WORKSPACE/docker_generate_blocked_releases_page',
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: Build Dockerfile - blocked_releases page"',
+        'cd $WORKSPACE/docker_generate_blocked_releases_page',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
+        'docker build -t blocked_releases_page_generation .',
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: Run Dockerfile - blocked_releases page"',
+        'rm -fr $WORKSPACE/blocked_releases_page',
+        'mkdir -p $WORKSPACE/blocked_releases_page',
+        'docker run' +
+        ' --rm ' +
+        ' --cidfile=$WORKSPACE/docker_generate_blocked_releases_page/docker.cid' +
+        ' --net=host' +
+        ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
+        ' -v $WORKSPACE/blocked_releases_page:/tmp/blocked_releases_page' +
+        ' blocked_releases_page_generation',
+        'echo "# END SECTION"',
+    ]),
+))@
+  </builders>
+  <publishers>
+@(SNIPPET(
+    'publisher_publish-over-ssh',
+    config_name='status_page',
+    remote_directory='',
+    source_files=['blocked_releases_page/**'],
+    remove_prefix='blocked_releases_page',
+))@
+@(SNIPPET(
+    'publisher_mailer',
+    recipients=notification_emails,
+    dynamic_recipients=[],
+    send_to_individuals=False,
+))@
+  </publishers>
+  <buildWrappers>
+@(SNIPPET(
+    'build-wrapper_timestamper',
+))@
+  </buildWrappers>
+</project>

--- a/ros_buildfarm/templates/status/blocked_source_entries_page_task.Dockerfile.em
+++ b/ros_buildfarm/templates/status/blocked_source_entries_page_task.Dockerfile.em
@@ -1,0 +1,52 @@
+# generated from @template_name
+
+FROM ubuntu:xenial
+
+VOLUME ["/var/cache/apt/archives"]
+
+ENV DEBIAN_FRONTEND noninteractive
+
+@(TEMPLATE(
+    'snippet/setup_locale.Dockerfile.em',
+    timezone=timezone,
+))@
+
+RUN useradd -u @uid -l -m buildfarm
+
+@(TEMPLATE(
+    'snippet/add_distribution_repositories.Dockerfile.em',
+    distribution_repository_keys=distribution_repository_keys,
+    distribution_repository_urls=distribution_repository_urls,
+    os_name='ubuntu',
+    os_code_name='xenial',
+    add_source=False,
+))@
+
+@(TEMPLATE(
+    'snippet/add_wrapper_scripts.Dockerfile.em',
+    wrapper_scripts=wrapper_scripts,
+))@
+
+# automatic invalidation once every day
+RUN echo "@today_str"
+
+@(TEMPLATE(
+    'snippet/install_python3.Dockerfile.em',
+    os_name='ubuntu',
+    os_code_name='xenial',
+))@
+
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-rosdistro-modules python3-yaml
+
+USER buildfarm
+ENTRYPOINT ["sh", "-c"]
+@{
+cmd = \
+    'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \
+    ' /tmp/ros_buildfarm/scripts/status/build_blocked_releases_page.py' + \
+    ' ' + config_url + \
+    ' ' + rosdistro_name + \
+    ' --output-dir /tmp/blocked_releases_page' + \
+    ' --copy-resources'
+}@
+CMD ["@cmd"]

--- a/ros_buildfarm/templates/status/blocked_source_entries_page_task.Dockerfile.em
+++ b/ros_buildfarm/templates/status/blocked_source_entries_page_task.Dockerfile.em
@@ -43,10 +43,10 @@ ENTRYPOINT ["sh", "-c"]
 @{
 cmd = \
     'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \
-    ' /tmp/ros_buildfarm/scripts/status/build_blocked_releases_page.py' + \
+    ' /tmp/ros_buildfarm/scripts/status/build_blocked_source_entries_page.py' + \
     ' ' + config_url + \
     ' ' + rosdistro_name + \
-    ' --output-dir /tmp/blocked_releases_page' + \
+    ' --output-dir /tmp/blocked_source_entries_page' + \
     ' --copy-resources'
 }@
 CMD ["@cmd"]

--- a/scripts/generate_all_jobs.py
+++ b/scripts/generate_all_jobs.py
@@ -149,6 +149,8 @@ def main(argv=sys.argv[1:]):
                 dry_run=not args.commit)
             generate_blocked_releases_page_job(
                 args.config_url, ros_distro_name, dry_run=not args.commit)
+            generate_blocked_source_entries_page_job(
+                args.config_url, ros_distro_name, dry_run=not args.commit)
 
 
 def generate_check_agents_job(config_url, dry_run=False):
@@ -234,6 +236,18 @@ def generate_blocked_releases_page_job(
         config_url, ros_distro_name, dry_run=False):
     cmd = [
         _resolve_script('status', 'generate_blocked_releases_page_job.py'),
+        config_url,
+        ros_distro_name,
+    ]
+    if dry_run:
+        cmd.append('--dry-run')
+    _check_call(cmd)
+
+
+def generate_blocked_source_entries_page_job(
+        config_url, ros_distro_name, dry_run=False):
+    cmd = [
+        _resolve_script('status', 'generate_blocked_source_entries_page_job.py'),
         config_url,
         ros_distro_name,
     ]

--- a/scripts/status/build_blocked_source_entries_page.py
+++ b/scripts/status/build_blocked_source_entries_page.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+
+from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_output_dir
+from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.status_page import build_blocked_releases_page
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description='Generate the blocked releases page')
+    add_argument_config_url(parser)
+    add_argument_rosdistro_name(parser)
+    add_argument_output_dir(parser)
+    parser.add_argument(
+        '--copy-resources',
+        action='store_true',
+        help='Copy the resources instead of using symlinks')
+    args = parser.parse_args(argv)
+
+    return build_blocked_releases_page(
+        args.config_url, args.rosdistro_name,
+        args.output_dir, copy_resources=args.copy_resources)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/status/build_blocked_source_entries_page.py
+++ b/scripts/status/build_blocked_source_entries_page.py
@@ -20,12 +20,12 @@ import sys
 from ros_buildfarm.argument import add_argument_config_url
 from ros_buildfarm.argument import add_argument_output_dir
 from ros_buildfarm.argument import add_argument_rosdistro_name
-from ros_buildfarm.status_page import build_blocked_releases_page
+from ros_buildfarm.status_page import build_blocked_source_entries_page
 
 
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
-        description='Generate the blocked releases page')
+        description='Generate the blocked source entries page')
     add_argument_config_url(parser)
     add_argument_rosdistro_name(parser)
     add_argument_output_dir(parser)
@@ -35,7 +35,7 @@ def main(argv=sys.argv[1:]):
         help='Copy the resources instead of using symlinks')
     args = parser.parse_args(argv)
 
-    return build_blocked_releases_page(
+    return build_blocked_source_entries_page(
         args.config_url, args.rosdistro_name,
         args.output_dir, copy_resources=args.copy_resources)
 

--- a/scripts/status/generate_blocked_source_entries_page_job.py
+++ b/scripts/status/generate_blocked_source_entries_page_job.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+import argparse
+import copy
+import sys
+
+from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_dry_run
+from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.common import get_release_job_prefix
+from ros_buildfarm.common import \
+    get_repositories_and_script_generating_key_files
+from ros_buildfarm.config import get_index
+from ros_buildfarm.git import get_repository
+from ros_buildfarm.jenkins import configure_job
+from ros_buildfarm.jenkins import configure_management_view
+from ros_buildfarm.jenkins import connect
+from ros_buildfarm.templates import expand_template
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Generate the 'blocked_releases_page' job on Jenkins")
+    add_argument_config_url(parser)
+    add_argument_rosdistro_name(parser)
+    add_argument_dry_run(parser)
+    args = parser.parse_args(argv)
+
+    config = get_index(args.config_url)
+    job_config = get_job_config(args, config)
+
+    jenkins = connect(config.jenkins_url)
+
+    configure_management_view(jenkins, dry_run=args.dry_run)
+
+    prefix = get_release_job_prefix(args.rosdistro_name)
+    job_name = '%s_blocked-releases-page' % prefix
+    configure_job(jenkins, job_name, job_config, dry_run=args.dry_run)
+
+
+def get_job_config(args, config):
+    template_name = 'status/blocked_releases_page_job.xml.em'
+
+    repository_args, script_generating_key_files = \
+        get_repositories_and_script_generating_key_files(config=config)
+
+    job_data = copy.deepcopy(args.__dict__)
+    job_data.update({
+        'ros_buildfarm_repository': get_repository(),
+
+        'script_generating_key_files': script_generating_key_files,
+
+        'rosdistro_index_url': config.rosdistro_index_url,
+
+        'repository_args': repository_args,
+
+        'notification_emails':
+        config.distributions[args.rosdistro_name]['notification_emails'],
+    })
+    job_config = expand_template(template_name, job_data)
+    return job_config
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/status/generate_blocked_source_entries_page_job.py
+++ b/scripts/status/generate_blocked_source_entries_page_job.py
@@ -20,7 +20,7 @@ from ros_buildfarm.templates import expand_template
 
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
-        description="Generate the 'blocked_releases_page' job on Jenkins")
+        description="Generate the 'blocked_source_entries_page' job on Jenkins")
     add_argument_config_url(parser)
     add_argument_rosdistro_name(parser)
     add_argument_dry_run(parser)
@@ -34,12 +34,12 @@ def main(argv=sys.argv[1:]):
     configure_management_view(jenkins, dry_run=args.dry_run)
 
     prefix = get_release_job_prefix(args.rosdistro_name)
-    job_name = '%s_blocked-releases-page' % prefix
+    job_name = '%s_blocked-source-entries-page' % prefix
     configure_job(jenkins, job_name, job_config, dry_run=args.dry_run)
 
 
 def get_job_config(args, config):
-    template_name = 'status/blocked_releases_page_job.xml.em'
+    template_name = 'status/blocked_source_entries_page_job.xml.em'
 
     repository_args, script_generating_key_files = \
         get_repositories_and_script_generating_key_files(config=config)

--- a/scripts/status/run_blocked_source_entries_page_job.py
+++ b/scripts/status/run_blocked_source_entries_page_job.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import argparse
+import copy
+import sys
+
+from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import \
+    add_argument_distribution_repository_key_files
+from ros_buildfarm.argument import add_argument_distribution_repository_urls
+from ros_buildfarm.argument import add_argument_dockerfile_dir
+from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.common import get_distribution_repository_keys
+from ros_buildfarm.common import get_user_id
+from ros_buildfarm.templates import create_dockerfile
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Run the 'blocked_releases_page' job")
+    add_argument_config_url(parser)
+    add_argument_rosdistro_name(parser)
+    add_argument_distribution_repository_urls(parser)
+    add_argument_distribution_repository_key_files(parser)
+    add_argument_dockerfile_dir(parser)
+    args = parser.parse_args(argv)
+
+    data = copy.deepcopy(args.__dict__)
+    data.update({
+        'distribution_repository_urls': args.distribution_repository_urls,
+        'distribution_repository_keys': get_distribution_repository_keys(
+            args.distribution_repository_urls,
+            args.distribution_repository_key_files),
+
+        'uid': get_user_id(),
+    })
+    create_dockerfile(
+        'status/blocked_releases_page_task.Dockerfile.em',
+        data, args.dockerfile_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/status/run_blocked_source_entries_page_job.py
+++ b/scripts/status/run_blocked_source_entries_page_job.py
@@ -17,7 +17,7 @@ from ros_buildfarm.templates import create_dockerfile
 
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
-        description="Run the 'blocked_releases_page' job")
+        description="Run the 'blocked_source_entries_page' job")
     add_argument_config_url(parser)
     add_argument_rosdistro_name(parser)
     add_argument_distribution_repository_urls(parser)
@@ -35,7 +35,7 @@ def main(argv=sys.argv[1:]):
         'uid': get_user_id(),
     })
     create_dockerfile(
-        'status/blocked_releases_page_task.Dockerfile.em',
+        'status/blocked_source_entries_page_task.Dockerfile.em',
         data, args.dockerfile_dir)
 
 


### PR DESCRIPTION
This also somewhat refactors the blocked releases page generation where convenient for code reuse.

This page shows which repositories need source entries, similar to the blocked releases page. The purpose is to determine which repos need to be worked on next for the Noetic release.

Fix Python 2.7 CI