### PR TITLE
Update plugin versions.

### DIFF
--- a/ros_buildfarm/templates/dashboard_view_all_jobs.xml.em
+++ b/ros_buildfarm/templates/dashboard_view_all_jobs.xml.em
@@ -1,4 +1,4 @@
-<hudson.plugins.view.dashboard.Dashboard plugin="dashboard-view@@2.9.11">
+<hudson.plugins.view.dashboard.Dashboard plugin="dashboard-view@@2.12">
   <name>@view_name</name>
   <description>Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'</description>
   <filterExecutors>false</filterExecutors>

--- a/ros_buildfarm/templates/dashboard_view_devel_jobs.xml.em
+++ b/ros_buildfarm/templates/dashboard_view_devel_jobs.xml.em
@@ -1,4 +1,4 @@
-<hudson.plugins.view.dashboard.Dashboard plugin="dashboard-view@@2.9.11">
+<hudson.plugins.view.dashboard.Dashboard plugin="dashboard-view@@2.12">
   <name>@view_name</name>
   <description>Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'</description>
   <filterExecutors>false</filterExecutors>

--- a/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
@@ -1,7 +1,7 @@
     <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.2">
 @[if command]@
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
-        <script plugin="script-security@@1.66">
+        <script plugin="script-security@@1.68">
           <script>@ESCAPE(command)</script>
           <sandbox>false</sandbox>
         </script>

--- a/ros_buildfarm/templates/snippet/copy_artifacts.xml.em
+++ b/ros_buildfarm/templates/snippet/copy_artifacts.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.copyartifact.CopyArtifact plugin="copyartifact@@1.38.1">
+    <hudson.plugins.copyartifact.CopyArtifact plugin="copyartifact@@1.41">
       <project>@(project)</project>
       <filter>@(','.join(artifacts))</filter>
       <target>@(target_directory)</target>

--- a/ros_buildfarm/templates/snippet/property_github-project.xml.em
+++ b/ros_buildfarm/templates/snippet/property_github-project.xml.em
@@ -1,4 +1,4 @@
-    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.29.4">
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@@1.29.5">
       <projectUrl>@ESCAPE(project_url)</projectUrl>
       <displayName/>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>

--- a/ros_buildfarm/templates/snippet/publisher_abi_report.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_abi_report.xml.em
@@ -1,4 +1,4 @@
-<htmlpublisher.HtmlPublisher plugin="htmlpublisher@@1.18">
+<htmlpublisher.HtmlPublisher plugin="htmlpublisher@@1.21">
   <reportTargets>
     <htmlpublisher.HtmlPublisherTarget>
       <reportName>API_ABI report</reportName>

--- a/ros_buildfarm/templates/snippet/publisher_extended-email.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_extended-email.xml.em
@@ -1,5 +1,5 @@
 @[if recipients]@
-    <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@@2.63">
+    <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@@2.68">
       <recipientList>@ESCAPE(' '.join(sorted(recipients)))</recipientList>
       <configuredTriggers>
         <hudson.plugins.emailext.plugins.trigger.FailureTrigger>

--- a/ros_buildfarm/templates/snippet/publisher_groovy-postbuild.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_groovy-postbuild.xml.em
@@ -1,5 +1,5 @@
     <org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder plugin="groovy-postbuild@@2.4.3">
-      <script plugin="script-security@@1.66">
+      <script plugin="script-security@@1.68">
         <script>@ESCAPE(script)</script>
         <sandbox>false</sandbox>
       </script>

--- a/ros_buildfarm/templates/snippet/publisher_mailer.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_mailer.xml.em
@@ -1,5 +1,5 @@
 @[if recipients or dynamic_recipients or send_to_individuals]@
-    <hudson.tasks.Mailer plugin="mailer@@1.23">
+    <hudson.tasks.Mailer plugin="mailer@@1.29">
       <recipients>@ESCAPE(' '.join(sorted(recipients)))@ESCAPE(('\t' + ' '.join(sorted(dynamic_recipients))) if dynamic_recipients else '')</recipients>
       <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
       <sendToIndividuals>@(send_to_individuals ? 'true' ! 'false')</sendToIndividuals>

--- a/ros_buildfarm/templates/snippet/publisher_publish-over-git.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_publish-over-git.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.git.GitPublisher plugin="git@@3.12.1">
+    <hudson.plugins.git.GitPublisher plugin="git@@4.0.0">
       <configVersion>2</configVersion>
       <pushMerge>false</pushMerge>
       <pushOnlyIfSuccess>true</pushOnlyIfSuccess>

--- a/ros_buildfarm/templates/snippet/scm_git.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_git.xml.em
@@ -1,4 +1,4 @@
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@@3.12.1">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@@4.0.0">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>


### PR DESCRIPTION
Some plugins are updated to close security holes. The upgrade to github-oauth 0.33 fixes the bug that was preventing configuration updates from being made via the Jenkins web UI.

These updates have already been applied to build.ros.org and build.ros2.org.