### PR TITLE
Documentation improvements and a warning

### DIFF
--- a/doc/basic_configuration.rst
+++ b/doc/basic_configuration.rst
@@ -17,9 +17,16 @@ configuration to generate the necessary Jobs on the Jenkins master.
 Create / fork configuration repository
 --------------------------------------
 
-First you need to either fork the
+First you need to either fork or clone the
 `ros_buildfarm_config <https://github.com/ros-infrastructure/ros_buildfarm_config>`_
 repository or create a repository containing the same configuration files.
+
+**Important:**
+Since ``ros_buildfarm_config`` files need to be accessed from within docker images,
+you **can not** use a local file system path (``file:/``) to reference them.
+You have to provide an http server where the configuration files can be accessed.
+(Note that on the build farm master, Jenkins usually occupies the standard port 80).
+
 
 Then you must update the configuration files:
 
@@ -35,8 +42,7 @@ The following options must be set in *all* build files::
 
     notifications:
       committers: false
-    maintainers
-      committers: false
+      maintainers: false
 
 
 Update administrator notification
@@ -44,7 +50,7 @@ Update administrator notification
 
 Change the email address which gets notified about any administrative jobs.
 
-In the entry point yaml::
+In [ros-infrastructure/ros_buildfarm_config](https://github.com/ros-infrastructure/ros_buildfarm_config)'s `index.yaml`::
 
   notification_emails:
   - your_email@example.com
@@ -55,17 +61,33 @@ In *all* build files::
     emails:
     - your_email@example.com
 
+Note that you need to have a local smtp service configured for email notifications.
+
+If you do not require email notifications, remove the configuration line entries.
+
 
 Update URLs to point to custom build farm
 -----------------------------------------
 
-Change the Jenkins URL in the entry point yaml to point to your earlier
-provisioned Jenkins master::
+Change the ``rosdistro_index_url`` in the [ros-infrastructure/ros_buildfarm_config](https://github.com/ros-infrastructure/ros_buildfarm_config)'s 
+``index.yaml`` to point to the ``rosdistro`` repository that defines the distro(s) that your buildfarm should build.
+
+**Important:** Note that this the [rosdistro](https://github.com/ros/rosdistro)'s ``index.yaml``
+(which points to the files that define which packages are included in the distro and respective caches),
+and **not** the ``index.yaml`` in ``ros_buildfarm_config`` which you are editing.
+
+This will usually be on the provisioned ``repo`` host, but can be the official [ros/rosdistro](https://github.com/ros/rosdistro)'
+
+    rosdistro_index_url: http://repo_hostname.example.com/rosdistro/index.yaml
+
+
+Change the Jenkins URL in the [ros-infrastructure/ros_buildfarm_config](https://github.com/ros-infrastructure/ros_buildfarm_config)'s 
+``index.yaml`` to point to your earlier provisioned Jenkins master::
 
   jenkins_url: http://jenkins_hostname.example.com:8080
 
-Change the repository URLs in the entry point yaml to point to your earlier
-provisioned ``repo`` host::
+Change the repository URLs in the [ros-infrastructure/ros_buildfarm_config](https://github.com/ros-infrastructure/ros_buildfarm_config)'s
+``index.yaml`` to point to your earlier provisioned ``repo`` host::
 
   status_page_repositories:
     CUSTOM_NAME:
@@ -100,3 +122,49 @@ repository::
 
 You can extract the repository PGP key from the ``buildfarm_deployment``
 configuration.
+
+
+Update URLs to point to required build tool repositories
+--------------------------------------------------------
+
+During job execution, access to repositories which contain the necessary tools to run the ROS build farm is required.
+These can be main ROS repository or mirrors of it.
+Note that the number of ``debian_repositories`` and ``debian_repository_keys`` must match, as well as the order in which they're specified.
+The keys can usually be found on the repository (for example: http://packages.ros.org/ros.asc )
+
+    prerequisites:
+      debian_repositories:
+      - http://packages.ros.org/ros/ubuntu
+      debian_repository_keys:
+      - |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: GnuPG v1
+
+        mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+        VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+        u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+        K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+        aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+        TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+        pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+        V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+        hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+        /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+        okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+        tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQoA
+        PhYhBMHPbjHmut6IaLFytPQu1vurF8ZUBQJc7yaWAhsDBQkDwmcABQsJCAcCBhUK
+        CQgLAgQWAgMBAh4BAheAAAoJEPQu1vurF8ZUkhIP/RbZY1ErvCEUy8iLJm9aSpLQ
+        nDZl5xILOxyZlzpg+Ml5bb0EkQDr92foCgcvLeANKARNCaGLyNIWkuyDovPV0xZJ
+        rEy0kgBrDNb3++NmdI/+GA92pkedMXXioQvqdsxUagXAIB/sNGByJEhs37F05AnF
+        vZbjUhceq3xTlvAMcrBWrgB4NwBivZY6IgLvl/CRQpVYwANShIQdbvHvZSxRonWh
+        NXr6v/Wcf8rsp7g2VqJ2N2AcWT84aa9BLQ3Oe/SgrNx4QEhA1y7rc3oaqPVu5ZXO
+        K+4O14JrpbEZ3Xs9YEjrcOuEDEpYktA8qqUDTdFyZrxb9S6BquUKrA6jZgT913kj
+        J4e7YAZobC4rH0w4u0PrqDgYOkXA9Mo7L601/7ZaDJob80UcK+Z12ZSw73IgBix6
+        DiJVfXuWkk5PM2zsFn6UOQXUNlZlDAOj5NC01V0fJ8P0v6GO9YOSSQx0j5UtkUbR
+        fp/4W7uCPFvwAatWEHJhlM3sQNiMNStJFegr56xQu1a/cbJH7GdbseMhG/f0BaKQ
+        qXCI3ffB5y5AOLc9Hw7PYiTFQsuY1ePRhE+J9mejgWRZxkjAH/FlAubqXkDgterC
+        h+sLkzGf+my2IbsMCuc+3aeNMJ5Ej/vlXefCH/MpPWAHCqpQhe2DET/jRSaM53US
+        AHNx8kw4MPUkxExgI7Sd
+        =4Ofr
+        -----END PGP PUBLIC KEY BLOCK-----
+

--- a/doc/basic_configuration.rst
+++ b/doc/basic_configuration.rst
@@ -76,7 +76,7 @@ and **not** the ``index.yaml`` in ``ros_buildfarm_config`` which you are editing
 
 This can be the official `ros/rosdistro <https://github.com/ros/rosdistro>`_'s ``index.yaml`` 
 if you intend to build the default set of packages, or your personal configuration where you intend to host
-``rosdistro`` (for example a GitHub fork of ``ros/rosdistro`` or your ``repo`` host) ::
+``rosdistro`` (for example a GitHub fork of ``ros/rosdistro`` or your ``repo`` host)::
 
   rosdistro_index_url: https://raw.githubusercontent.com/ros/rosdistro/master/index.yaml
 

--- a/doc/basic_configuration.rst
+++ b/doc/basic_configuration.rst
@@ -23,7 +23,7 @@ repository or create a repository containing the same configuration files.
 
 **Important:**
 Since ``ros_buildfarm_config`` files need to be accessed from within docker images,
-you **can not** use a local file system path (``file:/``) to reference them.
+you **can not** use a local file system path (`file://`) to reference them.
 You have to provide an http server where the configuration files can be accessed.
 (Note that on the build farm master, Jenkins usually occupies the standard port 80).
 

--- a/doc/basic_configuration.rst
+++ b/doc/basic_configuration.rst
@@ -22,9 +22,9 @@ First you need to either fork, clone, or copy the
 repository or create a repository containing the same configuration files.
 
 **Important:**
-Since ``ros_buildfarm_config`` files need to be accessed from within docker images,
+Since ``ros_buildfarm_config`` files need to be accessed from within Docker images,
 you **can not** use a local file system path (``file://``) to reference them.
-The configuration files must be accessible via http.
+The configuration files must be accessible via HTTP.
 
 
 Then you must update the configuration files:
@@ -77,7 +77,7 @@ and **not** the ``index.yaml`` in ``ros_buildfarm_config`` which you are editing
 
 This can be the official `ros/rosdistro <https://github.com/ros/rosdistro>`_'s ``index.yaml`` 
 if you intend to build the default set of packages, or your personal configuration where you intend to host
-``rosdistro`` (for example a github fork of ``ros/rosdistro`` or your ``repo`` host) ::
+``rosdistro`` (for example a GitHub fork of ``ros/rosdistro`` or your ``repo`` host) ::
 
   rosdistro_index_url: https://raw.githubusercontent.com/ros/rosdistro/master/index.yaml
 

--- a/doc/basic_configuration.rst
+++ b/doc/basic_configuration.rst
@@ -77,7 +77,7 @@ and **not** the ``index.yaml`` in ``ros_buildfarm_config`` which you are editing
 
 This can be the official `ros/rosdistro <https://github.com/ros/rosdistro>`_'s ``index.yaml`` 
 if you intend to build the default set of packages, or your personal configuration where you intend to host
-``rosdistro`` (for example your ``repo`` host) ::
+``rosdistro`` (for example a github fork of ``ros/rosdistro`` or your ``repo`` host) ::
 
   rosdistro_index_url: https://raw.githubusercontent.com/ros/rosdistro/master/index.yaml
 
@@ -128,44 +128,6 @@ Update URLs to point to required repositories
 ---------------------------------------------
 
 During job execution, access to repositories which contain the necessary tools to run the ROS build farm is required.
-These can be main ROS repository or mirrors of it::
-
-  prerequisites:
-    debian_repositories:
-    - http://packages.ros.org/ros/ubuntu
-    debian_repository_keys:
-    - |
-      -----BEGIN PGP PUBLIC KEY BLOCK-----
-      Version: GnuPG v1
-      
-      mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
-      VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
-      u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
-      K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
-      aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
-      TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
-      pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
-      V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
-      hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
-      /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
-      okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
-      tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQoA
-      PhYhBMHPbjHmut6IaLFytPQu1vurF8ZUBQJc7yaWAhsDBQkDwmcABQsJCAcCBhUK
-      CQgLAgQWAgMBAh4BAheAAAoJEPQu1vurF8ZUkhIP/RbZY1ErvCEUy8iLJm9aSpLQ
-      nDZl5xILOxyZlzpg+Ml5bb0EkQDr92foCgcvLeANKARNCaGLyNIWkuyDovPV0xZJ
-      rEy0kgBrDNb3++NmdI/+GA92pkedMXXioQvqdsxUagXAIB/sNGByJEhs37F05AnF
-      vZbjUhceq3xTlvAMcrBWrgB4NwBivZY6IgLvl/CRQpVYwANShIQdbvHvZSxRonWh
-      NXr6v/Wcf8rsp7g2VqJ2N2AcWT84aa9BLQ3Oe/SgrNx4QEhA1y7rc3oaqPVu5ZXO
-      K+4O14JrpbEZ3Xs9YEjrcOuEDEpYktA8qqUDTdFyZrxb9S6BquUKrA6jZgT913kj
-      J4e7YAZobC4rH0w4u0PrqDgYOkXA9Mo7L601/7ZaDJob80UcK+Z12ZSw73IgBix6
-      DiJVfXuWkk5PM2zsFn6UOQXUNlZlDAOj5NC01V0fJ8P0v6GO9YOSSQx0j5UtkUbR
-      fp/4W7uCPFvwAatWEHJhlM3sQNiMNStJFegr56xQu1a/cbJH7GdbseMhG/f0BaKQ
-      qXCI3ffB5y5AOLc9Hw7PYiTFQsuY1ePRhE+J9mejgWRZxkjAH/FlAubqXkDgterC
-      h+sLkzGf+my2IbsMCuc+3aeNMJ5Ej/vlXefCH/MpPWAHCqpQhe2DET/jRSaM53US
-      AHNx8kw4MPUkxExgI7Sd
-      =4Ofr
-      -----END PGP PUBLIC KEY BLOCK-----
-
-
-Note that the number of ``debian_repositories`` and ``debian_repository_keys`` must match, as well as the order in which they're specified.
-The keys can usually be found on the repository (for example: http://packages.ros.org/ros.asc )
+These must be specified in your ``ros_buildfarm_config``'s ``index.yaml`` as ``prerequisites``.
+You can use the official ROS repository or mirrors of it.
+See the `Configuration Options <https://github.com/max-krichenbauer/ros_buildfarm/blob/documentation-improvements/doc/configuration_options.rst#entry-point-yaml>`_ documentation page for details.

--- a/doc/basic_configuration.rst
+++ b/doc/basic_configuration.rst
@@ -26,7 +26,6 @@ Since ``ros_buildfarm_config`` files need to be accessed from within Docker imag
 you **can not** use a local file system path (``file://``) to reference them.
 The configuration files must be accessible via HTTP.
 
-
 Then you must update the configuration files:
 
 

--- a/doc/basic_configuration.rst
+++ b/doc/basic_configuration.rst
@@ -59,20 +59,19 @@ In *all* build files::
     emails:
     - your_email@example.com
 
-You need to have a `local smtp service configured <https://github.com/ros-infrastructure/buildfarm_deployment#setup-master-for-email-delivery>`_ for email notifications.
+You need to have a `local smtp service configured <https://github.com/ros-infrastructure/buildfarm_deployment#setup-master-for-email-delivery>`_ on your ``master`` host for email notifications.
 Note that even when you remove these global email notification settings
-some jobs will still send notification emails to package specific email addresses.
+some jobs will still send notification emails to package specific email addresses
+by default unless this is disabled by configuration.
+
 
 
 Update URLs to point to custom build farm
 -----------------------------------------
 
-Change the ``rosdistro_index_url`` in your ``ros_buildfarm_config``'s 
-``index.yaml`` to point to the ``rosdistro`` repository that defines the distro(s) that your buildfarm should build.
-
-**Important:** Note that this is the `rosdistro <https://github.com/ros/rosdistro>`_'s ``index.yaml``
-(which points to the files that define which packages are included in the distro and respective caches),
-and **not** the ``index.yaml`` in ``ros_buildfarm_config`` which you are editing.
+Change the ``rosdistro_index_url`` in your ``ros_buildfarm_config``'s ``index.yaml`` 
+to point to the ``rosdistro``'s ``index.yaml``
+that defines the distro(s) that your buildfarm should build and respective caches.
 
 This can be the official `ros/rosdistro <https://github.com/ros/rosdistro>`_'s ``index.yaml`` 
 if you intend to build the default set of packages, or your personal configuration where you intend to host
@@ -129,4 +128,4 @@ Update URLs to point to required repositories
 During job execution, access to repositories which contain the necessary tools to run the ROS build farm is required.
 These must be specified in your ``ros_buildfarm_config``'s ``index.yaml`` as ``prerequisites``.
 You can use the official ROS repository or mirrors of it.
-See the `Configuration Options <https://github.com/max-krichenbauer/ros_buildfarm/blob/documentation-improvements/doc/configuration_options.rst#entry-point-yaml>`_ documentation page for details.
+See the `Configuration Options <https://github.com/ros-infrastructure/ros_buildfarm/blob/master/doc/configuration_options.rst#entry-point-yaml>`_ documentation page for details.

--- a/doc/basic_configuration.rst
+++ b/doc/basic_configuration.rst
@@ -17,15 +17,14 @@ configuration to generate the necessary Jobs on the Jenkins master.
 Create / fork configuration repository
 --------------------------------------
 
-First you need to either fork or clone the
+First you need to either fork, clone, or copy the
 `ros_buildfarm_config <https://github.com/ros-infrastructure/ros_buildfarm_config>`_
 repository or create a repository containing the same configuration files.
 
 **Important:**
 Since ``ros_buildfarm_config`` files need to be accessed from within docker images,
-you **can not** use a local file system path (`file://`) to reference them.
-You have to provide an http server where the configuration files can be accessed.
-(Note that on the build farm master, Jenkins usually occupies the standard port 80).
+you **can not** use a local file system path (``file://``) to reference them.
+The configuration files must be accessible via http.
 
 
 Then you must update the configuration files:
@@ -50,7 +49,7 @@ Update administrator notification
 
 Change the email address which gets notified about any administrative jobs.
 
-In `ros-infrastructure/ros_buildfarm_config <https://github.com/ros-infrastructure/ros_buildfarm_config>`_'s `index.yaml`::
+In your ``ros_buildfarm_config``'s ``index.yaml``::
 
   notification_emails:
   - your_email@example.com
@@ -61,31 +60,33 @@ In *all* build files::
     emails:
     - your_email@example.com
 
-Note that you need to have a local smtp service configured for email notifications.
-
-If you do not require email notifications, remove the configuration line entries.
+You need to have a `local smtp service configured <https://github.com/ros-infrastructure/buildfarm_deployment#setup-master-for-email-delivery>`_ for email notifications.
+Note that even when you remove these global email notification settings
+some jobs will still send notification emails to package specific email addresses.
 
 
 Update URLs to point to custom build farm
 -----------------------------------------
 
-Change the ``rosdistro_index_url`` in the `ros-infrastructure/ros_buildfarm_config <https://github.com/ros-infrastructure/ros_buildfarm_config>`_'s 
+Change the ``rosdistro_index_url`` in your ``ros_buildfarm_config``'s 
 ``index.yaml`` to point to the ``rosdistro`` repository that defines the distro(s) that your buildfarm should build.
 
-**Important:** Note that this the `rosdistro <https://github.com/ros/rosdistro>`_'s ``index.yaml``
+**Important:** Note that this is the `rosdistro <https://github.com/ros/rosdistro>`_'s ``index.yaml``
 (which points to the files that define which packages are included in the distro and respective caches),
 and **not** the ``index.yaml`` in ``ros_buildfarm_config`` which you are editing.
 
-This will usually be on the provisioned ``repo`` host, but can be the official `ros/rosdistro <https://github.com/ros/rosdistro>`_'s ``index.yaml`` if you intend to build the default set of packages::
+This can be the official `ros/rosdistro <https://github.com/ros/rosdistro>`_'s ``index.yaml`` 
+if you intend to build the default set of packages, or your personal configuration where you intend to host
+``rosdistro`` (for example your ``repo`` host) ::
 
-  rosdistro_index_url: http://repo_hostname.example.com/rosdistro/index.yaml
+  rosdistro_index_url: https://raw.githubusercontent.com/ros/rosdistro/master/index.yaml
 
-Change the Jenkins URL in the `ros-infrastructure/ros_buildfarm_config <https://github.com/ros-infrastructure/ros_buildfarm_config>`_'s 
+Change the Jenkins URL in your ``ros_buildfarm_config``'s 
 ``index.yaml`` to point to your earlier provisioned Jenkins master::
 
   jenkins_url: http://jenkins_hostname.example.com:8080
 
-Change the repository URLs in the `ros-infrastructure/ros_buildfarm_config <https://github.com/ros-infrastructure/ros_buildfarm_config>`_'s
+Change the repository URLs in your ``ros_buildfarm_config``_'s
 ``index.yaml`` to point to your earlier provisioned ``repo`` host::
 
   status_page_repositories:
@@ -123,8 +124,8 @@ You can extract the repository PGP key from the ``buildfarm_deployment``
 configuration.
 
 
-Update URLs to point to required build tool repositories
---------------------------------------------------------
+Update URLs to point to required repositories
+---------------------------------------------
 
 During job execution, access to repositories which contain the necessary tools to run the ROS build farm is required.
 These can be main ROS repository or mirrors of it::

--- a/doc/basic_configuration.rst
+++ b/doc/basic_configuration.rst
@@ -65,7 +65,6 @@ some jobs will still send notification emails to package specific email addresse
 by default unless this is disabled by configuration.
 
 
-
 Update URLs to point to custom build farm
 -----------------------------------------
 

--- a/doc/basic_configuration.rst
+++ b/doc/basic_configuration.rst
@@ -50,7 +50,7 @@ Update administrator notification
 
 Change the email address which gets notified about any administrative jobs.
 
-In [ros-infrastructure/ros_buildfarm_config](https://github.com/ros-infrastructure/ros_buildfarm_config)'s `index.yaml`::
+In `ros-infrastructure/ros_buildfarm_config <https://github.com/ros-infrastructure/ros_buildfarm_config>`_'s `index.yaml`::
 
   notification_emails:
   - your_email@example.com
@@ -69,24 +69,23 @@ If you do not require email notifications, remove the configuration line entries
 Update URLs to point to custom build farm
 -----------------------------------------
 
-Change the ``rosdistro_index_url`` in the [ros-infrastructure/ros_buildfarm_config](https://github.com/ros-infrastructure/ros_buildfarm_config)'s 
+Change the ``rosdistro_index_url`` in the `ros-infrastructure/ros_buildfarm_config <https://github.com/ros-infrastructure/ros_buildfarm_config>`_'s 
 ``index.yaml`` to point to the ``rosdistro`` repository that defines the distro(s) that your buildfarm should build.
 
-**Important:** Note that this the [rosdistro](https://github.com/ros/rosdistro)'s ``index.yaml``
+**Important:** Note that this the `rosdistro <https://github.com/ros/rosdistro>`_'s ``index.yaml``
 (which points to the files that define which packages are included in the distro and respective caches),
 and **not** the ``index.yaml`` in ``ros_buildfarm_config`` which you are editing.
 
-This will usually be on the provisioned ``repo`` host, but can be the official [ros/rosdistro](https://github.com/ros/rosdistro)'
+This will usually be on the provisioned ``repo`` host, but can be the official `ros/rosdistro <https://github.com/ros/rosdistro>`_'s ``index.yaml`` if you intend to build the default set of packages.
 
-    rosdistro_index_url: http://repo_hostname.example.com/rosdistro/index.yaml
+  rosdistro_index_url: http://repo_hostname.example.com/rosdistro/index.yaml
 
-
-Change the Jenkins URL in the [ros-infrastructure/ros_buildfarm_config](https://github.com/ros-infrastructure/ros_buildfarm_config)'s 
+Change the Jenkins URL in the `ros-infrastructure/ros_buildfarm_config <https://github.com/ros-infrastructure/ros_buildfarm_config>`_'s 
 ``index.yaml`` to point to your earlier provisioned Jenkins master::
 
   jenkins_url: http://jenkins_hostname.example.com:8080
 
-Change the repository URLs in the [ros-infrastructure/ros_buildfarm_config](https://github.com/ros-infrastructure/ros_buildfarm_config)'s
+Change the repository URLs in the `ros-infrastructure/ros_buildfarm_config <https://github.com/ros-infrastructure/ros_buildfarm_config>`_'s
 ``index.yaml`` to point to your earlier provisioned ``repo`` host::
 
   status_page_repositories:
@@ -132,39 +131,39 @@ These can be main ROS repository or mirrors of it.
 Note that the number of ``debian_repositories`` and ``debian_repository_keys`` must match, as well as the order in which they're specified.
 The keys can usually be found on the repository (for example: http://packages.ros.org/ros.asc )
 
-    prerequisites:
-      debian_repositories:
-      - http://packages.ros.org/ros/ubuntu
-      debian_repository_keys:
-      - |
-        -----BEGIN PGP PUBLIC KEY BLOCK-----
-        Version: GnuPG v1
-
-        mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
-        VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
-        u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
-        K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
-        aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
-        TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
-        pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
-        V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
-        hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
-        /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
-        okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
-        tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQoA
-        PhYhBMHPbjHmut6IaLFytPQu1vurF8ZUBQJc7yaWAhsDBQkDwmcABQsJCAcCBhUK
-        CQgLAgQWAgMBAh4BAheAAAoJEPQu1vurF8ZUkhIP/RbZY1ErvCEUy8iLJm9aSpLQ
-        nDZl5xILOxyZlzpg+Ml5bb0EkQDr92foCgcvLeANKARNCaGLyNIWkuyDovPV0xZJ
-        rEy0kgBrDNb3++NmdI/+GA92pkedMXXioQvqdsxUagXAIB/sNGByJEhs37F05AnF
-        vZbjUhceq3xTlvAMcrBWrgB4NwBivZY6IgLvl/CRQpVYwANShIQdbvHvZSxRonWh
-        NXr6v/Wcf8rsp7g2VqJ2N2AcWT84aa9BLQ3Oe/SgrNx4QEhA1y7rc3oaqPVu5ZXO
-        K+4O14JrpbEZ3Xs9YEjrcOuEDEpYktA8qqUDTdFyZrxb9S6BquUKrA6jZgT913kj
-        J4e7YAZobC4rH0w4u0PrqDgYOkXA9Mo7L601/7ZaDJob80UcK+Z12ZSw73IgBix6
-        DiJVfXuWkk5PM2zsFn6UOQXUNlZlDAOj5NC01V0fJ8P0v6GO9YOSSQx0j5UtkUbR
-        fp/4W7uCPFvwAatWEHJhlM3sQNiMNStJFegr56xQu1a/cbJH7GdbseMhG/f0BaKQ
-        qXCI3ffB5y5AOLc9Hw7PYiTFQsuY1ePRhE+J9mejgWRZxkjAH/FlAubqXkDgterC
-        h+sLkzGf+my2IbsMCuc+3aeNMJ5Ej/vlXefCH/MpPWAHCqpQhe2DET/jRSaM53US
-        AHNx8kw4MPUkxExgI7Sd
-        =4Ofr
-        -----END PGP PUBLIC KEY BLOCK-----
+  prerequisites:
+    debian_repositories:
+    - http://packages.ros.org/ros/ubuntu
+    debian_repository_keys:
+    - |
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+      Version: GnuPG v1
+      
+      mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+      VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+      u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+      K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+      aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+      TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+      pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+      V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+      hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+      /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+      okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+      tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQoA
+      PhYhBMHPbjHmut6IaLFytPQu1vurF8ZUBQJc7yaWAhsDBQkDwmcABQsJCAcCBhUK
+      CQgLAgQWAgMBAh4BAheAAAoJEPQu1vurF8ZUkhIP/RbZY1ErvCEUy8iLJm9aSpLQ
+      nDZl5xILOxyZlzpg+Ml5bb0EkQDr92foCgcvLeANKARNCaGLyNIWkuyDovPV0xZJ
+      rEy0kgBrDNb3++NmdI/+GA92pkedMXXioQvqdsxUagXAIB/sNGByJEhs37F05AnF
+      vZbjUhceq3xTlvAMcrBWrgB4NwBivZY6IgLvl/CRQpVYwANShIQdbvHvZSxRonWh
+      NXr6v/Wcf8rsp7g2VqJ2N2AcWT84aa9BLQ3Oe/SgrNx4QEhA1y7rc3oaqPVu5ZXO
+      K+4O14JrpbEZ3Xs9YEjrcOuEDEpYktA8qqUDTdFyZrxb9S6BquUKrA6jZgT913kj
+      J4e7YAZobC4rH0w4u0PrqDgYOkXA9Mo7L601/7ZaDJob80UcK+Z12ZSw73IgBix6
+      DiJVfXuWkk5PM2zsFn6UOQXUNlZlDAOj5NC01V0fJ8P0v6GO9YOSSQx0j5UtkUbR
+      fp/4W7uCPFvwAatWEHJhlM3sQNiMNStJFegr56xQu1a/cbJH7GdbseMhG/f0BaKQ
+      qXCI3ffB5y5AOLc9Hw7PYiTFQsuY1ePRhE+J9mejgWRZxkjAH/FlAubqXkDgterC
+      h+sLkzGf+my2IbsMCuc+3aeNMJ5Ej/vlXefCH/MpPWAHCqpQhe2DET/jRSaM53US
+      AHNx8kw4MPUkxExgI7Sd
+      =4Ofr
+      -----END PGP PUBLIC KEY BLOCK-----
 

--- a/doc/basic_configuration.rst
+++ b/doc/basic_configuration.rst
@@ -76,7 +76,7 @@ Change the ``rosdistro_index_url`` in the `ros-infrastructure/ros_buildfarm_conf
 (which points to the files that define which packages are included in the distro and respective caches),
 and **not** the ``index.yaml`` in ``ros_buildfarm_config`` which you are editing.
 
-This will usually be on the provisioned ``repo`` host, but can be the official `ros/rosdistro <https://github.com/ros/rosdistro>`_'s ``index.yaml`` if you intend to build the default set of packages.
+This will usually be on the provisioned ``repo`` host, but can be the official `ros/rosdistro <https://github.com/ros/rosdistro>`_'s ``index.yaml`` if you intend to build the default set of packages::
 
   rosdistro_index_url: http://repo_hostname.example.com/rosdistro/index.yaml
 
@@ -127,9 +127,7 @@ Update URLs to point to required build tool repositories
 --------------------------------------------------------
 
 During job execution, access to repositories which contain the necessary tools to run the ROS build farm is required.
-These can be main ROS repository or mirrors of it.
-Note that the number of ``debian_repositories`` and ``debian_repository_keys`` must match, as well as the order in which they're specified.
-The keys can usually be found on the repository (for example: http://packages.ros.org/ros.asc )
+These can be main ROS repository or mirrors of it::
 
   prerequisites:
     debian_repositories:
@@ -167,3 +165,6 @@ The keys can usually be found on the repository (for example: http://packages.ro
       =4Ofr
       -----END PGP PUBLIC KEY BLOCK-----
 
+
+Note that the number of ``debian_repositories`` and ``debian_repository_keys`` must match, as well as the order in which they're specified.
+The keys can usually be found on the repository (for example: http://packages.ros.org/ros.asc )

--- a/doc/basic_configuration.rst
+++ b/doc/basic_configuration.rst
@@ -128,4 +128,4 @@ Update URLs to point to required repositories
 During job execution, access to repositories which contain the necessary tools to run the ROS build farm is required.
 These must be specified in your ``ros_buildfarm_config``'s ``index.yaml`` as ``prerequisites``.
 You can use the official ROS repository or mirrors of it.
-See the `Configuration Options <https://github.com/ros-infrastructure/ros_buildfarm/blob/master/doc/configuration_options.rst#entry-point-yaml>`_ documentation page for details.
+See the `Configuration Options <configuration_options.rst#entry-point-yaml>`_ documentation page for details.

--- a/doc/basic_configuration.rst
+++ b/doc/basic_configuration.rst
@@ -59,7 +59,7 @@ In *all* build files::
     emails:
     - your_email@example.com
 
-You need to have a `local smtp service configured <https://github.com/ros-infrastructure/buildfarm_deployment#setup-master-for-email-delivery>`_ on your ``master`` host for email notifications.
+You need to have a `local SMTP service configured <https://github.com/ros-infrastructure/buildfarm_deployment#setup-master-for-email-delivery>`_ on your ``master`` host for email notifications.
 Note that even when you remove these global email notification settings
 some jobs will still send notification emails to package specific email addresses
 by default unless this is disabled by configuration.

--- a/scripts/generate_all_jobs.py
+++ b/scripts/generate_all_jobs.py
@@ -58,6 +58,13 @@ def main(argv=sys.argv[1:]):
     print('')
 
     config = get_index(args.config_url)
+    if args.config_url.startswith("file:"):
+        print('!WARNING!')
+        print('! Local file system path used for configuration.')
+        print('! Configuration will not be accessible to jobs during execution.')
+        print('! Consider using a web(http) hosted configuration repository.')
+        print('')
+
     ros_distro_names = sorted(config.distributions.keys())
 
     invalid_ros_distro_name = [

--- a/scripts/generate_all_jobs.py
+++ b/scripts/generate_all_jobs.py
@@ -59,9 +59,10 @@ def main(argv=sys.argv[1:]):
 
     config = get_index(args.config_url)
     if args.config_url.startswith('file:'):
-        sys.stderr.write('WARNING: Local file system path used for configuration. ', \
-                         'Configuration will not be accessible to jobs during execution. ', \
-                         'Consider using a web(http) hosted configuration repository.')
+        sys.stderr.write('WARNING: Local file system path used for ',
+                         'configuration. Configuration will not be ',
+                         'accessible to jobs during execution. Consider ',
+                         'using a web(http) hosted configuration repository.')
 
     ros_distro_names = sorted(config.distributions.keys())
 

--- a/scripts/generate_all_jobs.py
+++ b/scripts/generate_all_jobs.py
@@ -60,12 +60,10 @@ def main(argv=sys.argv[1:]):
     config = get_index(args.config_url)
     if args.config_url.startswith('file:'):
         print(
-            'WARNING: Local file system path used for ',
-            'configuration. Configuration will not be ',
-            'accessible to jobs during execution. Consider ',
-            'using a web(http) hosted configuration repository.',
-            file=sys.stderr
-        )
+            'WARNING: Local file system path used for configuration. ',
+            'Configuration will not be accessible to jobs during execution. ',
+            'Consider  using a web(http) hosted configuration repository.',
+            file=sys.stderr)
 
     ros_distro_names = sorted(config.distributions.keys())
 

--- a/scripts/generate_all_jobs.py
+++ b/scripts/generate_all_jobs.py
@@ -58,12 +58,10 @@ def main(argv=sys.argv[1:]):
     print('')
 
     config = get_index(args.config_url)
-    if args.config_url.startswith("file:"):
-        print('!WARNING!')
-        print('! Local file system path used for configuration.')
-        print('! Configuration will not be accessible to jobs during execution.')
-        print('! Consider using a web(http) hosted configuration repository.')
-        print('')
+    if args.config_url.startswith('file:'):
+        sys.stderr.write('WARNING: Local file system path used for configuration. ', \
+                         'Configuration will not be accessible to jobs during execution. ', \
+                         'Consider using a web(http) hosted configuration repository.')
 
     ros_distro_names = sorted(config.distributions.keys())
 

--- a/scripts/generate_all_jobs.py
+++ b/scripts/generate_all_jobs.py
@@ -59,10 +59,11 @@ def main(argv=sys.argv[1:]):
 
     config = get_index(args.config_url)
     if args.config_url.startswith('file:'):
-        sys.stderr.write('WARNING: Local file system path used for ',
-                         'configuration. Configuration will not be ',
-                         'accessible to jobs during execution. Consider ',
-                         'using a web(http) hosted configuration repository.')
+        print('WARNING: Local file system path used for ',
+              'configuration. Configuration will not be ',
+              'accessible to jobs during execution. Consider ',
+              'using a web(http) hosted configuration repository.',
+              file=sys.stderr)
 
     ros_distro_names = sorted(config.distributions.keys())
 

--- a/scripts/generate_all_jobs.py
+++ b/scripts/generate_all_jobs.py
@@ -59,11 +59,13 @@ def main(argv=sys.argv[1:]):
 
     config = get_index(args.config_url)
     if args.config_url.startswith('file:'):
-        print('WARNING: Local file system path used for ',
-              'configuration. Configuration will not be ',
-              'accessible to jobs during execution. Consider ',
-              'using a web(http) hosted configuration repository.',
-              file=sys.stderr)
+        print(
+            'WARNING: Local file system path used for ',
+            'configuration. Configuration will not be ',
+            'accessible to jobs during execution. Consider ',
+            'using a web(http) hosted configuration repository.',
+            file=sys.stderr
+        )
 
     ros_distro_names = sorted(config.distributions.keys())
 


### PR DESCRIPTION
Hello!

These are just some minor improvements to the documentation on how to set up a build farm, as well as adding a warning when users are about to make a common mistake in specifying a local file system path as config URL. 

The related ROS Answers thread is here:
https://answers.ros.org/question/331213/buildfarm-jobs-cant-access-ros_buildfarm-ros_buildfarm_config-repos/
