### PR TITLE
Added num_build option to jenkin plot plugin

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -474,7 +474,7 @@ The following options are valid in version ``1`` (beside the generic options):
   * ``y_axis_maximum``: Maximum y-axis value.
   * ``num_builds``: Number of builds back to show on this plot.
     An empty string or not defined mean all builds.
-    Must not be "0", the default is 10.
+    Must not be "0", the default value is an empty string.
   * ``data_series``: a list of data series definitions comprised of:
 
     * ``data_file``: a path pattern relative to the workspace root to a file

--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -472,8 +472,9 @@ The following options are valid in version ``1`` (beside the generic options):
     implicit zero value from the y-axis.
   * ``y_axis_minimum``: Minimum y-axis value.
   * ``y_axis_maximum``: Maximum y-axis value.
-  * ``num_build``: Number of builds back to show on this plot.
-    An empty string means all builds. Must not be "0".
+  * ``num_builds``: Number of builds back to show on this plot.
+    An empty string or not defined mean all builds.
+    Must not be "0", the default is 10.
   * ``data_series``: a list of data series definitions comprised of:
 
     * ``data_file``: a path pattern relative to the workspace root to a file

--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -473,7 +473,7 @@ The following options are valid in version ``1`` (beside the generic options):
   * ``y_axis_minimum``: Minimum y-axis value.
   * ``y_axis_maximum``: Maximum y-axis value.
   * ``num_build``: Number of builds back to show on this plot.
-  An empty string means all builds. Must not be "0".
+    An empty string means all builds. Must not be "0".
   * ``data_series``: a list of data series definitions comprised of:
 
     * ``data_file``: a path pattern relative to the workspace root to a file

--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -472,8 +472,8 @@ The following options are valid in version ``1`` (beside the generic options):
     implicit zero value from the y-axis.
   * ``y_axis_minimum``: Minimum y-axis value.
   * ``y_axis_maximum``: Maximum y-axis value.
-  * ``num_build``: Number of builds back to show on this plot. An empty string
-    means all builds. Must not be "0".
+  * ``num_build``: Number of builds back to show on this plot.
+  An empty string means all builds. Must not be "0".
   * ``data_series``: a list of data series definitions comprised of:
 
     * ``data_file``: a path pattern relative to the workspace root to a file

--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -472,6 +472,8 @@ The following options are valid in version ``1`` (beside the generic options):
     implicit zero value from the y-axis.
   * ``y_axis_minimum``: Minimum y-axis value.
   * ``y_axis_maximum``: Maximum y-axis value.
+  * ``num_build``: Number of builds back to show on this plot. An empty string
+    means all builds. Must not be "0".
   * ``data_series``: a list of data series definitions comprised of:
 
     * ``data_file``: a path pattern relative to the workspace root to a file

--- a/ros_buildfarm/config/plot_config.py
+++ b/ros_buildfarm/config/plot_config.py
@@ -46,7 +46,7 @@ class PlotConfig:
         self.y_axis_minimum = data.get('y_axis_minimum', None)
         self.y_axis_maximum = data.get('y_axis_maximum', None)
 
-        self.num_builds = 10
+        self.num_builds = ""
         if 'num_builds' in data:
             self.num_builds = data['num_builds']
 

--- a/ros_buildfarm/config/plot_config.py
+++ b/ros_buildfarm/config/plot_config.py
@@ -49,6 +49,7 @@ class PlotConfig:
         self.num_build = 10
         if 'num_build' in data:
             self.num_build = data['num_build']
+            assert isinstance(self.num_build, int)
 
         self.data_series = []
         if 'data_series' in data:

--- a/ros_buildfarm/config/plot_config.py
+++ b/ros_buildfarm/config/plot_config.py
@@ -45,7 +45,10 @@ class PlotConfig:
 
         self.y_axis_minimum = data.get('y_axis_minimum', None)
         self.y_axis_maximum = data.get('y_axis_maximum', None)
-        self.num_build = int(data.get('num_build', 10))
+
+        self.num_build = 10
+        if 'num_build' in data:
+            self.num_build = data['num_build']
 
         self.data_series = []
         if 'data_series' in data:

--- a/ros_buildfarm/config/plot_config.py
+++ b/ros_buildfarm/config/plot_config.py
@@ -45,6 +45,7 @@ class PlotConfig:
 
         self.y_axis_minimum = data.get('y_axis_minimum', None)
         self.y_axis_maximum = data.get('y_axis_maximum', None)
+        self.num_build = int(data.get('num_build', 10))
 
         self.data_series = []
         if 'data_series' in data:

--- a/ros_buildfarm/config/plot_config.py
+++ b/ros_buildfarm/config/plot_config.py
@@ -46,10 +46,9 @@ class PlotConfig:
         self.y_axis_minimum = data.get('y_axis_minimum', None)
         self.y_axis_maximum = data.get('y_axis_maximum', None)
 
-        self.num_build = 10
-        if 'num_build' in data:
-            self.num_build = data['num_build']
-            assert isinstance(self.num_build, int)
+        self.num_builds = 10
+        if 'num_builds' in data:
+            self.num_builds = data['num_builds']
 
         self.data_series = []
         if 'data_series' in data:

--- a/ros_buildfarm/templates/snippet/plot_plugin.xml.em
+++ b/ros_buildfarm/templates/snippet/plot_plugin.xml.em
@@ -27,7 +27,7 @@
 @[end for]@
           </series>
           <group>@(plot_group)</group>
-          <numBuilds>@(plot.num_build)</numBuilds>
+          <numBuilds>@(plot.num_builds)</numBuilds>
           <csvFileName>@(plot.master_csv_name)</csvFileName>
           <csvLastModification>0</csvLastModification>
           <style>@(plot.style)</style>

--- a/ros_buildfarm/templates/snippet/plot_plugin.xml.em
+++ b/ros_buildfarm/templates/snippet/plot_plugin.xml.em
@@ -27,7 +27,7 @@
 @[end for]@
           </series>
           <group>@(plot_group)</group>
-          <numBuilds />
+          <numBuilds>@(plot.num_build)</numBuilds>
           <csvFileName>@(plot.master_csv_name)</csvFileName>
           <csvLastModification>0</csvLastModification>
           <style>@(plot.style)</style>


### PR DESCRIPTION
According with the [Jenkins plot plugin documentation](https://wiki.jenkins.io/display/JENKINS/Plot+Plugin) `numBuild` value must be not zero, I set up the default value to to 10 which means we will be able to visualize plots of the 10 days before.

