### PR TITLE
Use yaml.safe_load

### DIFF
--- a/ros_buildfarm/config/__init__.py
+++ b/ros_buildfarm/config/__init__.py
@@ -32,7 +32,7 @@ logger = logging.getLogger('ros_buildfarm.config')
 def get_index(url):
     logger.debug("Load index from '%s'" % url)
     yaml_str = load_url(url)
-    data = yaml.load(yaml_str)
+    data = yaml.safe_load(yaml_str)
     base_url = os.path.dirname(url)
     return Index(data, base_url)
 
@@ -104,7 +104,7 @@ def _load_build_file_data(entries):
     def _load_yaml_data(url):
         logger.debug('Load file from "%s"' % url)
         yaml_str = load_url(url)
-        return yaml.load(yaml_str)
+        return yaml.safe_load(yaml_str)
 
     data = {}
     for k, v in entries.items():

--- a/ros_buildfarm/rosdoc_index.py
+++ b/ros_buildfarm/rosdoc_index.py
@@ -92,7 +92,7 @@ class RosdocIndex(object):
             if os.path.exists(path):
                 for key in os.listdir(path):
                     with open(os.path.join(path, key), 'r') as h:
-                        data[key] = yaml.load(h)
+                        data[key] = yaml.safe_load(h)
             maps.append(data)
         return ChainMap(*maps)
 

--- a/ros_buildfarm/rosdoc_lite.py
+++ b/ros_buildfarm/rosdoc_lite.py
@@ -12,7 +12,7 @@ def get_generator_output_folders(pkg_rosdoc_config_file, pkg_name):
         with open(pkg_rosdoc_config_file, 'r') as h:
             content = h.read()
         try:
-            data = yaml.load(content)
+            data = yaml.safe_load(content)
         except Exception as e:
             print("WARNING: package '%s' has an invalid rosdoc config: %s" %
                   (pkg_name, e), file=sys.stderr)

--- a/scripts/doc/build_doc.py
+++ b/scripts/doc/build_doc.py
@@ -165,12 +165,12 @@ def main(argv=sys.argv[1:]):
                 args.output_dir, 'manifests', pkg_name, 'manifest.yaml')
             if os.path.exists(rosdoc_manifest_yaml_file):
                 with open(rosdoc_manifest_yaml_file, 'r') as h:
-                    rosdoc_data = yaml.load(h)
+                    rosdoc_data = yaml.safe_load(h)
             else:
                 # if rosdoc_lite failed to generate the file
                 rosdoc_data = {}
             with open(job_manifest_yaml_file, 'r') as h:
-                job_data = yaml.load(h)
+                job_data = yaml.safe_load(h)
             rosdoc_data.update(job_data)
             with open(rosdoc_manifest_yaml_file, 'w') as h:
                 yaml.safe_dump(rosdoc_data, h, default_flow_style=False)

--- a/scripts/doc/create_doc_task_generator.py
+++ b/scripts/doc/create_doc_task_generator.py
@@ -185,7 +185,7 @@ def main(argv=sys.argv[1:]):
                     print('- %s: skipping no manifest.yaml yet' % pkg_name)
                     continue
                 with open(current_manifest_yaml_file, 'r') as h:
-                    remote_data = yaml.load(h)
+                    remote_data = yaml.safe_load(h)
                 data = copy.deepcopy(remote_data)
 
                 data['vcs'] = vcs_type


### PR DESCRIPTION
Calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe.

Please read https://msg.pyyaml.org/load for full details.