### PR TITLE
Skip unreleased packages from ABI checking

### DIFF
--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -81,7 +81,7 @@ RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
 ))@
 
 @[if run_abichecker]@
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3 abi-compliance-checker python3-catkin-pkg-modules
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-pip abi-compliance-checker python3-catkin-pkg-modules
 RUN pip3 install -U auto_abi_checker
 @[end if]@
 

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -81,7 +81,7 @@ RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
 ))@
 
 @[if run_abichecker]@
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-pip abi-compliance-checker python3-catkin-pkg-modules
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3 python3-pip abi-compliance-checker python3-catkin-pkg-modules
 RUN pip3 install -U auto_abi_checker
 @[end if]@
 

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -81,7 +81,7 @@ RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
 ))@
 
 @[if run_abichecker]@
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3 python3-pip abi-compliance-checker python3-catkin-pkg-modules
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y abi-compliance-checker python3 python3-catkin-pkg-modules python3-pip 
 RUN pip3 install -U auto_abi_checker
 @[end if]@
 

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -60,7 +60,7 @@ def call_abi_checker(workspace_root, ros_version, env):
     assert len(workspace_root) == 1, 'auto-abi tool needs the implementation of multiple local-dir'
     # ROS_DISTRO is set in the env object
     cmd = ['auto-abi.py ' +
-           '--orig-type ros-pkg --orig ' + ",".join(pkg_names) + ' ' +
+           '--orig-type ros-pkg --orig ' + ",".join(pkg_names_released) + ' ' +
            '--new-type ros-ws --new ' + os.path.join(workspace_root[0], 'install_isolated') + ' ' +
            '--report-dir ' + workspace_root[0] + ' ' +
            '--no-fail-if-empty ' +

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -44,11 +44,11 @@ def call_abi_checker(workspace_root, ros_version, env):
 
     # Filter packages in source space that has been released
     index_file = rosdistro.get_index(rosdistro.get_index_url())
-    distro_file = rosdistro.get_cached_distribution(index_file, env['ROS_DISTRO'])
+    dist = rosdistro.get_cached_distribution(index_file, env['ROS_DISTRO'])
     pkg_names_released = []
     for pkg_name in pkg_names:
         try:
-            if distro_file.get_release_package_xml(pkg_name):
+            if dist.get_release_package_xml(pkg_name):
                 pkg_names_released.append(pkg_name)
         except KeyError:
             # skip unreleased packages, nothing to do with ABI checking

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -45,7 +45,8 @@ def call_abi_checker(workspace_root, ros_version, env):
     # Filter packages in source space that has been released
     index = rosdistro.get_index(rosdistro.get_index_url())
     dist_file = rosdistro.get_distribution_file(index, env['ROS_DISTRO'])
-    pkg_names_released = [pkg_name for pkg_name in pkg_names if pkg_name in dist_file.release_packages]
+    pkg_names_released = \
+        [pkg_name for pkg_name in pkg_names if pkg_name in dist_file.release_packages]
 
     assert len(workspace_root) == 1, 'auto-abi tool needs the implementation of multiple local-dir'
     # ROS_DISTRO is set in the env object

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -54,7 +54,7 @@ def call_abi_checker(workspace_root, ros_version, env):
             # skip unreleased packages, nothing to do with ABI checking
             pass
     if not pkg_names_released:
-        print("No released packages found in the workspace. Skipping abi-checker run")
+        print('No released packages found in the workspace. Skipping abi-checker run')
         return True
 
     assert len(workspace_root) == 1, 'auto-abi tool needs the implementation of multiple local-dir'

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -45,19 +45,7 @@ def call_abi_checker(workspace_root, ros_version, env):
     # Filter packages in source space that has been released
     index = rosdistro.get_index(rosdistro.get_index_url())
     dist_file = rosdistro.get_distribution_file(index, env['ROS_DISTRO'])
-
-    pkg_names_released = []
-    for pkg_name in pkg_names:
-        try:
-            # Check in released packages for pkg_name (KeyError if unreleased)
-            dist_file.release_packages[pkg_name]
-            pkg_names_released.append(pkg_name)
-        except KeyError:
-            # skip unreleased packages, nothing to do with ABI checking
-            pass
-    if not pkg_names_released:
-        print('No released packages found in the workspace. Skipping abi-checker run')
-        return True
+    pkg_names_released = [pkg_name for pkg_name in pkg_names if pkg_name in dist_file.release_packages]
 
     assert len(workspace_root) == 1, 'auto-abi tool needs the implementation of multiple local-dir'
     # ROS_DISTRO is set in the env object

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -45,8 +45,8 @@ def call_abi_checker(workspace_root, ros_version, env):
     # Filter packages in source space that has been released
     index = rosdistro.get_index(rosdistro.get_index_url())
     dist_file = rosdistro.get_distribution_file(index, env['ROS_DISTRO'])
-    pkg_names_released = \
-        [pkg_name for pkg_name in pkg_names if pkg_name in dist_file.release_packages]
+    pkg_names_released = [
+        pkg_name for pkg_name in pkg_names if pkg_name in dist_file.release_packages]
 
     assert len(workspace_root) == 1, 'auto-abi tool needs the implementation of multiple local-dir'
     # ROS_DISTRO is set in the env object

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -43,13 +43,15 @@ def call_abi_checker(workspace_root, ros_version, env):
     assert pkg_names, 'No packages found in the workspace'
 
     # Filter packages in source space that has been released
-    index_file = rosdistro.get_index(rosdistro.get_index_url())
-    dist = rosdistro.get_cached_distribution(index_file, env['ROS_DISTRO'])
+    index = rosdistro.get_index(rosdistro.get_index_url())
+    dist_file = rosdistro.get_distribution_file(index, env['ROS_DISTRO'])
+
     pkg_names_released = []
     for pkg_name in pkg_names:
         try:
-            if dist.get_release_package_xml(pkg_name):
-                pkg_names_released.append(pkg_name)
+            # Check in released packages for pkg_name (KeyError if unreleased)
+            dist_file.release_packages[pkg_name]
+            pkg_names_released.append(pkg_name)
         except KeyError:
             # skip unreleased packages, nothing to do with ABI checking
             pass


### PR DESCRIPTION
The current implementation of abi-checking is getting all packages present in the catkin workspace under analysis to inject them into the auto-abi call. The problem is that packages marked "not to be released" are not filtered so the python script is trying to get packages from them and failing.

**Tested:**
 * Failing [with current code](http://18.206.154.49/view/Mdev/job/Mdev__ros_comm__ubuntu_bionic_amd64/3/consoleFull#console-section-13)
 * Fixed [with this PR](http://18.206.154.49/view/Mdev/job/Mdev__ros_comm__ubuntu_bionic_amd64/9/consoleFull#console-section-13)