### PR TITLE
Add buster to os code name mapping

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -280,7 +280,7 @@ def get_short_os_code_name(os_code_name):
     os_code_name_mappings = {
         'artful': 'A',
         'bionic': 'B',
-        'buster': 'DB',
+        'buster': 'B',
         'focal': 'F',
         'jessie': 'J',
         'saucy': 'S',

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -280,6 +280,7 @@ def get_short_os_code_name(os_code_name):
     os_code_name_mappings = {
         'artful': 'A',
         'bionic': 'B',
+        'buster': 'DB',
         'focal': 'F',
         'jessie': 'J',
         'saucy': 'S',


### PR DESCRIPTION
`DB` for Debian Buster since `B` is taken by Ubuntu Bionic.