### PR TITLE
update plugin versions

### DIFF
--- a/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
@@ -1,7 +1,7 @@
     <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.2">
 @[if command]@
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
-        <script plugin="script-security@@1.59">
+        <script plugin="script-security@@1.66">
           <script>@ESCAPE(command)</script>
           <sandbox>false</sandbox>
         </script>

--- a/ros_buildfarm/templates/snippet/publisher_groovy-postbuild.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_groovy-postbuild.xml.em
@@ -1,5 +1,5 @@
     <org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder plugin="groovy-postbuild@@2.4.3">
-      <script plugin="script-security@@1.59">
+      <script plugin="script-security@@1.66">
         <script>@ESCAPE(script)</script>
         <sandbox>false</sandbox>
       </script>

--- a/ros_buildfarm/templates/snippet/publisher_publish-over-git.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_publish-over-git.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.git.GitPublisher plugin="git@@3.9.1">
+    <hudson.plugins.git.GitPublisher plugin="git@@3.12.1">
       <configVersion>2</configVersion>
       <pushMerge>false</pushMerge>
       <pushOnlyIfSuccess>true</pushOnlyIfSuccess>

--- a/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
@@ -8,7 +8,7 @@
       <usePreviousBuildAsReference>false</usePreviousBuildAsReference>
       <useStableBuildAsReference>false</useStableBuildAsReference>
       <useDeltaValues>false</useDeltaValues>
-      <thresholds plugin="analysis-core@@1.95">
+      <thresholds plugin="analysis-core@@1.96">
 @[if unstable_threshold != '']@
         <unstableTotalAll>@unstable_threshold</unstableTotalAll>
 @[else]@

--- a/ros_buildfarm/templates/snippet/scm_git.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_git.xml.em
@@ -1,4 +1,4 @@
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@@3.9.1">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@@3.12.1">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>


### PR DESCRIPTION
After noticing several plugins are using newer versions on the deployed Jenkins instances.

@nuclearsandwich FYI please make sure to keep the plugin versions on both Jenkins instance (build.ros.org and build.ros2.org) in sync and when you update them also update the information in this repo. Otherwise the nightly reconfigure jobs spend an unnecessary time reconfiguring every job.