### PR TITLE
Implement the abichecker run on devel builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -197,8 +197,6 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
-        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
-        - *rosgpgkeyadd
         - sudo apt-get update
         - sudo apt-get install -y python3-pip python3-setuptools
         - sudo pip3 install vcstool
@@ -302,8 +300,6 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
-        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
-        - *rosgpgkeyadd
         - sudo apt-get update
         - sudo apt-get install -y python3-pip python3-setuptools
         - sudo pip3 install vcstool
@@ -407,8 +403,6 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
-        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
-        - *rosgpgkeyadd
         - sudo apt-get update
         - sudo apt-get install -y python3-pip  python3-setuptools
         - sudo pip3 install vcstool
@@ -491,8 +485,6 @@ matrix:
         - docker
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="roscpp_core" OVERLAY_PACKAGE_NAMES=roscpp
       before_script:
-        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
-        - *rosgpgkeyadd
         - sudo apt-get update
         - sudo apt-get install -y python3-pip python3-setuptools
         - sudo pip3 install EmPy
@@ -517,8 +509,6 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
-        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
-        - *rosgpgkeyadd
         - sudo apt-get update
         - sudo apt-get install -y python3-pip python3-setuptools
         - sudo pip3 install EmPy vcstool

--- a/.travis.yml
+++ b/.travis.yml
@@ -197,8 +197,10 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
+        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
+        - *rosgpgkeyadd
         - sudo apt-get update
-        - sudo apt-get install -y python3-pip python3-setuptools
+        - sudo apt-get install -y python3-pip python3-setuptools python3-catkin-pkg-modules
         - sudo pip3 install vcstool
         - python setup.py install
         - mkdir job && cd job
@@ -285,6 +287,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install dpkg -y  # necessary for catkin-pkg to be installable
         - sudo apt-get install ros-kinetic-catkin -y
+        - sudo apt-get install python3-catkin-pkg-modules -y
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm
@@ -300,8 +303,10 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
+        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
+        - *rosgpgkeyadd
         - sudo apt-get update
-        - sudo apt-get install -y python3-pip python3-setuptools
+        - sudo apt-get install -y python3-pip python3-setuptools python3-catkin-pkg-modules
         - sudo pip3 install vcstool
         - python setup.py install
         - mkdir job && cd job
@@ -388,6 +393,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install dpkg -y  # necessary for catkin-pkg to be installable
         - sudo apt-get install ros-kinetic-catkin -y
+        - sudo apt-get install python3-catkin-pkg-modules -y
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm
@@ -403,8 +409,10 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
+        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
+        - *rosgpgkeyadd
         - sudo apt-get update
-        - sudo apt-get install -y python3-pip  python3-setuptools
+        - sudo apt-get install -y python3-pip  python3-setuptools python3-catkin-pkg-modules
         - sudo pip3 install vcstool
         - python setup.py install
         - mkdir job && cd job
@@ -485,8 +493,10 @@ matrix:
         - docker
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="roscpp_core" OVERLAY_PACKAGE_NAMES=roscpp
       before_script:
+        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
+        - *rosgpgkeyadd
         - sudo apt-get update
-        - sudo apt-get install -y python3-pip python3-setuptools
+        - sudo apt-get install -y python3-pip python3-setuptools python3-catkin-pkg-modules
         - sudo pip3 install EmPy
         # install catkin for test results
         - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
@@ -509,8 +519,10 @@ matrix:
         - docker
       env: JOB_TYPE=external_prerelease
       before_script:
+        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros.list'
+        - *rosgpgkeyadd
         - sudo apt-get update
-        - sudo apt-get install -y python3-pip python3-setuptools
+        - sudo apt-get install -y python3-pip python3-setuptools python3-catkin-pkg-modules
         - sudo pip3 install EmPy vcstool
         - python setup.py install
         - mkdir job && cd job

--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -265,6 +265,11 @@ The following options are valid in version ``2`` (beside the generic options):
   * ``default``: a boolean flag as described for *test_commits*.
   * ``force``: a boolean flag as described for *test_commits*.
 
+* ``test_abi``: a dictionary to decide if *abi checker* is going to be run in
+  PR and devel jobs
+  * ``default``: a boolean flag as described for *test_commits*.
+  * ``force``: a boolean flag as described for *test_commits*.
+
 * ``collate_test_stats``: a boolean flag (default: ``False``) controlling
   whether test statistics collation should be enabled for devel jobs.
   Enabling this will add post-build steps to jobs that collate test statistics

--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -342,6 +342,12 @@ def add_argument_repos_file_urls(parser):
         help='URLs of repos files to import with vcs.')
 
 
+def add_argument_run_abichecker(parser):
+    parser.add_argument(
+        '--run-abichecker', action='store_true',
+        help='Run the ABI checker when compiling packages')
+
+
 def add_argument_skip_cleanup(parser):
     parser.add_argument(
         '--skip-cleanup', action='store_true',

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -533,3 +533,26 @@ def get_system_architecture():
     if machine == 'aarch64':
         return 'armv8'
     raise RuntimeError('Unable to determine architecture')
+
+
+def get_pkgs_in_workspace(ws_path, condition_context):
+    """
+    Return packages present in the workspaces in ws_path
+
+    Given a catkin workspace get the ROS packages inside it
+
+    :param ws_path: A list of filysystem full paths pointing to catkin workspaces
+    :param condition_context: A dict mapping ROS enviroment variables affecting package names
+    :returns: A list of ``Package`` objects
+    """
+    from catkin_pkg.packages import find_packages
+
+    pkgs = {}
+    for workspace_root in ws_path:
+        source_space = os.path.join(workspace_root, 'src')
+        print("Crawling for packages in workspace '%s'" % source_space)
+        ws_pkgs = find_packages(source_space)
+        for pkg in ws_pkgs.values():
+            pkg.evaluate_conditions(condition_context)
+        pkgs.update(ws_pkgs)
+    return pkgs

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -535,20 +535,19 @@ def get_system_architecture():
     raise RuntimeError('Unable to determine architecture')
 
 
-def get_pkgs_in_workspace(ws_path, condition_context):
+def get_packages_in_workspaces(workspace_roots, condition_context):
     """
-    Return packages present in the workspaces in ws_path
+    Return packages found in the passed workspaces.
 
-    Given a catkin workspace get the ROS packages inside it
-
-    :param ws_path: A list of filysystem full paths pointing to catkin workspaces
-    :param condition_context: A dict mapping ROS enviroment variables affecting package names
+    :param workspace_roots: A list of absolute paths to workspaces
+    :param condition_context: A dict containing environment variables for the
+      conditions in the package manifests
     :returns: A list of ``Package`` objects
     """
     from catkin_pkg.packages import find_packages
 
     pkgs = {}
-    for workspace_root in ws_path:
+    for workspace_root in workspace_roots:
         source_space = os.path.join(workspace_root, 'src')
         print("Crawling for packages in workspace '%s'" % source_space)
         ws_pkgs = find_packages(source_space)

--- a/ros_buildfarm/config/source_build_file.py
+++ b/ros_buildfarm/config/source_build_file.py
@@ -113,6 +113,16 @@ class SourceBuildFile(BuildFile):
                 self.test_pull_requests_force = bool(
                     data['test_pull_requests']['force'])
 
+        self.test_abi_default = False
+        self.test_abi_force = None
+        if 'test_abi' in data:
+            if 'default' in data['test_abi']:
+                self.test_abi_default = bool(
+                    data['test_abi']['default'])
+            if 'force' in data['test_abi']:
+                self.test_abi_force = bool(
+                    data['test_abi']['force'])
+
         self.collate_test_stats = bool(data.get('collate_test_stats', False))
 
     def filter_repositories(self, repository_names):

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -162,11 +162,9 @@ def configure_devel_jobs(
         run_abichecker = False
         if build_file.test_abi_force is False:
             pass
-        elif hasattr(repo.source_repository, 'test_abi') and \
-                repo.source_repository.test_abi is False:
+        elif getattr(repo.source_repository, 'test_abi', None) is False:
             pass
-        elif hasattr(repo.source_repository, 'test_abi') and \
-                repo.source_repository.test_abi is None and \
+        elif getattr(repo.source_repository, 'test_abi', None) is None and \
                 not build_file.test_abi_default:
             pass
         else:

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -407,6 +407,7 @@ def _get_devel_job_config(
         'build_tool': build_file.build_tool,
         'ros_version': ros_version,
         'build_environment_variables': build_environment_variables,
+
         'run_abichecker': run_abichecker,
         'notify_compiler_warnings': build_file.notify_compiler_warnings,
         'notify_emails': build_file.notify_emails,

--- a/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
@@ -78,7 +78,7 @@ cmd = \
     ' --ros-version ' + str(ros_version) + \
     ' --env-vars ' + ' ' .join(env_vars)
 if run_abichecker:
-    cmd += " --run-abichecker"
+    cmd += ' --run-abichecker'
 cmds += [
     cmd +
     ' --dockerfile-dir /tmp/docker_build_and_install',

--- a/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
@@ -83,6 +83,7 @@ cmds += [
     cmd +
     ' --dockerfile-dir /tmp/docker_build_and_test' +
     ' --testing',
+    ' --abi-checking',
 ]
 }@
 CMD ["@(' && '.join(cmds))"]

--- a/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
@@ -82,7 +82,7 @@ cmds += [
     ' --dockerfile-dir /tmp/docker_build_and_install',
     cmd +
     ' --dockerfile-dir /tmp/docker_build_and_test' +
-    ' --testing',
+    ' --testing' +
     ' --abi-checking',
 ]
 }@

--- a/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
@@ -83,7 +83,7 @@ cmds += [
     cmd +
     ' --dockerfile-dir /tmp/docker_build_and_test' +
     ' --testing' +
-    ' --abi-checking',
+    ' --run-abichecker',
 ]
 }@
 CMD ["@(' && '.join(cmds))"]

--- a/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
@@ -77,13 +77,14 @@ cmd = \
     ' --build-tool ' + build_tool + \
     ' --ros-version ' + str(ros_version) + \
     ' --env-vars ' + ' ' .join(env_vars)
+if run_abichecker:
+    cmd += " --run-abichecker"
 cmds += [
     cmd +
     ' --dockerfile-dir /tmp/docker_build_and_install',
     cmd +
     ' --dockerfile-dir /tmp/docker_build_and_test' +
-    ' --testing' +
-    ' --run-abichecker',
+    ' --testing'
 ]
 }@
 CMD ["@(' && '.join(cmds))"]

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -111,11 +111,6 @@ if pull_request:
     'builder_shell_key-files',
     script_generating_key_files=script_generating_key_files,
 ))@
-@[if run_abichecker]
-@{ str_abichecker = ' --run-abichecker' }
-@[else]
-@{ str_abichecker = '' }
-@[end if]
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
@@ -143,7 +138,7 @@ if pull_request:
         ' ' + ' '.join(repository_args) +
         ' --build-tool ' + build_tool +
         ' --ros-version ' + str(ros_version) +
-        str_abichecker +
+        (' --run-abichecker' if run_abichecker else '') +
         ' --env-vars ' + ' '.join(build_environment_variables) +
         ' --dockerfile-dir $WORKSPACE/docker_generating_dockers',
         'echo "# END SECTION"',

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -111,6 +111,11 @@ if pull_request:
     'builder_shell_key-files',
     script_generating_key_files=script_generating_key_files,
 ))@
+@[if run_abichecker]
+@{ str_abichecker = ' --run-abichecker' }
+@[else]
+@{ str_abichecker = '' }
+@[end if]
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
@@ -138,6 +143,7 @@ if pull_request:
         ' ' + ' '.join(repository_args) +
         ' --build-tool ' + build_tool +
         ' --ros-version ' + str(ros_version) +
+        str_abichecker +
         ' --env-vars ' + ' '.join(build_environment_variables) +
         ' --dockerfile-dir $WORKSPACE/docker_generating_dockers',
         'echo "# END SECTION"',
@@ -361,7 +367,7 @@ if pull_request:
 @(SNIPPET(
     'publisher_groovy-postbuild_maintainer-notification',
 ))@
-@[ end if]@
+@[end if]@
 @(SNIPPET(
     'publisher_mailer',
     recipients=notify_emails,
@@ -369,12 +375,14 @@ if pull_request:
     send_to_individuals=notify_committers,
 ))@
 @[end if]@
+@[if run_abichecker]
 @(SNIPPET(
     'publisher_abi_report',
 ))@
 @(SNIPPET(
     'publisher_parser_unstable',
 ))@
+@[end if]@
   </publishers>
   <buildWrappers>
 @[if timeout_minutes is not None]@

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -138,6 +138,7 @@ if pull_request:
         ' ' + ' '.join(repository_args) +
         ' --build-tool ' + build_tool +
         ' --ros-version ' + str(ros_version) +
+        ' --run-abichecker ' +
         ' --env-vars ' + ' '.join(build_environment_variables) +
         ' --dockerfile-dir $WORKSPACE/docker_generating_dockers',
         'echo "# END SECTION"',

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -62,7 +62,7 @@ RUN pip3 install -U setuptools
 @[if ros_version == 2]@
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ros-@(rosdistro_name)-ros-workspace
 @[end if]@
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache python3-catkin-pkg-modules
 
 @(TEMPLATE(
     'snippet/set_environment_variables.Dockerfile.em',

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -99,14 +99,13 @@ cmd = \
     'PATH=/usr/lib/ccache:$PATH' + \
     ' PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u'
 if not testing:
-    str_run_abi = ''
-    if run_abichecker:
-        str_run_abi = ' --run-abichecker'
     cmd += \
         ' /tmp/ros_buildfarm/scripts/devel/build_and_install.py' + \
         ' --rosdistro-name ' + rosdistro_name + \
         ' --ros-version ' + str(ros_version) + \
-        ' --clean-before' + str_run_abi
+        ' --clean-before'
+    if run_abichecker:
+        cmd += ' --run-abichecker'
 else:
     cmd += \
         ' /tmp/ros_buildfarm/scripts/devel/build_and_test.py' + \

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -80,6 +80,11 @@ RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
     install_lists=install_lists,
 ))@
 
+@[if abichecking]@
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-rosdistro python3-rosdep python3
+RUN git clone https://github.com/osrf/auto-abi-checker /tmp/auto-abi-checker
+@[end if]@
+
 # After all dependencies are installed, update ccache symlinks.
 # This command is supposed to be invoked whenever a new compiler is installed
 # but that isn't happening. So we invoke it here to make sure all compilers are
@@ -96,7 +101,7 @@ cmd = \
 if not testing:
     cmd += \
         ' /tmp/ros_buildfarm/scripts/devel/build_and_install.py' + \
-        ' --rosdistro-name %s --clean-before' % rosdistro_name
+        ' --rosdistro-name %s --clean-before --abi-checker' % rosdistro_name
 else:
     cmd += \
         ' /tmp/ros_buildfarm/scripts/devel/build_and_test.py' + \

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -101,7 +101,7 @@ cmd = \
 if not testing:
     cmd += \
         ' /tmp/ros_buildfarm/scripts/devel/build_and_install.py' + \
-        ' --rosdistro-name %s --clean-before --abi-checker' % rosdistro_name
+        ' --rosdistro-name %s --clean-before --run-abichecker' % rosdistro_name
 else:
     cmd += \
         ' /tmp/ros_buildfarm/scripts/devel/build_and_test.py' + \

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -81,6 +81,7 @@ RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
 ))@
 
 @[if abichecking]@
+ADD https://api.github.com/repos/osrf/auto-abi-checker/git/refs/heads/master version.json[remote "upstream"]
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-rosdistro python3-rosdep python3 python3-docopt abi-compliance-checker
 RUN git clone https://github.com/osrf/auto-abi-checker /tmp/auto-abi-checker
 @[end if]@

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -81,7 +81,7 @@ RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
 ))@
 
 @[if abichecking]@
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-rosdistro python3-rosdep python3 python3-docopt
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-rosdistro python3-rosdep python3 python3-docopt abi-compliance-checker
 RUN git clone https://github.com/osrf/auto-abi-checker /tmp/auto-abi-checker
 @[end if]@
 

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -80,7 +80,7 @@ RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
     install_lists=install_lists,
 ))@
 
-@[if abichecking]@
+@[if run_abichecker]@
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3 abi-compliance-checker
 RUN pip3 install -U auto_abi_checker
 @[end if]@
@@ -99,11 +99,14 @@ cmd = \
     'PATH=/usr/lib/ccache:$PATH' + \
     ' PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u'
 if not testing:
+    str_run_abi = ''
+    if run_abichecker:
+        str_run_abi = ' --run-abichecker'
     cmd += \
         ' /tmp/ros_buildfarm/scripts/devel/build_and_install.py' + \
         ' --rosdistro-name ' + rosdistro_name + \
         ' --ros-version ' + str(ros_version) + \
-        ' --clean-before --run-abichecker'
+        ' --clean-before' + str_run_abi
 else:
     cmd += \
         ' /tmp/ros_buildfarm/scripts/devel/build_and_test.py' + \

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -81,7 +81,7 @@ RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
 ))@
 
 @[if abichecking]@
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-rosdistro python3-rosdep python3
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-rosdistro python3-rosdep python3 python3-docopt
 RUN git clone https://github.com/osrf/auto-abi-checker /tmp/auto-abi-checker
 @[end if]@
 

--- a/ros_buildfarm/workspace.py
+++ b/ros_buildfarm/workspace.py
@@ -16,8 +16,6 @@ import os
 import shutil
 import subprocess
 
-from catkin_pkg.packages import find_packages
-
 
 def ensure_workspace_exists(workspace_root):
     # ensure that workspace exists
@@ -42,37 +40,6 @@ def clean_workspace(workspace_root):
     test_results_dir = os.path.join(workspace_root, 'test_results')
     if os.path.exists(test_results_dir):
         shutil.rmtree(test_results_dir)
-
-
-def call_abi_checker(workspace_root, ros_version, rosdistro_name, env):
-    # TODO: pkgs detection, code based on create_devel_task_generator.py
-    condition_context = {}
-    condition_context['ROS_DISTRO'] = rosdistro_name
-    condition_context['ROS_VERSION'] = ros_version
-    condition_context['ROS_PYTHON_VERSION'] = \
-        (env or os.environ).get('ROS_PYTHON_VERSION')
-    pkgs = {}
-    for ws_root in workspace_root:
-        source_space = os.path.join(ws_root, 'src')
-        ws_pkgs = find_packages(source_space)
-        for pkg in ws_pkgs.values():
-            pkg.evaluate_conditions(condition_context)
-        pkgs.update(ws_pkgs)
-    pkg_names = [pkg.name for pkg in pkgs.values()]
-    assert(pkg_names), 'No packages found in the workspace'
-
-    assert(len(workspace_root) == 1), 'auto-abi tool needs the implementation of multiple local-dir'
-    cmd = ['ROS_DISTRO=' + rosdistro_name + ' ' +
-           'auto-abi.py ' +
-           '--orig-type ros-pkg --orig ' + ",".join(pkg_names) + ' ' +
-           '--new-type ros-ws --new ' + os.path.join(workspace_root[0], 'install_isolated') + ' ' +
-           '--report-dir ' + workspace_root[0] + ' ' +
-           '--no-fail-if-empty ' +
-           '--display-exec-time'
-           ]
-    print("Invoking '%s'" % (cmd))
-    return subprocess.call(
-        cmd, shell=True, stderr=subprocess.STDOUT, env=env)
 
 
 def call_build_tool(

--- a/ros_buildfarm/workspace.py
+++ b/ros_buildfarm/workspace.py
@@ -61,6 +61,7 @@ def call_abi_checker(workspace_root, rosdistro_name, env):
     # it, implement the support for multiple local-dir in auto-abi tool
     cmd = ['ROS_DISTRO=' + rosdistro_name + ' ' +
            '/tmp/auto-abi-checker/auto-abi.py ' +
+           '--report-dir ' + workspace_root + ' ' +
            '--orig-type ros-pkg --orig ' + ",".join(pkg_names) + ' ' +
            '--new-type local-dir --new ' + workspace_root[0]]
     print("Invoking '%s'" % (cmd))

--- a/ros_buildfarm/workspace.py
+++ b/ros_buildfarm/workspace.py
@@ -18,6 +18,7 @@ import subprocess
 
 from catkin_pkg.packages import find_packages
 
+
 def ensure_workspace_exists(workspace_root):
     # ensure that workspace exists
     assert os.path.exists(workspace_root), \

--- a/ros_buildfarm/workspace.py
+++ b/ros_buildfarm/workspace.py
@@ -59,7 +59,8 @@ def call_abi_checker(workspace_root, rosdistro_name, env):
     # TODO: workspace_root[0] to be compatible with a code in
     # create_devel_task_generator for a future refactor. To fix
     # it, implement the support for multiple local-dir in auto-abi tool
-    cmd = ['/tmp/auto-abi-checker/auto-abi.py ' +
+    cmd = ['ROS_DISTRO=' + rosdistro_name + ' ' +
+           '/tmp/auto-abi-checker/auto-abi.py ' +
            '--orig-type ros-pkg --orig ' + ",".join(pkg_names) + ' ' +
            '--new-type local-dir --new ' + workspace_root[0]]
     print("Invoking '%s'" % (cmd))

--- a/ros_buildfarm/workspace.py
+++ b/ros_buildfarm/workspace.py
@@ -50,15 +50,18 @@ def call_abi_checker(workspace_root, rosdistro_name, env):
     pkgs = {}
     for ws_root in workspace_root:
         source_space = os.path.join(ws_root, 'src')
-        print("Crawling for packages in workspace '%s'" % source_space)
         ws_pkgs = find_packages(source_space)
         for pkg in ws_pkgs.values():
             pkg.evaluate_conditions(condition_context)
         pkgs.update(ws_pkgs)
+    pkg_names = [pkg.name for pkg in pkgs.values()]
 
-    cmd = ['/tmp/auto-abi-checker/auto-abi.py',
-           '--orig-type', 'osrf-pkg', '--orig', ",".join(pkgs),
-           '--new-type', 'local-dir', '--new', workspace_root]
+    # TODO: workspace_root[0] to be compatible with a code in
+    # create_devel_task_generator for a future refactor. To fix
+    # it, implement the support for multiple local-dir in auto-abi tool
+    cmd = ['/tmp/auto-abi-checker/auto-abi.py ' +
+           '--orig-type ros-pkg --orig ' + ",".join(pkg_names) + ' ' +
+           '--new-type local-dir --new ' + workspace_root[0]]
     print("Invoking '%s'" % (cmd))
     return subprocess.call(
         cmd, shell=True, stderr=subprocess.STDOUT, env=env)

--- a/ros_buildfarm/workspace.py
+++ b/ros_buildfarm/workspace.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import subprocess
 
+from catkin_pkg.packages import find_packages
 
 def ensure_workspace_exists(workspace_root):
     # ensure that workspace exists
@@ -41,6 +42,16 @@ def clean_workspace(workspace_root):
     if os.path.exists(test_results_dir):
         shutil.rmtree(test_results_dir)
 
+def call_abi_checker(workspace_root, rosdistro_name, env):
+    # TODO: improve the approach of parsing ghprbGhRepository variable in Jenkins
+    ros_repo = env['ghprbGhRepository'].rpartition('/')[2]
+    install_space = os.path.join(workspace_root, 'install_isolated')
+    cmd = ['/tmp/auto-abi-checker/auto-abi.py ' +
+            '--orig-type ros-pkg --orig ' + ros_repo + ' ' +
+            '--new-type local-dir --new ' + install_space]
+    print("Invoking '%s'" % (cmd))
+    return subprocess.call(
+        cmd, shell=True, stderr=subprocess.STDOUT, env=env)
 
 def call_build_tool(
     build_tool, rosdistro_name, workspace_root, cmake_args=None,

--- a/ros_buildfarm/workspace.py
+++ b/ros_buildfarm/workspace.py
@@ -61,9 +61,9 @@ def call_abi_checker(workspace_root, rosdistro_name, env):
     # it, implement the support for multiple local-dir in auto-abi tool
     cmd = ['ROS_DISTRO=' + rosdistro_name + ' ' +
            '/tmp/auto-abi-checker/auto-abi.py ' +
-           '--report-dir ' + workspace_root + ' ' +
            '--orig-type ros-pkg --orig ' + ",".join(pkg_names) + ' ' +
-           '--new-type local-dir --new ' + workspace_root[0]]
+           '--new-type local-dir --new ' + workspace_root[0] + '' +
+           '--report-dir ' + workspace_root[0]]
     print("Invoking '%s'" % (cmd))
     return subprocess.call(
         cmd, shell=True, stderr=subprocess.STDOUT, env=env)

--- a/ros_buildfarm/workspace.py
+++ b/ros_buildfarm/workspace.py
@@ -62,7 +62,7 @@ def call_abi_checker(workspace_root, rosdistro_name, env):
     cmd = ['ROS_DISTRO=' + rosdistro_name + ' ' +
            '/tmp/auto-abi-checker/auto-abi.py ' +
            '--orig-type ros-pkg --orig ' + ",".join(pkg_names) + ' ' +
-           '--new-type local-dir --new ' + workspace_root[0] + '' +
+           '--new-type local-dir --new ' + workspace_root[0] + ' ' +
            '--report-dir ' + workspace_root[0]]
     print("Invoking '%s'" % (cmd))
     return subprocess.call(

--- a/scripts/ci/build_task_generator.py
+++ b/scripts/ci/build_task_generator.py
@@ -32,6 +32,7 @@ from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
 from ros_buildfarm.argument import add_argument_ros_version
 from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.argument import add_argument_run_abichecker
 from ros_buildfarm.argument import add_argument_testing
 from ros_buildfarm.common import get_binary_package_versions
 from ros_buildfarm.common import get_distribution_repository_keys
@@ -57,6 +58,7 @@ def main(argv=sys.argv[1:]):
     add_argument_env_vars(parser)
     add_argument_install_packages(parser)
     add_argument_ros_version(parser)
+    add_argument_run_abichecker(parser)
     add_argument_testing(parser)
     parser.add_argument(
         '--workspace-root', nargs='+',
@@ -120,6 +122,7 @@ def main(argv=sys.argv[1:]):
         'dependency_versions': [],
 
         'testing': args.testing,
+        'run_abichecker': args.run_abichecker,
         'workspace_root': mapped_workspaces[-1][1],
         'parent_result_space': [mapping[1] for mapping in mapped_workspaces[:-1]],
     }

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -21,6 +21,7 @@ import sys
 from ros_buildfarm.argument import add_argument_build_tool
 from ros_buildfarm.argument import add_argument_build_tool_args
 from ros_buildfarm.argument import add_argument_ros_version
+from ros_buildfarm.argument import add_argument_run_abichecker
 from ros_buildfarm.common import Scope
 from ros_buildfarm.workspace import call_abi_checker
 from ros_buildfarm.workspace import call_build_tool
@@ -38,6 +39,7 @@ def main(argv=sys.argv[1:]):
              'sourced (if available)')
     add_argument_build_tool(parser, required=True)
     add_argument_build_tool_args(parser)
+    add_argument_run_abichecker(parser)
     parser.add_argument(
         '--workspace-root',
         required=True,
@@ -55,10 +57,6 @@ def main(argv=sys.argv[1:]):
         action='store_true',
         help='The flag if the workspace should be cleaned after the '
              'invocation')
-    parser.add_argument(
-        '--run-abichecker',
-        action='store_true',
-        help='The flag if the abi checking tool should be run')
 
     add_argument_ros_version(parser)
 

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -23,7 +23,7 @@ from ros_buildfarm.argument import add_argument_build_tool
 from ros_buildfarm.argument import add_argument_build_tool_args
 from ros_buildfarm.argument import add_argument_ros_version
 from ros_buildfarm.argument import add_argument_run_abichecker
-from ros_buildfarm.common import get_pkgs_in_workspace
+from ros_buildfarm.common import get_packages_in_workspaces
 from ros_buildfarm.common import Scope
 from ros_buildfarm.workspace import call_build_tool
 from ros_buildfarm.workspace import clean_workspace

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -24,29 +24,19 @@ from ros_buildfarm.argument import add_argument_build_tool_args
 from ros_buildfarm.argument import add_argument_ros_version
 from ros_buildfarm.argument import add_argument_run_abichecker
 from ros_buildfarm.common import Scope
+from ros_buildfarm.common import get_pkgs_in_workspace
 from ros_buildfarm.workspace import call_build_tool
 from ros_buildfarm.workspace import clean_workspace
 from ros_buildfarm.workspace import ensure_workspace_exists
 
 
 def call_abi_checker(workspace_root, ros_version, env):
-    # import the module only if the function is being called to reduce the
-    # number of mandatory dependencies
-    from catkin_pkg.packages import find_packages
-
-    # TODO: pkgs detection, code based on create_devel_task_generator.py
     condition_context = {}
     condition_context['ROS_DISTRO'] = env['ROS_DISTRO']
     condition_context['ROS_VERSION'] = ros_version
     condition_context['ROS_PYTHON_VERSION'] = \
         (env or os.environ).get('ROS_PYTHON_VERSION')
-    pkgs = {}
-    for ws_root in workspace_root:
-        source_space = os.path.join(ws_root, 'src')
-        ws_pkgs = find_packages(source_space)
-        for pkg in ws_pkgs.values():
-            pkg.evaluate_conditions(condition_context)
-        pkgs.update(ws_pkgs)
+    pkgs = get_pkgs_in_workspace(workspace_root, condition_context)
     pkg_names = [pkg.name for pkg in pkgs.values()]
     assert pkg_names, 'No packages found in the workspace'
 

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -120,23 +120,20 @@ def main(argv=sys.argv[1:]):
         if args.clean_after:
             clean_workspace(args.workspace_root)
 
-    # if something went bad with call_build_tool or the abi-checker is not not
-    # in use, return the rc code
-    if rc != 0 or not args.run_abichecker:
-        return rc
+    # only run abi-checker after successful builds and when requested
+    if not rc and args.run_abichecker
+        with Scope('SUBSECTION', 'use abi checker'):
+            abi_rc = call_abi_checker(
+                [args.workspace_root],
+                args.ros_version,
+                env)
+        # Never fail a build because of abi errors but make them
+        # unstable by printing MAKE_BUILD_UNSTABLE. Jenkins will
+        # use a plugin to make it
+        if abi_rc:
+            print('MAKE_BUILD_UNSTABLE')
 
-    with Scope('SUBSECTION', 'use abi checker'):
-        rc = call_abi_checker(
-            [args.workspace_root],
-            args.ros_version,
-            env)
-    # Never fail a build because of abi errors but make them
-    # unstable by printing MAKE_BUILD_UNSTABLE. Jenkins will
-    # use a`plugin to make it
-    if rc != 0:
-        print('MAKE_BUILD_UNSTABLE')
-
-    return 0
+    return rc
 
 
 if __name__ == '__main__':

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -36,7 +36,7 @@ def call_abi_checker(workspace_root, ros_version, env):
     condition_context['ROS_VERSION'] = ros_version
     condition_context['ROS_PYTHON_VERSION'] = \
         (env or os.environ).get('ROS_PYTHON_VERSION')
-    pkgs = get_pkgs_in_workspace(workspace_root, condition_context)
+    pkgs = get_packages_in_workspaces(workspace_root, condition_context)
     pkg_names = [pkg.name for pkg in pkgs.values()]
     assert pkg_names, 'No packages found in the workspace'
 

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -16,17 +16,49 @@
 
 import argparse
 import os
+import subprocess
 import sys
 
+from catkin_pkg.packages import find_packages
 from ros_buildfarm.argument import add_argument_build_tool
 from ros_buildfarm.argument import add_argument_build_tool_args
 from ros_buildfarm.argument import add_argument_ros_version
 from ros_buildfarm.argument import add_argument_run_abichecker
 from ros_buildfarm.common import Scope
-from ros_buildfarm.workspace import call_abi_checker
 from ros_buildfarm.workspace import call_build_tool
 from ros_buildfarm.workspace import clean_workspace
 from ros_buildfarm.workspace import ensure_workspace_exists
+
+
+def call_abi_checker(workspace_root, ros_version, rosdistro_name, env):
+    # TODO: pkgs detection, code based on create_devel_task_generator.py
+    condition_context = {}
+    condition_context['ROS_DISTRO'] = rosdistro_name
+    condition_context['ROS_VERSION'] = ros_version
+    condition_context['ROS_PYTHON_VERSION'] = \
+        (env or os.environ).get('ROS_PYTHON_VERSION')
+    pkgs = {}
+    for ws_root in workspace_root:
+        source_space = os.path.join(ws_root, 'src')
+        ws_pkgs = find_packages(source_space)
+        for pkg in ws_pkgs.values():
+            pkg.evaluate_conditions(condition_context)
+        pkgs.update(ws_pkgs)
+    pkg_names = [pkg.name for pkg in pkgs.values()]
+    assert(pkg_names), 'No packages found in the workspace'
+
+    assert(len(workspace_root) == 1), 'auto-abi tool needs the implementation of multiple local-dir'
+    cmd = ['ROS_DISTRO=' + rosdistro_name + ' ' +
+           'auto-abi.py ' +
+           '--orig-type ros-pkg --orig ' + ",".join(pkg_names) + ' ' +
+           '--new-type ros-ws --new ' + os.path.join(workspace_root[0], 'install_isolated') + ' ' +
+           '--report-dir ' + workspace_root[0] + ' ' +
+           '--no-fail-if-empty ' +
+           '--display-exec-time'
+           ]
+    print("Invoking '%s'" % (cmd))
+    return subprocess.call(
+        cmd, shell=True, stderr=subprocess.STDOUT, env=env)
 
 
 def main(argv=sys.argv[1:]):

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -48,9 +48,9 @@ def call_abi_checker(workspace_root, ros_version, env):
             pkg.evaluate_conditions(condition_context)
         pkgs.update(ws_pkgs)
     pkg_names = [pkg.name for pkg in pkgs.values()]
-    assert(pkg_names), 'No packages found in the workspace'
+    assert pkg_names, 'No packages found in the workspace'
 
-    assert(len(workspace_root) == 1), 'auto-abi tool needs the implementation of multiple local-dir'
+    assert len(workspace_root) == 1, 'auto-abi tool needs the implementation of multiple local-dir'
     # ROS_DISTRO is set in the env object
     cmd = ['auto-abi.py ' +
            '--orig-type ros-pkg --orig ' + ",".join(pkg_names) + ' ' +

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -87,7 +87,7 @@ def main(argv=sys.argv[1:]):
         return rc
 
     with Scope('SUBSECTION', 'use abi checker'):
-        rc = call_abi_checker(args.workspace_root, args.rosdistro_name, env=env)
+        rc = call_abi_checker([args.workspace_root], args.rosdistro_name, env=env)
 
     if rc != 0:
         print("Failure during the execution of abi-checking")

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -23,8 +23,8 @@ from ros_buildfarm.argument import add_argument_build_tool
 from ros_buildfarm.argument import add_argument_build_tool_args
 from ros_buildfarm.argument import add_argument_ros_version
 from ros_buildfarm.argument import add_argument_run_abichecker
-from ros_buildfarm.common import Scope
 from ros_buildfarm.common import get_pkgs_in_workspace
+from ros_buildfarm.common import Scope
 from ros_buildfarm.workspace import call_build_tool
 from ros_buildfarm.workspace import clean_workspace
 from ros_buildfarm.workspace import ensure_workspace_exists

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -111,7 +111,7 @@ def main(argv=sys.argv[1:]):
             clean_workspace(args.workspace_root)
 
     # only run abi-checker after successful builds and when requested
-    if not rc and args.run_abichecker
+    if not rc and args.run_abichecker:
         with Scope('SUBSECTION', 'use abi checker'):
             abi_rc = call_abi_checker(
                 [args.workspace_root],

--- a/scripts/devel/create_devel_task_generator.py
+++ b/scripts/devel/create_devel_task_generator.py
@@ -19,7 +19,6 @@ import os
 import sys
 
 from apt import Cache
-from catkin_pkg.packages import find_packages
 from ros_buildfarm.argument import add_argument_build_tool
 from ros_buildfarm.argument import \
     add_argument_distribution_repository_key_files
@@ -30,6 +29,7 @@ from ros_buildfarm.argument import add_argument_ros_version
 from ros_buildfarm.argument import add_argument_run_abichecker
 from ros_buildfarm.common import get_binary_package_versions
 from ros_buildfarm.common import get_distribution_repository_keys
+from ros_buildfarm.common import get_pkgs_in_workspace
 from ros_buildfarm.common import get_user_id
 from ros_buildfarm.templates import create_dockerfile
 from rosdep2 import create_default_installer_context
@@ -84,15 +84,7 @@ def main(argv=sys.argv[1:]):
     condition_context['ROS_VERSION'] = args.ros_version
 
     # get direct build dependencies
-    pkgs = {}
-    for workspace_root in args.workspace_root:
-        source_space = os.path.join(workspace_root, 'src')
-        print("Crawling for packages in workspace '%s'" % source_space)
-        ws_pkgs = find_packages(source_space)
-        for pkg in ws_pkgs.values():
-            pkg.evaluate_conditions(condition_context)
-        pkgs.update(ws_pkgs)
-
+    pkgs = get_pkgs_in_workspace(args.workspace_root, condition_context)
     pkg_names = [pkg.name for pkg in pkgs.values()]
     print("Found the following packages:")
     for pkg_name in sorted(pkg_names):

--- a/scripts/devel/create_devel_task_generator.py
+++ b/scripts/devel/create_devel_task_generator.py
@@ -71,6 +71,11 @@ def main(argv=sys.argv[1:]):
         action='store_true',
         help='The flag if the workspace should be built with tests enabled '
              'and instead of installing the tests are ran')
+    parser.add_argument(
+        '--run-abichecker',
+        dest='abichecking',
+        action='store_true',
+        help='The flag if the abi checking tool should be run')
     args = parser.parse_args(argv)
 
     condition_context = {}
@@ -186,6 +191,7 @@ def main(argv=sys.argv[1:]):
         'install_lists': [],
 
         'testing': args.testing,
+        'abichecking': args.abichecking,
         'workspace_root': mapped_workspaces[-1][1],
         'parent_result_space': parent_result_space,
     }

--- a/scripts/devel/create_devel_task_generator.py
+++ b/scripts/devel/create_devel_task_generator.py
@@ -29,7 +29,7 @@ from ros_buildfarm.argument import add_argument_ros_version
 from ros_buildfarm.argument import add_argument_run_abichecker
 from ros_buildfarm.common import get_binary_package_versions
 from ros_buildfarm.common import get_distribution_repository_keys
-from ros_buildfarm.common import get_pkgs_in_workspace
+from ros_buildfarm.common import get_packages_in_workspaces
 from ros_buildfarm.common import get_user_id
 from ros_buildfarm.templates import create_dockerfile
 from rosdep2 import create_default_installer_context

--- a/scripts/devel/create_devel_task_generator.py
+++ b/scripts/devel/create_devel_task_generator.py
@@ -27,6 +27,7 @@ from ros_buildfarm.argument import add_argument_distribution_repository_urls
 from ros_buildfarm.argument import add_argument_dockerfile_dir
 from ros_buildfarm.argument import add_argument_env_vars
 from ros_buildfarm.argument import add_argument_ros_version
+from ros_buildfarm.argument import add_argument_run_abichecker
 from ros_buildfarm.common import get_binary_package_versions
 from ros_buildfarm.common import get_distribution_repository_keys
 from ros_buildfarm.common import get_user_id
@@ -66,15 +67,12 @@ def main(argv=sys.argv[1:]):
     add_argument_ros_version(parser)
     add_argument_env_vars(parser)
     add_argument_dockerfile_dir(parser)
+    add_argument_run_abichecker(parser)
     parser.add_argument(
         '--testing',
         action='store_true',
         help='The flag if the workspace should be built with tests enabled '
              'and instead of installing the tests are ran')
-    parser.add_argument(
-        '--run-abichecker',
-        action='store_false',
-        help='The flag if the abi checking tool should be run')
     args = parser.parse_args(argv)
 
     condition_context = {}
@@ -190,7 +188,7 @@ def main(argv=sys.argv[1:]):
         'install_lists': [],
 
         'testing': args.testing,
-        'abichecking': args.run_abichecker,
+        'run_abichecker': args.run_abichecker,
         'workspace_root': mapped_workspaces[-1][1],
         'parent_result_space': parent_result_space,
     }

--- a/scripts/devel/create_devel_task_generator.py
+++ b/scripts/devel/create_devel_task_generator.py
@@ -74,7 +74,7 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '--run-abichecker',
         dest='abichecking',
-        action='store_true',
+        action='store_false',
         help='The flag if the abi checking tool should be run')
     args = parser.parse_args(argv)
 

--- a/scripts/devel/create_devel_task_generator.py
+++ b/scripts/devel/create_devel_task_generator.py
@@ -84,7 +84,7 @@ def main(argv=sys.argv[1:]):
     condition_context['ROS_VERSION'] = args.ros_version
 
     # get direct build dependencies
-    pkgs = get_pkgs_in_workspace(args.workspace_root, condition_context)
+    pkgs = get_packages_in_workspaces(args.workspace_root, condition_context)
     pkg_names = [pkg.name for pkg in pkgs.values()]
     print("Found the following packages:")
     for pkg_name in sorted(pkg_names):

--- a/scripts/devel/generate_devel_script.py
+++ b/scripts/devel/generate_devel_script.py
@@ -27,6 +27,7 @@ from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
 from ros_buildfarm.argument import add_argument_repository_name
 from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.argument import add_argument_run_abichecker
 from ros_buildfarm.common import get_devel_job_name
 from ros_buildfarm.config import get_index as get_config_index
 from ros_buildfarm.config import get_source_build_files
@@ -45,6 +46,7 @@ def main(argv=sys.argv[1:]):
     add_argument_os_code_name(parser)
     add_argument_arch(parser)
     add_argument_build_tool(parser)
+    add_argument_run_abichecker(parser)
     args = parser.parse_args(argv)
 
     # collect all template snippets of specific types
@@ -89,7 +91,8 @@ def main(argv=sys.argv[1:]):
     configure_devel_job(
         args.config_url, args.rosdistro_name, args.source_build_name,
         args.repository_name, args.os_name, args.os_code_name, args.arch,
-        config=config, build_file=build_file, jenkins=False, views=False)
+        config=config, build_file=build_file, jenkins=False, views=False,
+        abi_checking=args.run_abichecker)
 
     templates.template_hooks = None
 

--- a/scripts/devel/run_devel_job.py
+++ b/scripts/devel/run_devel_job.py
@@ -33,6 +33,7 @@ from ros_buildfarm.argument import add_argument_repository_name
 from ros_buildfarm.argument import add_argument_ros_version
 from ros_buildfarm.argument import add_argument_rosdistro_index_url
 from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.argument import add_argument_run_abichecker
 from ros_buildfarm.common import get_distribution_repository_keys
 from ros_buildfarm.common import get_user_id
 from ros_buildfarm.templates import create_dockerfile
@@ -59,6 +60,7 @@ def main(argv=sys.argv[1:]):
     add_argument_ros_version(parser)
     add_argument_env_vars(parser)
     add_argument_dockerfile_dir(parser)
+    add_argument_run_abichecker(parser)
     args = parser.parse_args(argv)
 
     data = copy.deepcopy(args.__dict__)


### PR DESCRIPTION
The PR tries to implement the ABI checking for ROS2 packages (issue #678).

The approach followed was to use implement the option of abi checking in the `build_and_install.py` script used by the devel scripts. I've implement an argument in the script named `--abi-checker` that runs the [auto-abi-checker](https://github.com/osrf/auto-abi-checker) tool using:
 1. The workspace installation space
 1. The debian packages associated to the ROS repository under testing.

**Testing:**
 * Using the `build_and_install.py` script directly on my local system the runs of simple packages (`rclcpp`) was succesful.
 * I'm not sure about the best wait to test this in the ROS2 build farm. Last time I used a testing instance of a buildfarm (I think @nuclearsandwich is generating one these days). If there is a faster approach, please let me know.

**Open questions and TODO:**
 * Still need to resolve the question in #678 about how are we going to identify which packages needs ABI. The easiest thing would be the abi-checker always. If the package does not provide any `.h` or `.so` the checker will probably do nothing and report success.
 * Export results in Jenkins (the osrf buildfarm uses [HTML publisher](https://wiki.jenkins.io/display/JENKINS/HTML+Publisher+Plugin) + [Console parser](https://wiki.jenkins.io/display/JENKINS/Console+Parser+Plugin) to make build unstable.)
 * The local test build fails miserably on packages that has msgs generation support due to the lack of headers related to context and opensplice (not sure if the buildfarm is installing all the support for them). Support to remove the headers of these DDS implementations can be added to the `auto-abi-checker`.
 * There are problems with packages (i.e: `gazebo_ros_pkgs`) that introduce boost headers into the mix of headers to check (some expected definitions are missing). I'm still investigating them.