### PR TITLE
Use platform-neutral term 'pkg' in place of 'deb' in CLA

### DIFF
--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -110,32 +110,32 @@ def add_argument_source_dir(parser):
         help='The path to the package sources')
 
 
-def add_argument_sourcedeb_dir(parser):
+def add_argument_sourcepkg_dir(parser):
     parser.add_argument(
-        '--sourcedeb-dir',
+        '--sourcepkg-dir', '--sourcedeb-dir',
         required=True,
-        help='The path to the package sourcedeb')
+        help='The path to the package source')
 
 
-def add_argument_binarydeb_dir(parser):
+def add_argument_binarypkg_dir(parser):
     parser.add_argument(
-        '--binarydeb-dir',
+        '--binarypkg-dir', '--binarydeb-dir',
         required=True,
-        help='The path to the package binarydeb')
+        help='The path to the package binary package')
 
 
-def add_argument_skip_download_sourcedeb(parser):
+def add_argument_skip_download_sourcepkg(parser):
     parser.add_argument(
-        '--skip-download-sourcedeb',
+        '--skip-download-sourcepkg', '--skip-download-sourcedeb',
         action='store_true',
-        help='Skip downloading sourcedeb and expect it to be already there')
+        help='Skip downloading source package and expect it to be already there')
 
 
 def add_argument_append_timestamp(parser):
     parser.add_argument(
         '--append-timestamp',
         action='store_true',
-        help='Append timestamp to binarydeb version')
+        help='Append timestamp to binary package version')
 
 
 def add_argument_output_dir(parser, required=False):

--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -114,14 +114,14 @@ def add_argument_sourcepkg_dir(parser):
     parser.add_argument(
         '--sourcepkg-dir', '--sourcedeb-dir',
         required=True,
-        help='The path to the package source')
+        help='The path to the source package')
 
 
 def add_argument_binarypkg_dir(parser):
     parser.add_argument(
         '--binarypkg-dir', '--binarydeb-dir',
         required=True,
-        help='The path to the package binary package')
+        help='The path to the binary package')
 
 
 def add_argument_skip_download_sourcepkg(parser):

--- a/ros_buildfarm/binarydeb_job.py
+++ b/ros_buildfarm/binarydeb_job.py
@@ -24,7 +24,7 @@ from ros_buildfarm.release_common import dpkg_parsechangelog
 
 def get_sourcedeb(
         rosdistro_index_url, rosdistro_name, package_name, sourcepkg_dir,
-        skip_download_sourcedeb=False):
+        skip_download_sourcepkg=False):
     # ensure that no source subfolder exists
     debian_package_name = get_debian_package_name(rosdistro_name, package_name)
     subfolders = _get_package_subfolders(sourcepkg_dir, debian_package_name)
@@ -33,7 +33,7 @@ def get_sourcedeb(
          "subfolders starting with '%s-'") % (sourcepkg_dir, package_name)
 
     debian_package_name = get_debian_package_name(rosdistro_name, package_name)
-    if not skip_download_sourcedeb:
+    if not skip_download_sourcepkg:
         # get expected package version from rosdistro
         from rosdistro import get_distribution_cache
         from rosdistro import get_index

--- a/ros_buildfarm/binarydeb_job.py
+++ b/ros_buildfarm/binarydeb_job.py
@@ -23,14 +23,14 @@ from ros_buildfarm.release_common import dpkg_parsechangelog
 
 
 def get_sourcedeb(
-        rosdistro_index_url, rosdistro_name, package_name, sourcedeb_dir,
+        rosdistro_index_url, rosdistro_name, package_name, sourcepkg_dir,
         skip_download_sourcedeb=False):
     # ensure that no source subfolder exists
     debian_package_name = get_debian_package_name(rosdistro_name, package_name)
-    subfolders = _get_package_subfolders(sourcedeb_dir, debian_package_name)
+    subfolders = _get_package_subfolders(sourcepkg_dir, debian_package_name)
     assert not subfolders, \
         ("Sourcedeb directory '%s' must not have any " +
-         "subfolders starting with '%s-'") % (sourcedeb_dir, package_name)
+         "subfolders starting with '%s-'") % (sourcepkg_dir, package_name)
 
     debian_package_name = get_debian_package_name(rosdistro_name, package_name)
     if not skip_download_sourcedeb:
@@ -64,18 +64,18 @@ def get_sourcedeb(
             'source', '--download-only', '--only-source',
             debian_package_name + '=' + debian_package_versions[0]]
         print("Invoking '%s'" % ' '.join(cmd))
-        subprocess.check_call(cmd, cwd=sourcedeb_dir)
+        subprocess.check_call(cmd, cwd=sourcepkg_dir)
 
     # extract sourcedeb
-    filenames = _get_package_dsc_filename(sourcedeb_dir, debian_package_name)
+    filenames = _get_package_dsc_filename(sourcepkg_dir, debian_package_name)
     assert len(filenames) == 1, filenames
     dsc_filename = filenames[0]
     cmd = ['dpkg-source', '-x', dsc_filename]
     print("Invoking '%s'" % ' '.join(cmd))
-    subprocess.check_call(cmd, cwd=sourcedeb_dir)
+    subprocess.check_call(cmd, cwd=sourcepkg_dir)
 
     # ensure that one source subfolder exists
-    subfolders = _get_package_subfolders(sourcedeb_dir, debian_package_name)
+    subfolders = _get_package_subfolders(sourcepkg_dir, debian_package_name)
     assert len(subfolders) == 1, subfolders
     source_dir = subfolders[0]
 
@@ -90,10 +90,10 @@ def get_sourcedeb(
               ' '.join(sorted(maintainer_emails)))
 
 
-def append_build_timestamp(rosdistro_name, package_name, sourcedeb_dir):
+def append_build_timestamp(rosdistro_name, package_name, sourcepkg_dir):
     # ensure that one source subfolder exists
     debian_package_name = get_debian_package_name(rosdistro_name, package_name)
-    subfolders = _get_package_subfolders(sourcedeb_dir, debian_package_name)
+    subfolders = _get_package_subfolders(sourcepkg_dir, debian_package_name)
     assert len(subfolders) == 1, subfolders
     source_dir = subfolders[0]
 
@@ -117,10 +117,10 @@ def append_build_timestamp(rosdistro_name, package_name, sourcedeb_dir):
     subprocess.check_call(cmd, cwd=source_dir)
 
 
-def build_binarydeb(rosdistro_name, package_name, sourcedeb_dir):
+def build_binarydeb(rosdistro_name, package_name, sourcepkg_dir):
     # ensure that one source subfolder exists
     debian_package_name = get_debian_package_name(rosdistro_name, package_name)
-    subfolders = _get_package_subfolders(sourcedeb_dir, debian_package_name)
+    subfolders = _get_package_subfolders(sourcepkg_dir, debian_package_name)
     assert len(subfolders) == 1, subfolders
     source_dir = subfolders[0]
 

--- a/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
@@ -77,7 +77,7 @@ cmds = [
     ' ' + rosdistro_name +
     ' ' + package_name +
     ' --sourcepkg-dir ' + binarypkg_dir +
-    (' --skip-download-sourcedeb' if skip_download_sourcedeb else ''),
+    (' --skip-download-sourcepkg' if skip_download_sourcepkg else ''),
 ]
 
 if append_timestamp:

--- a/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_create_task.Dockerfile.em
@@ -76,7 +76,7 @@ cmds = [
     ' --rosdistro-index-url ' + rosdistro_index_url +
     ' ' + rosdistro_name +
     ' ' + package_name +
-    ' --sourcedeb-dir ' + binarydeb_dir +
+    ' --sourcepkg-dir ' + binarypkg_dir +
     (' --skip-download-sourcedeb' if skip_download_sourcedeb else ''),
 ]
 
@@ -86,7 +86,7 @@ if append_timestamp:
         ' /tmp/ros_buildfarm/scripts/release/append_build_timestamp.py' +
         ' ' + rosdistro_name +
         ' ' + package_name +
-        ' --sourcedeb-dir ' + binarydeb_dir)
+        ' --sourcepkg-dir ' + binarypkg_dir)
 
 cmds.append(
     'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' +
@@ -99,7 +99,7 @@ cmds.append(
     ' ' + arch +
     ' --distribution-repository-urls ' + ' '.join(distribution_repository_urls) +
     ' --distribution-repository-key-files ' + ' ' .join(['/tmp/keys/%d.key' % i for i in range(len(distribution_repository_keys))]) +
-    ' --binarydeb-dir ' + binarydeb_dir +
+    ' --binarypkg-dir ' + binarypkg_dir +
     ' --env-vars ' + ' '.join(build_environment_variables) +
     ' --dockerfile-dir ' + dockerfile_dir)
 }@

--- a/ros_buildfarm/templates/release/binarydeb_job.xml.em
+++ b/ros_buildfarm/templates/release/binarydeb_job.xml.em
@@ -102,7 +102,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' ' + os_code_name +
         ' ' + arch +
         ' ' + ' '.join(repository_args) +
-        ' --binarydeb-dir $WORKSPACE/binarydeb' +
+        ' --binarypkg-dir $WORKSPACE/binarydeb' +
         ' --dockerfile-dir $WORKSPACE/docker_generating_docker' +
         ' --env-vars ' + ' '.join(build_environment_variables) +
         (' --append-timestamp' if append_timestamp else ''),
@@ -201,7 +201,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 @#         ' ' + os_code_name +
 @#         ' ' + arch +
 @#         ' ' + ' '.join(repository_args) +
-@#         ' --binarydeb-dir $WORKSPACE/binarydeb' +
+@#         ' --binarypkg-dir $WORKSPACE/binarydeb' +
 @#         ' --dockerfile-dir $WORKSPACE/docker_install_binarydeb',
 @#         'echo "# END SECTION"',
 @#         '',

--- a/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/binarydeb_task.Dockerfile.em
@@ -93,6 +93,6 @@ cmd = \
     ' /tmp/ros_buildfarm/scripts/release/build_binarydeb.py' + \
     ' ' + rosdistro_name + \
     ' ' + package_name + \
-    ' --sourcedeb-dir ' + binarydeb_dir
+    ' --sourcepkg-dir ' + binarypkg_dir
 }@
 CMD ["@cmd"]

--- a/scripts/release/append_build_timestamp.py
+++ b/scripts/release/append_build_timestamp.py
@@ -19,7 +19,7 @@ import sys
 
 from ros_buildfarm.argument import add_argument_package_name
 from ros_buildfarm.argument import add_argument_rosdistro_name
-from ros_buildfarm.argument import add_argument_sourcedeb_dir
+from ros_buildfarm.argument import add_argument_sourcepkg_dir
 from ros_buildfarm.binarydeb_job import append_build_timestamp
 from ros_buildfarm.common import Scope
 
@@ -30,11 +30,11 @@ def main(argv=sys.argv[1:]):
             description='Append current timestamp to package version')
         add_argument_rosdistro_name(parser)
         add_argument_package_name(parser)
-        add_argument_sourcedeb_dir(parser)
+        add_argument_sourcepkg_dir(parser)
         args = parser.parse_args(argv)
 
         return append_build_timestamp(
-            args.rosdistro_name, args.package_name, args.sourcedeb_dir)
+            args.rosdistro_name, args.package_name, args.sourcepkg_dir)
 
 
 if __name__ == '__main__':

--- a/scripts/release/build_binarydeb.py
+++ b/scripts/release/build_binarydeb.py
@@ -19,7 +19,7 @@ import sys
 
 from ros_buildfarm.argument import add_argument_package_name
 from ros_buildfarm.argument import add_argument_rosdistro_name
-from ros_buildfarm.argument import add_argument_sourcedeb_dir
+from ros_buildfarm.argument import add_argument_sourcepkg_dir
 from ros_buildfarm.binarydeb_job import build_binarydeb
 from ros_buildfarm.common import Scope
 
@@ -30,11 +30,11 @@ def main(argv=sys.argv[1:]):
             description='Build package binarydeb')
         add_argument_rosdistro_name(parser)
         add_argument_package_name(parser)
-        add_argument_sourcedeb_dir(parser)
+        add_argument_sourcepkg_dir(parser)
         args = parser.parse_args(argv)
 
         return build_binarydeb(
-            args.rosdistro_name, args.package_name, args.sourcedeb_dir)
+            args.rosdistro_name, args.package_name, args.sourcepkg_dir)
 
 
 if __name__ == '__main__':

--- a/scripts/release/create_binarydeb_install_task_generator.py
+++ b/scripts/release/create_binarydeb_install_task_generator.py
@@ -18,7 +18,7 @@ import argparse
 import sys
 
 from ros_buildfarm.argument import add_argument_arch
-from ros_buildfarm.argument import add_argument_binarydeb_dir
+from ros_buildfarm.argument import add_argument_binarypkg_dir
 from ros_buildfarm.argument import \
     add_argument_distribution_repository_key_files
 from ros_buildfarm.argument import add_argument_distribution_repository_urls
@@ -37,7 +37,7 @@ def main(argv=sys.argv[1:]):
     add_argument_arch(parser)
     add_argument_distribution_repository_urls(parser)
     add_argument_distribution_repository_key_files(parser)
-    add_argument_binarydeb_dir(parser)
+    add_argument_binarypkg_dir(parser)
     add_argument_dockerfile_dir(parser)
     args = parser.parse_args(argv)
 
@@ -58,7 +58,7 @@ def main(argv=sys.argv[1:]):
 
     # output hints about necessary volumes to mount
     print('Mount the following volumes when running the container:')
-    print('  -v %s:/tmp/binarydeb:ro' % args.binarydeb_dir)
+    print('  -v %s:/tmp/binarydeb:ro' % args.binarypkg_dir)
 
 
 if __name__ == '__main__':

--- a/scripts/release/create_binarydeb_task_generator.py
+++ b/scripts/release/create_binarydeb_task_generator.py
@@ -22,7 +22,7 @@ import sys
 
 from apt import Cache
 from ros_buildfarm.argument import add_argument_arch
-from ros_buildfarm.argument import add_argument_binarydeb_dir
+from ros_buildfarm.argument import add_argument_binarypkg_dir
 from ros_buildfarm.argument import \
     add_argument_distribution_repository_key_files
 from ros_buildfarm.argument import add_argument_distribution_repository_urls
@@ -53,7 +53,7 @@ def main(argv=sys.argv[1:]):
     add_argument_arch(parser)
     add_argument_distribution_repository_urls(parser)
     add_argument_distribution_repository_key_files(parser)
-    add_argument_binarydeb_dir(parser)
+    add_argument_binarypkg_dir(parser)
     add_argument_dockerfile_dir(parser)
     add_argument_env_vars(parser)
     args = parser.parse_args(argv)
@@ -76,7 +76,7 @@ def main(argv=sys.argv[1:]):
 
     # add build dependencies from .dsc file
     dsc_file = get_dsc_file(
-        args.binarydeb_dir, debian_package_name, debian_package_version)
+        args.binarypkg_dir, debian_package_name, debian_package_version)
     debian_pkg_names += sorted(get_build_depends(dsc_file))
 
     # get versions for build dependencies
@@ -105,7 +105,7 @@ def main(argv=sys.argv[1:]):
 
         'rosdistro_name': args.rosdistro_name,
         'package_name': args.package_name,
-        'binarydeb_dir': args.binarydeb_dir,
+        'binarypkg_dir': args.binarypkg_dir,
     }
     create_dockerfile(
         'release/binarydeb_task.Dockerfile.em', data, args.dockerfile_dir)
@@ -115,7 +115,7 @@ def main(argv=sys.argv[1:]):
         os.path.join(os.path.dirname(__file__), '..', '..'))
     print('Mount the following volumes when running the container:')
     print('  -v %s:/tmp/ros_buildfarm:ro' % ros_buildfarm_basepath)
-    print('  -v %s:/tmp/binarydeb' % args.binarydeb_dir)
+    print('  -v %s:/tmp/binarydeb' % args.binarypkg_dir)
 
 
 def get_dsc_file(basepath, debian_package_name, debian_package_version):

--- a/scripts/release/generate_release_script.py
+++ b/scripts/release/generate_release_script.py
@@ -102,7 +102,7 @@ def main(argv=sys.argv[1:]):
 
     # inject additional argument to skip fetching sourcedeb from repo
     script_name = '/run_binarydeb_job.py '
-    additional_argument = '--skip-download-sourcedeb '
+    additional_argument = '--skip-download-sourcepkg '
     for i, script in enumerate(binary_scripts):
         offset = script.find(script_name)
         if offset != -1:

--- a/scripts/release/get_sourcedeb.py
+++ b/scripts/release/get_sourcedeb.py
@@ -20,7 +20,7 @@ import sys
 from ros_buildfarm.argument import add_argument_package_name
 from ros_buildfarm.argument import add_argument_rosdistro_index_url
 from ros_buildfarm.argument import add_argument_rosdistro_name
-from ros_buildfarm.argument import add_argument_skip_download_sourcedeb
+from ros_buildfarm.argument import add_argument_skip_download_sourcepkg
 from ros_buildfarm.argument import add_argument_sourcepkg_dir
 from ros_buildfarm.binarydeb_job import get_sourcedeb
 from ros_buildfarm.common import Scope
@@ -34,12 +34,12 @@ def main(argv=sys.argv[1:]):
         add_argument_rosdistro_name(parser)
         add_argument_package_name(parser)
         add_argument_sourcepkg_dir(parser)
-        add_argument_skip_download_sourcedeb(parser)
+        add_argument_skip_download_sourcepkg(parser)
         args = parser.parse_args(argv)
 
         return get_sourcedeb(
             args.rosdistro_index_url, args.rosdistro_name, args.package_name,
-            args.sourcepkg_dir, args.skip_download_sourcedeb)
+            args.sourcepkg_dir, args.skip_download_sourcepkg)
 
 
 if __name__ == '__main__':

--- a/scripts/release/get_sourcedeb.py
+++ b/scripts/release/get_sourcedeb.py
@@ -21,7 +21,7 @@ from ros_buildfarm.argument import add_argument_package_name
 from ros_buildfarm.argument import add_argument_rosdistro_index_url
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.argument import add_argument_skip_download_sourcedeb
-from ros_buildfarm.argument import add_argument_sourcedeb_dir
+from ros_buildfarm.argument import add_argument_sourcepkg_dir
 from ros_buildfarm.binarydeb_job import get_sourcedeb
 from ros_buildfarm.common import Scope
 
@@ -33,13 +33,13 @@ def main(argv=sys.argv[1:]):
         add_argument_rosdistro_index_url(parser)
         add_argument_rosdistro_name(parser)
         add_argument_package_name(parser)
-        add_argument_sourcedeb_dir(parser)
+        add_argument_sourcepkg_dir(parser)
         add_argument_skip_download_sourcedeb(parser)
         args = parser.parse_args(argv)
 
         return get_sourcedeb(
             args.rosdistro_index_url, args.rosdistro_name, args.package_name,
-            args.sourcedeb_dir, args.skip_download_sourcedeb)
+            args.sourcepkg_dir, args.skip_download_sourcedeb)
 
 
 if __name__ == '__main__':

--- a/scripts/release/run_binarydeb_job.py
+++ b/scripts/release/run_binarydeb_job.py
@@ -31,7 +31,7 @@ from ros_buildfarm.argument import add_argument_os_name
 from ros_buildfarm.argument import add_argument_package_name
 from ros_buildfarm.argument import add_argument_rosdistro_index_url
 from ros_buildfarm.argument import add_argument_rosdistro_name
-from ros_buildfarm.argument import add_argument_skip_download_sourcedeb
+from ros_buildfarm.argument import add_argument_skip_download_sourcepkg
 from ros_buildfarm.argument import add_argument_target_repository
 from ros_buildfarm.common import get_distribution_repository_keys
 from ros_buildfarm.common import get_user_id
@@ -52,7 +52,7 @@ def main(argv=sys.argv[1:]):
     add_argument_target_repository(parser)
     add_argument_binarypkg_dir(parser)
     add_argument_dockerfile_dir(parser)
-    add_argument_skip_download_sourcedeb(parser)
+    add_argument_skip_download_sourcepkg(parser)
     add_argument_append_timestamp(parser)
     add_argument_env_vars(parser)
     args = parser.parse_args(argv)
@@ -67,7 +67,7 @@ def main(argv=sys.argv[1:]):
             args.distribution_repository_key_files),
         'target_repository': args.target_repository,
 
-        'skip_download_sourcedeb': args.skip_download_sourcedeb,
+        'skip_download_sourcepkg': args.skip_download_sourcepkg,
 
         'binarypkg_dir': '/tmp/binarydeb',
         'build_environment_variables': args.env_vars,

--- a/scripts/release/run_binarydeb_job.py
+++ b/scripts/release/run_binarydeb_job.py
@@ -20,7 +20,7 @@ import sys
 
 from ros_buildfarm.argument import add_argument_append_timestamp
 from ros_buildfarm.argument import add_argument_arch
-from ros_buildfarm.argument import add_argument_binarydeb_dir
+from ros_buildfarm.argument import add_argument_binarypkg_dir
 from ros_buildfarm.argument import \
     add_argument_distribution_repository_key_files
 from ros_buildfarm.argument import add_argument_distribution_repository_urls
@@ -50,7 +50,7 @@ def main(argv=sys.argv[1:]):
     add_argument_distribution_repository_urls(parser)
     add_argument_distribution_repository_key_files(parser)
     add_argument_target_repository(parser)
-    add_argument_binarydeb_dir(parser)
+    add_argument_binarypkg_dir(parser)
     add_argument_dockerfile_dir(parser)
     add_argument_skip_download_sourcedeb(parser)
     add_argument_append_timestamp(parser)
@@ -69,7 +69,7 @@ def main(argv=sys.argv[1:]):
 
         'skip_download_sourcedeb': args.skip_download_sourcedeb,
 
-        'binarydeb_dir': '/tmp/binarydeb',
+        'binarypkg_dir': '/tmp/binarydeb',
         'build_environment_variables': args.env_vars,
         'dockerfile_dir': '/tmp/docker_build_binarydeb',
     })


### PR DESCRIPTION
I'd like to reuse these arguments for the RPM scripts.

This change maintains reverse compatibility with the deb-specific command line arguments.

A demonstration of the reverse compatibility:
```python
>>> import argparse
>>> parser = argparse.ArgumentParser()
>>> parser.add_argument('--foo', '--bar', '-f')
>>> parser.parse_args(['--foo', 'baz'])
Namespace(foo='baz')
>>> parser.parse_args(['--bar', 'baz'])
Namespace(foo='baz')
>>> parser.parse_args(['-f', 'baz'])
Namespace(foo='baz')
>>> parser.print_usage()
usage: [-h] [--foo FOO]
>>> parser.print_help()
usage: [-h] [--foo FOO]

optional arguments:
  -h, --help            show this help message and exit
  --foo FOO, --bar FOO, -f FOO
```