### PR TITLE
inject downstream job dependencies for ros_workspace

### DIFF
--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -487,6 +487,15 @@ def configure_release_job(
             print(("Skipping binary jobs for package '%s' because it is not " +
                    "yet in the rosdistro cache") % pkg_name, file=sys.stderr)
             return source_job_names, binary_job_names, job_configs
+        # for ROS 2 distributions bloom injects a dependency on ros_workspace
+        # into almost all packages (except its dependencies)
+        # therefore the same dependency needs to to be injected here
+        distribution_type = index.distributions[rosdistro_name].get(
+            'distribution_type')
+        if distribution_type == 'ros2' and pkg_name not in (
+            'ament_cmake_core', 'ament_package', 'ros_workspace',
+        ):
+            dependency_names.add('ros_workspace')
 
     # binarydeb jobs
     for arch in build_file.targets[os_name][os_code_name]:


### PR DESCRIPTION
Whenever a new release of `ament_package` is made into an existing distribution a lot of jobs are failing to build. The symptom is that they pass the Jenkins upstream job test (all upstream jobs are green) but then fail to find the Debian package of a dependency in the apt repo.

After a package is built all packages depending on it are wiped from the apt repo and their Jenkins job is triggered. But since `bloom` artificially adds `ros_workspace` as a dependency to almost all other packages (except a few which are dependencies of `ros_workspace` itself) (see https://github.com/ros-infrastructure/bloom/blob/master/bloom/generators/rosdebian.py#L96-L102) the Jenkins jobs don't know about that since they use the dependencies from the package manifest only.

To fix this mismatch this patch injects the same dependencies from the `ros_workspace` job in Jenkins to almost all other packages / jobs.