### PR TITLE
Add mapping from OS names to packaging formats

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -21,6 +21,14 @@ except ImportError:
     from urlparse import urlparse
 
 
+_package_format_mapping = {
+    'debian': 'deb',
+    'fedora': 'rpm',
+    'rhel': 'rpm',
+    'ubuntu': 'deb',
+}
+
+
 class JobValidationError(Exception):
     """
     Indicates that the validation of a build job failed.

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -21,7 +21,7 @@ except ImportError:
     from urlparse import urlparse
 
 
-_package_format_mapping = {
+package_format_mapping = {
     'debian': 'deb',
     'fedora': 'rpm',
     'rhel': 'rpm',


### PR DESCRIPTION
~~At the moment, only the 'deb' package format is supported. However, this configuration option will enable plumbing for additional package formats moving forward.~~

I plan to follow this PR with other PRs which will take advantage of it on a case-by-case basis. Once the 'rpm' format is supported throughout the release jobs, I'll add it to the list of supported values for this option.