### PR TITLE
Always update apt cache for CI dependency enumeration

### DIFF
--- a/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
@@ -78,6 +78,10 @@ RUN sudo -H -u buildfarm -- git config --global user.email "jenkins@@ros.invalid
     custom_rosdep_urls=custom_rosdep_urls,
 ))@
 
+# always ensure that the apt cache is up-to-date
+RUN echo "@now_str"
+RUN python3 -u /tmp/wrapper_scripts/apt.py update
+
 USER buildfarm
 ENTRYPOINT ["sh", "-c"]
 @{


### PR DESCRIPTION
In the CI job infrastructure, the `create_workspace` task is responsible for enumerating the dependencies needed to build and test the workspace, and it resolves those dependencies to package names and versions against the apt cache of the container.

That apt cache is never updated outside of the docker build, so if we get a Dockerfile cache hit, we'll probably have a somewhat stale cache.

This change forces an apt update at the end of the docker build, so we'll always have a fresh cache when enumerating dependencies. If this results in some change that we would otherwise have missed, the `install_list.txt` will change to reflect that, which will propagate the cache miss into the `build_and_install` and `build_and_test` tasks. If the resolved packages are the same, the files stay the same, and the downstream jobs can still get 100% Dockerfile cache hits.

Example failure: http://build.ros2.org/job/Eci__nightly-performance_ubuntu_bionic_amd64/76/
With this change: http://build.ros2.org/job/Eci__nightly-performance_ubuntu_bionic_amd64/78/