### PR TITLE
Refactor and abstract debian repo data caching

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -20,6 +20,8 @@ try:
 except ImportError:
     from urlparse import urlparse
 
+from .debian_repo import get_debian_repo_index
+
 
 class JobValidationError(Exception):
     """
@@ -557,3 +559,12 @@ def get_packages_in_workspaces(workspace_roots, condition_context):
             pkg.evaluate_conditions(condition_context)
         pkgs.update(ws_pkgs)
     return pkgs
+
+
+def get_package_repo_data(repository_baseurl, targets, cache_dir):
+    data = {}
+    for target in targets:
+        index = get_debian_repo_index(
+            repository_baseurl, target, cache_dir)
+        data[target] = index
+    return data

--- a/ros_buildfarm/debian_repo.py
+++ b/ros_buildfarm/debian_repo.py
@@ -12,21 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from gzip import GzipFile
-import hashlib
-from io import BytesIO
 import logging
 import os
-import socket
-import time
-try:
-    from urllib.error import HTTPError
-    from urllib.error import URLError
-    from urllib.request import urlopen
-except ImportError:
-    from urllib2 import HTTPError
-    from urllib2 import URLError
-    from urllib2 import urlopen
+
+from .package_repo import fetch_and_cache_gzip
 
 
 def get_debian_repo_data(debian_repository_baseurl, targets, cache_dir):
@@ -46,10 +35,7 @@ def get_debian_repo_index(debian_repository_baseurl, target, cache_dir):
     else:
         url = os.path.join(url, 'binary-%s' % target.arch, 'Packages.gz')
 
-    cache_filename = os.path.join(
-        cache_dir, hashlib.md5(url.encode()).hexdigest())
-    if not os.path.exists(cache_filename):
-        fetch_gzip_url(url, cache_filename)
+    cache_filename = fetch_and_cache_gzip(url, cache_dir)
 
     logging.debug('Reading file: %s' % cache_filename)
     # split package blocks
@@ -71,36 +57,3 @@ def get_debian_repo_index(debian_repository_baseurl, target, cache_dir):
         package_versions[debian_pkg_name] = version
 
     return package_versions
-
-
-def fetch_gzip_url(url, dst_filename):
-    dst_dirname = os.path.dirname(dst_filename)
-    if not os.path.exists(dst_dirname):
-        os.makedirs(dst_dirname)
-    logging.debug('Downloading gz url: %s' % url)
-    gz_str = load_url(url)
-    gz_stream = BytesIO(gz_str)
-    g = GzipFile(fileobj=gz_stream, mode='rb')
-    with open(dst_filename, 'wb') as f:
-        f.write(g.read())
-
-
-def load_url(url, retry=2, retry_period=1, timeout=10):
-    try:
-        fh = urlopen(url, timeout=timeout)
-    except HTTPError as e:
-        if e.code == 503 and retry:
-            time.sleep(retry_period)
-            return load_url(
-                url, retry=retry - 1, retry_period=retry_period,
-                timeout=timeout)
-        e.msg += ' (%s)' % url
-        raise
-    except URLError as e:
-        if isinstance(e.reason, socket.timeout) and retry:
-            time.sleep(retry_period)
-            return load_url(
-                url, retry=retry - 1, retry_period=retry_period,
-                timeout=timeout)
-        raise URLError(str(e) + ' (%s)' % url)
-    return fh.read()

--- a/ros_buildfarm/debian_repo.py
+++ b/ros_buildfarm/debian_repo.py
@@ -18,15 +18,6 @@ import os
 from .package_repo import fetch_and_cache_gzip
 
 
-def get_debian_repo_data(debian_repository_baseurl, targets, cache_dir):
-    data = {}
-    for target in targets:
-        index = get_debian_repo_index(
-            debian_repository_baseurl, target, cache_dir)
-        data[target] = index
-    return data
-
-
 def get_debian_repo_index(debian_repository_baseurl, target, cache_dir):
     url = os.path.join(
         debian_repository_baseurl, 'dists', target.os_code_name, 'main')

--- a/ros_buildfarm/debian_repo.py
+++ b/ros_buildfarm/debian_repo.py
@@ -15,7 +15,7 @@
 import logging
 import os
 
-from .package_repo import fetch_and_cache_gzip
+from .http_cache import fetch_and_cache_gzip
 
 
 def get_debian_repo_index(debian_repository_baseurl, target, cache_dir):

--- a/ros_buildfarm/http_cache.py
+++ b/ros_buildfarm/http_cache.py
@@ -28,17 +28,6 @@ except ImportError:
     from urllib2 import URLError
     from urllib2 import urlopen
 
-from .debian_repo import get_debian_repo_index
-
-
-def get_package_repo_data(repository_baseurl, targets, cache_dir):
-    data = {}
-    for target in targets:
-        index = get_debian_repo_index(
-            repository_baseurl, target, cache_dir)
-        data[target] = index
-    return data
-
 
 def fetch_and_cache_gzip(url, cache_dir):
     cache_filename = os.path.join(

--- a/ros_buildfarm/package_repo.py
+++ b/ros_buildfarm/package_repo.py
@@ -1,0 +1,87 @@
+# Copyright 2014, 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from gzip import GzipFile
+import hashlib
+from io import BytesIO
+import logging
+import os
+import socket
+import time
+try:
+    from urllib.error import HTTPError
+    from urllib.error import URLError
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import HTTPError
+    from urllib2 import URLError
+    from urllib2 import urlopen
+
+
+def fetch_and_cache_gzip(url, cache_dir):
+    cache_filename = os.path.join(
+        cache_dir, hashlib.md5(url.encode()).hexdigest())
+    if not os.path.exists(cache_filename):
+        _fetch_gzip_url(url, cache_filename)
+    return cache_filename
+
+
+def fetch_and_cache_plaintext(url, cache_dir):
+    cache_filename = os.path.join(
+        cache_dir, hashlib.md5(url.encode()).hexdigest())
+    if not os.path.exists(cache_filename):
+        _fetch_plain_url(url, cache_filename)
+    return cache_filename
+
+
+def _fetch_gzip_url(url, dst_filename):
+    dst_dirname = os.path.dirname(dst_filename)
+    if not os.path.exists(dst_dirname):
+        os.makedirs(dst_dirname)
+    logging.debug('Downloading gz url: %s' % url)
+    gz_str = _load_url(url)
+    gz_stream = BytesIO(gz_str)
+    g = GzipFile(fileobj=gz_stream, mode='rb')
+    with open(dst_filename, 'wb') as f:
+        f.write(g.read())
+
+
+def _fetch_plain_url(url, dst_filename):
+    dst_dirname = os.path.dirname(dst_filename)
+    if not os.path.exists(dst_dirname):
+        os.makedirs(dst_dirname)
+    logging.debug('Downloading url: %s' % url)
+    with open(dst_filename, 'wb') as f:
+        f.write(_load_url(url))
+
+
+def _load_url(url, retry=2, retry_period=1, timeout=10):
+    try:
+        fh = urlopen(url, timeout=timeout)
+    except HTTPError as e:
+        if e.code == 503 and retry:
+            time.sleep(retry_period)
+            return _load_url(
+                url, retry=retry - 1, retry_period=retry_period,
+                timeout=timeout)
+        e.msg += ' (%s)' % url
+        raise
+    except URLError as e:
+        if isinstance(e.reason, socket.timeout) and retry:
+            time.sleep(retry_period)
+            return _load_url(
+                url, retry=retry - 1, retry_period=retry_period,
+                timeout=timeout)
+        raise URLError(str(e) + ' (%s)' % url)
+    return fh.read()

--- a/ros_buildfarm/package_repo.py
+++ b/ros_buildfarm/package_repo.py
@@ -28,6 +28,17 @@ except ImportError:
     from urllib2 import URLError
     from urllib2 import urlopen
 
+from .debian_repo import get_debian_repo_index
+
+
+def get_package_repo_data(repository_baseurl, targets, cache_dir):
+    data = {}
+    for target in targets:
+        index = get_debian_repo_index(
+            repository_baseurl, target, cache_dir)
+        data[target] = index
+    return data
+
 
 def fetch_and_cache_gzip(url, cache_dir):
     cache_filename = os.path.join(

--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -32,7 +32,7 @@ from .common import get_short_arch
 from .common import Target
 from .config import get_index as get_config_index
 from .config import get_release_build_files
-from .debian_repo import get_debian_repo_data
+from .package_repo import get_package_repo_data
 from .status_page_input import get_rosdistro_info
 from .status_page_input import RosPackage
 from .templates import expand_template
@@ -77,11 +77,11 @@ def build_release_status_page(
     testing_repo_url = os.path.join(base_url, 'testing')
     main_repo_url = os.path.join(base_url, 'main')
 
-    building_repo_data = get_debian_repo_data(
+    building_repo_data = get_package_repo_data(
         building_repo_url, targets, cache_dir)
-    testing_repo_data = get_debian_repo_data(
+    testing_repo_data = get_package_repo_data(
         testing_repo_url, targets, cache_dir)
-    main_repo_data = get_debian_repo_data(main_repo_url, targets, cache_dir)
+    main_repo_data = get_package_repo_data(main_repo_url, targets, cache_dir)
 
     repos_data = [building_repo_data, testing_repo_data, main_repo_data]
 
@@ -178,7 +178,7 @@ def build_debian_repos_status_page(
     # get all input data
     repos_data = []
     for repo_url in repo_urls:
-        repo_data = get_debian_repo_data(repo_url, targets, cache_dir)
+        repo_data = get_package_repo_data(repo_url, targets, cache_dir)
         repos_data.append(repo_data)
 
     # compute derived attributes

--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -27,12 +27,12 @@ import time
 import yaml
 
 from .common import get_debian_package_name
+from .common import get_package_repo_data
 from .common import get_release_view_name
 from .common import get_short_arch
 from .common import Target
 from .config import get_index as get_config_index
 from .config import get_release_build_files
-from .package_repo import get_package_repo_data
 from .status_page_input import get_rosdistro_info
 from .status_page_input import RosPackage
 from .templates import expand_template

--- a/ros_buildfarm/templates/release/release_trigger-jobs_job.xml.em
+++ b/ros_buildfarm/templates/release/release_trigger-jobs_job.xml.em
@@ -103,7 +103,7 @@ if missed_jobs:
         ' ' + ' '.join(repository_args) +
         ' $args' +
         ' --groovy-script /tmp/trigger_jobs/trigger_jobs.groovy' +
-        ' --cache-dir /tmp/debian_repo_cache' +
+        ' --cache-dir /tmp/package_repo_cache' +
         ' --dockerfile-dir $WORKSPACE/docker_trigger_jobs',
         'echo "# END SECTION"',
         '',
@@ -114,8 +114,8 @@ if missed_jobs:
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - trigger jobs"',
-        'rm -fr $WORKSPACE/debian_repo_cache',
-        'mkdir -p $WORKSPACE/debian_repo_cache',
+        'rm -fr $WORKSPACE/package_repo_cache',
+        'mkdir -p $WORKSPACE/package_repo_cache',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_trigger_jobs/docker.cid' +
@@ -123,7 +123,7 @@ if missed_jobs:
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v %s:%s:ro' % (credentials_src, credentials_dst) +
         ' -v $WORKSPACE/trigger_jobs:/tmp/trigger_jobs' +
-        ' -v $WORKSPACE/debian_repo_cache:/tmp/debian_repo_cache' +
+        ' -v $WORKSPACE/package_repo_cache:/tmp/package_repo_cache' +
         ' release_trigger_jobs',
         'echo "# END SECTION"',
     ]),

--- a/ros_buildfarm/templates/release/sync_packages_to_testing_job.xml.em
+++ b/ros_buildfarm/templates/release/sync_packages_to_testing_job.xml.em
@@ -62,7 +62,7 @@
         ' ' + os_code_name +
         ' ' + arch +
         ' ' + ' '.join(repository_args) +
-        ' --cache-dir /tmp/debian_repo_cache' +
+        ' --cache-dir /tmp/package_repo_cache' +
         ' --dockerfile-dir $WORKSPACE/docker_check_sync_criteria',
         'echo "# END SECTION"',
         '',
@@ -73,13 +73,13 @@
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - check sync condition"',
-        'rm -fr $WORKSPACE/debian_repo_cache',
-        'mkdir -p $WORKSPACE/debian_repo_cache',
+        'rm -fr $WORKSPACE/package_repo_cache',
+        'mkdir -p $WORKSPACE/package_repo_cache',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_check_sync_criteria/docker.cid' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
-        ' -v $WORKSPACE/debian_repo_cache:/tmp/debian_repo_cache' +
+        ' -v $WORKSPACE/package_repo_cache:/tmp/package_repo_cache' +
         ' check_sync_condition',
         'echo "# END SECTION"',
     ]),

--- a/ros_buildfarm/templates/status/release_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_status_page_job.xml.em
@@ -75,16 +75,16 @@
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - status page"',
-        'rm -fr $WORKSPACE/debian_repo_cache',
+        'rm -fr $WORKSPACE/package_repo_cache',
         'rm -fr $WORKSPACE/status_page',
-        'mkdir -p $WORKSPACE/debian_repo_cache',
+        'mkdir -p $WORKSPACE/package_repo_cache',
         'mkdir -p $WORKSPACE/status_page',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_generate_status_page/docker.cid' +
         ' --net=host' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
-        ' -v $WORKSPACE/debian_repo_cache:/tmp/debian_repo_cache' +
+        ' -v $WORKSPACE/package_repo_cache:/tmp/package_repo_cache' +
         ' -v $WORKSPACE/status_page:/tmp/status_page' +
         ' status_page_generation',
         'echo "# END SECTION"',

--- a/ros_buildfarm/templates/status/release_status_page_task.Dockerfile.em
+++ b/ros_buildfarm/templates/status/release_status_page_task.Dockerfile.em
@@ -47,7 +47,7 @@ cmd = \
     ' ' + config_url + \
     ' ' + rosdistro_name + \
     ' ' + release_build_name + \
-    ' --cache-dir /tmp/debian_repo_cache' + \
+    ' --cache-dir /tmp/package_repo_cache' + \
     ' --output-dir /tmp/status_page' + \
     ' --copy-resources'
 }@

--- a/ros_buildfarm/templates/status/repos_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/repos_status_page_job.xml.em
@@ -40,9 +40,9 @@
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
-        'rm -fr $WORKSPACE/debian_repo_cache',
+        'rm -fr $WORKSPACE/package_repo_cache',
         'rm -fr $WORKSPACE/status_page',
-        'mkdir -p $WORKSPACE/debian_repo_cache',
+        'mkdir -p $WORKSPACE/package_repo_cache',
         'mkdir -p $WORKSPACE/status_page',
     ]),
 ))@
@@ -62,7 +62,7 @@ os_code_name_and_arch_tuples = status_page['os_code_name_and_arch_tuples']
         ' ' + ' '.join(debian_repository_urls) +
         ' --os-code-name-and-arch-tuples ' +
         ' '.join(os_code_name_and_arch_tuples) +
-        ' --cache-dir $WORKSPACE/debian_repo_cache' +
+        ' --cache-dir $WORKSPACE/package_repo_cache' +
         ' --output-name %s_%s' % (rosdistro_name, status_page_name) +
         ' --output-dir $WORKSPACE/status_page',
         'echo "# END SECTION"',

--- a/ros_buildfarm/trigger_job.py
+++ b/ros_buildfarm/trigger_job.py
@@ -20,11 +20,11 @@ from rosdistro import get_index
 
 from .common import get_binarydeb_job_name
 from .common import get_debian_package_name
+from .common import get_package_repo_data
 from .common import get_sourcedeb_job_name
 from .common import Target
 from .config import get_index as get_config_index
 from .config import get_release_build_files
-from .package_repo import get_package_repo_data
 from .status_page import _strip_version_suffix
 from .templates import expand_template
 

--- a/ros_buildfarm/trigger_job.py
+++ b/ros_buildfarm/trigger_job.py
@@ -24,7 +24,7 @@ from .common import get_sourcedeb_job_name
 from .common import Target
 from .config import get_index as get_config_index
 from .config import get_release_build_files
-from .debian_repo import get_debian_repo_data
+from .package_repo import get_package_repo_data
 from .status_page import _strip_version_suffix
 from .templates import expand_template
 
@@ -60,7 +60,7 @@ def trigger_release_jobs(
 
     repo_data = None
     if missing_only:
-        repo_data = get_debian_repo_data(
+        repo_data = get_package_repo_data(
             build_file.target_repository, targets, cache_dir)
 
     if groovy_script is None:

--- a/scripts/release/check_sync_criteria.py
+++ b/scripts/release/check_sync_criteria.py
@@ -43,7 +43,7 @@ def main(argv=sys.argv[1:]):
     add_argument_build_name(parser, 'release')
     add_argument_os_code_name(parser)
     add_argument_arch(parser)
-    add_argument_cache_dir(parser, '/tmp/debian_repo_cache')
+    add_argument_cache_dir(parser, '/tmp/package_repo_cache')
     args = parser.parse_args(argv)
 
     success = check_sync_criteria(

--- a/scripts/release/trigger_jobs.py
+++ b/scripts/release/trigger_jobs.py
@@ -41,7 +41,7 @@ def main(argv=sys.argv[1:]):
     add_argument_not_failed_only(parser)
     add_argument_cause(parser)
     add_argument_groovy_script(parser)
-    add_argument_cache_dir(parser, '/tmp/debian_repo_cache')
+    add_argument_cache_dir(parser, '/tmp/package_repo_cache')
     args = parser.parse_args(argv)
 
     return trigger_release_jobs(

--- a/scripts/status/build_release_status_page.py
+++ b/scripts/status/build_release_status_page.py
@@ -38,7 +38,7 @@ def main(argv=sys.argv[1:]):
     add_argument_config_url(parser)
     add_argument_rosdistro_name(parser)
     add_argument_build_name(parser, 'release')
-    add_argument_cache_dir(parser, '/tmp/debian_repo_cache')
+    add_argument_cache_dir(parser, '/tmp/package_repo_cache')
     add_argument_output_dir(parser)
     parser.add_argument(
         '--copy-resources',

--- a/scripts/status/build_repos_status_page.py
+++ b/scripts/status/build_repos_status_page.py
@@ -32,7 +32,7 @@ def main(argv=sys.argv[1:]):
     add_argument_rosdistro_name(parser)
     add_argument_debian_repository_urls(parser)
     add_argument_os_code_name_and_arch_tuples(parser)
-    add_argument_cache_dir(parser, '/tmp/debian_repo_cache')
+    add_argument_cache_dir(parser, '/tmp/package_repo_cache')
     add_argument_output_name(parser)
     add_argument_output_dir(parser)
     args = parser.parse_args(argv)


### PR DESCRIPTION
I'd like to use much of the same functionality in the RPM equivalent routines.

The caching mechanism used for repository data is actually just an HTTP file cache and isn't debian-specific, so it can be used for non-debian repositories as well.

The packaging format of the targets could be non-debian as well, so rename and move that function to a neutral location.

This change will obviously cause a total cache-miss on the buildfarm.