### PR TITLE
vertical align cells in blocked status pages

### DIFF
--- a/ros_buildfarm/templates/status/css/blocked_releases_page.css
+++ b/ros_buildfarm/templates/status/css/blocked_releases_page.css
@@ -6,7 +6,7 @@ thead tr th:nth-child(even) div { font-weight: normal }
 tbody tr td:nth-child(1) div { width: 150px; overflow-x: hidden; text-overflow: ellipsis; }
 
 .table-div { padding-left: 15px; padding-right: 15px; }
-tbody tr td { padding-left: 10px; }
+tbody tr td { padding-left: 10px; vertical-align: top; }
 
 /* Give the table more breathing room on a wider display. */
 @media (min-width: 1400px) {


### PR DESCRIPTION
Since the blocked status pages sometimes show a large number of names in a single cell the height of a row can get pretty high. As a consequence cells with only a single line are not easy to see since they are shown vertically centered by default.

This patch makes sure all cells are vertically positioned at the top of each cell. Also helpful for #674.