### PR TITLE
Use directory arguments on deb job scripts for decoupling (Part Two)

### DIFF
--- a/ros_buildfarm/templates/release/deb/sourcepkg_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/sourcepkg_job.xml.em
@@ -91,7 +91,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' ' + os_name +
         ' ' + os_code_name +
         ' ' + ' '.join(repository_args) +
-        ' --source-dir $WORKSPACE/sourcedeb/source' +
+        ' --sourcepkg-dir /tmp/sourcedeb' +
         ' --dockerfile-dir $WORKSPACE/docker_sourcedeb',
         'echo "# END SECTION"',
         '',

--- a/scripts/release/run_binarydeb_job.py
+++ b/scripts/release/run_binarydeb_job.py
@@ -69,7 +69,6 @@ def main(argv=sys.argv[1:]):
 
         'skip_download_sourcepkg': args.skip_download_sourcepkg,
 
-        'binarypkg_dir': '/tmp/binarydeb',
         'build_environment_variables': ['%s=%s' % key_value for key_value in args.env_vars.items()],
         'dockerfile_dir': '/tmp/docker_build_binarydeb',
     })


### PR DESCRIPTION
These values behind these arguments are never referenced in the code. Their intended purpose is fulfilled when specifying the mount directory in the `docker run` call.

It is possible that there was some confusion here, and their intended purpose was actually to decouple the Jenkins jobs from the `ros_buildfarm` repository, by specifying where in the container the mountpoint should be expected (instead of where on the host the directory resides). If that is the case, then I'll change this PR to use the arguments more appropriately.

Either way, because that decoupling doesn't exist, we'll have to figure out how to deploy this change. Recommendations would be appreciated.