### PR TITLE
test against Dashing instead of Crystal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,13 +95,13 @@ matrix:
         - mkdir job job/underlay1 job/underlay2 && cd job
         - ln -s .. ros_buildfarm
       script:
-        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly $OS_NAME $OS_CODE_NAME2 $ARCH --package-selection-args --packages-up-to $UNDERLAY1_PACKAGES > job.sh
+        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly-release $OS_NAME $OS_CODE_NAME2 $ARCH --package-selection-args --packages-up-to $UNDERLAY1_PACKAGES > job.sh
         - (. job.sh -y; exit $test_result_RC)
         - tar -xjf ros2-$ROS2_DISTRO_NAME-linux-$OS_CODE_NAME2-$ARCH-ci.tar.bz2 -C underlay1
-        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly $OS_NAME $OS_CODE_NAME2 $ARCH --underlay-source-path underlay1/ros2-linux --package-selection-args --packages-skip-up-to $UNDERLAY1_PACKAGES --packages-up-to $UNDERLAY2_PACKAGES > job.sh
+        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly-release $OS_NAME $OS_CODE_NAME2 $ARCH --underlay-source-path underlay1/ros2-linux --package-selection-args --packages-skip-up-to $UNDERLAY1_PACKAGES --packages-up-to $UNDERLAY2_PACKAGES > job.sh
         - (. job.sh -y; exit $test_result_RC)
         - tar -xjf ros2-$ROS2_DISTRO_NAME-linux-$OS_CODE_NAME2-$ARCH-ci.tar.bz2 -C underlay2
-        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly $OS_NAME $OS_CODE_NAME2 $ARCH --underlay-source-path underlay1/ros2-linux underlay2/ros2-linux --package-selection-args --packages-skip-up-to $UNDERLAY1_PACKAGES $UNDERLAY2_PACKAGES --packages-up-to $OVERLAY_PACKAGES > job.sh
+        - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly-release $OS_NAME $OS_CODE_NAME2 $ARCH --underlay-source-path underlay1/ros2-linux underlay2/ros2-linux --package-selection-args --packages-skip-up-to $UNDERLAY1_PACKAGES $UNDERLAY2_PACKAGES --packages-up-to $OVERLAY_PACKAGES > job.sh
         - (. job.sh -y; exit $test_result_RC)
     - language: python
       python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
     - CONFIG_URL=https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml
     - CONFIG2_URL=https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
     - ROS_DISTRO_NAME=melodic
-    - ROS2_DISTRO_NAME=crystal
+    - ROS2_DISTRO_NAME=dashing
     - OS_NAME=ubuntu
     - OS_CODE_NAME=bionic
     - OS_CODE_NAME2=bionic


### PR DESCRIPTION
CI on master is already failing and needs a backport and release of ament/ament_lint#185.

This is just an unrelated change to move to the latest ROS 2 distro.