### PR TITLE
Activated displayTableFlag

### DIFF
--- a/ros_buildfarm/templates/snippet/plot_plugin.xml.em
+++ b/ros_buildfarm/templates/snippet/plot_plugin.xml.em
@@ -22,7 +22,7 @@
                 </a>
               </exclusionValuesList>
               <url>@(series.url)</url>
-              <displayTableFlag>false</displayTableFlag>
+              <displayTableFlag>true</displayTableFlag>
             </hudson.plugins.plot.CSVSeries>
 @[end for]@
           </series>


### PR DESCRIPTION
I activated this flag and I consider that may be useful to visualize the value in a table. You can see how it looks [here](http://3.83.10.11/job/Dci__nightly-performance-overhead-multi_ubuntu_bionic_amd64/plot/Performance%20Test%20Results/)

If you consider this is not relevant or useful just close the PR