### PR TITLE
Rename get_debian_package_name function for non-debian use

### DIFF
--- a/ros_buildfarm/binarydeb_job.py
+++ b/ros_buildfarm/binarydeb_job.py
@@ -18,7 +18,7 @@ import sys
 from time import gmtime, strftime
 import traceback
 
-from ros_buildfarm.common import get_debian_package_name
+from ros_buildfarm.common import get_os_package_name
 from ros_buildfarm.release_common import dpkg_parsechangelog
 
 
@@ -26,13 +26,13 @@ def get_sourcedeb(
         rosdistro_index_url, rosdistro_name, package_name, sourcepkg_dir,
         skip_download_sourcepkg=False):
     # ensure that no source subfolder exists
-    debian_package_name = get_debian_package_name(rosdistro_name, package_name)
+    debian_package_name = get_os_package_name(rosdistro_name, package_name)
     subfolders = _get_package_subfolders(sourcepkg_dir, debian_package_name)
     assert not subfolders, \
         ("Sourcedeb directory '%s' must not have any " +
          "subfolders starting with '%s-'") % (sourcepkg_dir, package_name)
 
-    debian_package_name = get_debian_package_name(rosdistro_name, package_name)
+    debian_package_name = get_os_package_name(rosdistro_name, package_name)
     if not skip_download_sourcepkg:
         # get expected package version from rosdistro
         from rosdistro import get_distribution_cache
@@ -92,7 +92,7 @@ def get_sourcedeb(
 
 def append_build_timestamp(rosdistro_name, package_name, sourcepkg_dir):
     # ensure that one source subfolder exists
-    debian_package_name = get_debian_package_name(rosdistro_name, package_name)
+    debian_package_name = get_os_package_name(rosdistro_name, package_name)
     subfolders = _get_package_subfolders(sourcepkg_dir, debian_package_name)
     assert len(subfolders) == 1, subfolders
     source_dir = subfolders[0]
@@ -119,7 +119,7 @@ def append_build_timestamp(rosdistro_name, package_name, sourcepkg_dir):
 
 def build_binarydeb(rosdistro_name, package_name, sourcepkg_dir):
     # ensure that one source subfolder exists
-    debian_package_name = get_debian_package_name(rosdistro_name, package_name)
+    debian_package_name = get_os_package_name(rosdistro_name, package_name)
     subfolders = _get_package_subfolders(sourcepkg_dir, debian_package_name)
     assert len(subfolders) == 1, subfolders
     source_dir = subfolders[0]

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -167,13 +167,13 @@ def get_ci_view_name(rosdistro_name):
     return view_name
 
 
-def get_debian_package_name_prefix(rosdistro_name):
+def get_os_package_name_prefix(rosdistro_name):
     return 'ros-%s-' % rosdistro_name
 
 
-def get_debian_package_name(rosdistro_name, ros_package_name):
+def get_os_package_name(rosdistro_name, ros_package_name):
     return '%s%s' % \
-        (get_debian_package_name_prefix(rosdistro_name),
+        (get_os_package_name_prefix(rosdistro_name),
          ros_package_name.replace('_', '-'))
 
 

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -18,10 +18,10 @@ from collections import OrderedDict
 import sys
 
 from ros_buildfarm.common import get_binarydeb_job_name
-from ros_buildfarm.common import get_os_package_name
 from ros_buildfarm.common import get_default_node_label
 from ros_buildfarm.common import get_github_project_url
 from ros_buildfarm.common import get_node_label
+from ros_buildfarm.common import get_os_package_name
 from ros_buildfarm.common import get_release_binary_view_name
 from ros_buildfarm.common import get_release_job_prefix
 from ros_buildfarm.common import get_release_source_view_name

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -18,7 +18,7 @@ from collections import OrderedDict
 import sys
 
 from ros_buildfarm.common import get_binarydeb_job_name
-from ros_buildfarm.common import get_debian_package_name
+from ros_buildfarm.common import get_os_package_name
 from ros_buildfarm.common import get_default_node_label
 from ros_buildfarm.common import get_github_project_url
 from ros_buildfarm.common import get_node_label
@@ -635,7 +635,7 @@ def _get_sourcedeb_job_config(
         'sourcedeb_files': sourcedeb_files,
 
         'import_package_job_name': get_import_package_job_name(rosdistro_name),
-        'debian_package_name': get_debian_package_name(
+        'debian_package_name': get_os_package_name(
             rosdistro_name, pkg_name),
 
         'notify_emails': notify_emails,
@@ -716,7 +716,7 @@ def _get_binarydeb_job_config(
         'build_environment_variables': build_environment_variables,
 
         'import_package_job_name': get_import_package_job_name(rosdistro_name),
-        'debian_package_name': get_debian_package_name(
+        'debian_package_name': get_os_package_name(
             rosdistro_name, pkg_name),
 
         'child_projects': sync_to_testing_job_name,

--- a/ros_buildfarm/sourcedeb_job.py
+++ b/ros_buildfarm/sourcedeb_job.py
@@ -17,7 +17,7 @@ import subprocess
 from urllib.error import HTTPError
 from urllib.request import urlretrieve
 
-from ros_buildfarm.common import get_debian_package_name
+from ros_buildfarm.common import get_os_package_name
 from ros_buildfarm.release_common import dpkg_parsechangelog
 
 
@@ -63,7 +63,7 @@ def get_sources(
 
     # If a tarball already exists reuse it
     origtgz_version = pkg_version.split('-')[0]
-    debian_package_name = get_debian_package_name(rosdistro_name, pkg_name)
+    debian_package_name = get_os_package_name(rosdistro_name, pkg_name)
     filename = '%s_%s.orig.tar.gz' % (debian_package_name, origtgz_version)
 
     URL_TEMPLATE = '%s/pool/main/%s/%s/%s'
@@ -98,7 +98,7 @@ def _get_source_tag(
         rosdistro_name, pkg_name, pkg_version, os_name, os_code_name):
     assert os_name in ['debian', 'ubuntu']
     return 'debian/%s_%s_%s' % \
-        (get_debian_package_name(rosdistro_name, pkg_name),
+        (get_os_package_name(rosdistro_name, pkg_name),
          pkg_version, os_code_name)
 
 

--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -26,7 +26,7 @@ import time
 
 import yaml
 
-from .common import get_debian_package_name
+from .common import get_os_package_name
 from .common import get_package_repo_data
 from .common import get_release_view_name
 from .common import get_short_arch
@@ -256,7 +256,7 @@ PackageDescriptor = namedtuple(
 def get_rosdistro_package_descriptors(rosdistro_info, rosdistro_name):
     descriptors = {}
     for pkg_name, pkg in rosdistro_info.items():
-        debian_pkg_name = get_debian_package_name(rosdistro_name, pkg_name)
+        debian_pkg_name = get_os_package_name(rosdistro_name, pkg_name)
         descriptors[pkg_name] = PackageDescriptor(
             pkg_name, debian_pkg_name, pkg.version)
     return descriptors

--- a/ros_buildfarm/status_page_input.py
+++ b/ros_buildfarm/status_page_input.py
@@ -14,7 +14,7 @@
 
 from collections import namedtuple
 
-from .common import get_debian_package_name
+from .common import get_os_package_name
 
 MaintainerDescriptor = namedtuple('Maintainer', 'name email')
 
@@ -45,7 +45,7 @@ def get_rosdistro_info(dist, build_file):
     for pkg_name in pkg_names:
         # package name
         ros_pkg = RosPackage(pkg_name)
-        ros_pkg.debian_name = get_debian_package_name(dist.name, pkg_name)
+        ros_pkg.debian_name = get_os_package_name(dist.name, pkg_name)
 
         pkg = dist.release_packages[pkg_name]
         repo = dist.repositories[pkg.repository_name].release_repository

--- a/ros_buildfarm/trigger_job.py
+++ b/ros_buildfarm/trigger_job.py
@@ -19,7 +19,7 @@ from rosdistro import get_cached_distribution
 from rosdistro import get_index
 
 from .common import get_binarydeb_job_name
-from .common import get_debian_package_name
+from .common import get_os_package_name
 from .common import get_package_repo_data
 from .common import get_sourcedeb_job_name
 from .common import Target
@@ -85,7 +85,7 @@ def trigger_release_jobs(
             continue
         pkg_version = repo.release_repository.version
 
-        debian_package_name = get_debian_package_name(rosdistro_name, pkg_name)
+        debian_package_name = get_os_package_name(rosdistro_name, pkg_name)
 
         for target in targets:
             job_name = get_sourcedeb_job_name(

--- a/scripts/doc/create_doc_task_generator.py
+++ b/scripts/doc/create_doc_task_generator.py
@@ -39,7 +39,7 @@ from ros_buildfarm.argument import add_argument_repository_name
 from ros_buildfarm.argument import add_argument_vcs_information
 from ros_buildfarm.common import find_executable
 from ros_buildfarm.common import get_binary_package_versions
-from ros_buildfarm.common import get_debian_package_name
+from ros_buildfarm.common import get_os_package_name
 from ros_buildfarm.common import get_devel_job_urls
 from ros_buildfarm.common import get_distribution_repository_keys
 from ros_buildfarm.common import get_doc_job_url
@@ -528,16 +528,16 @@ def main(argv=sys.argv[1:]):
             'python-sphinx',
             'python-yaml',
             # since catkin is not a run dependency but provides the setup files
-            get_debian_package_name(args.rosdistro_name, 'catkin'),
+            get_os_package_name(args.rosdistro_name, 'catkin'),
             # rosdoc_lite does not work without genmsg being importable
-            get_debian_package_name(args.rosdistro_name, 'genmsg'),
+            get_os_package_name(args.rosdistro_name, 'genmsg'),
         ]
         if args.build_tool == 'colcon':
             debian_pkg_names.append('python3-colcon-ros')
         if 'actionlib_msgs' in pkg_names:
             # to document actions in other packages in the same repository
             debian_pkg_names.append(
-                get_debian_package_name(args.rosdistro_name, 'actionlib_msgs'))
+                get_os_package_name(args.rosdistro_name, 'actionlib_msgs'))
         print('Always install the following generic dependencies:')
         for debian_pkg_name in sorted(debian_pkg_names):
             print('  -', debian_pkg_name)

--- a/scripts/doc/create_doc_task_generator.py
+++ b/scripts/doc/create_doc_task_generator.py
@@ -39,10 +39,10 @@ from ros_buildfarm.argument import add_argument_repository_name
 from ros_buildfarm.argument import add_argument_vcs_information
 from ros_buildfarm.common import find_executable
 from ros_buildfarm.common import get_binary_package_versions
-from ros_buildfarm.common import get_os_package_name
 from ros_buildfarm.common import get_devel_job_urls
 from ros_buildfarm.common import get_distribution_repository_keys
 from ros_buildfarm.common import get_doc_job_url
+from ros_buildfarm.common import get_os_package_name
 from ros_buildfarm.common import get_release_job_urls
 from ros_buildfarm.common import get_user_id
 from ros_buildfarm.common import Scope

--- a/scripts/release/check_sync_criteria.py
+++ b/scripts/release/check_sync_criteria.py
@@ -25,7 +25,7 @@ from ros_buildfarm.argument import add_argument_cache_dir
 from ros_buildfarm.argument import add_argument_config_url
 from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_rosdistro_name
-from ros_buildfarm.common import get_debian_package_name
+from ros_buildfarm.common import get_os_package_name
 from ros_buildfarm.common import Target
 from ros_buildfarm.config import get_index as get_config_index
 from ros_buildfarm.config import get_release_build_files
@@ -73,7 +73,7 @@ def check_sync_criteria(
     all_pkg_names = dist_file.release_packages.keys()
     pkg_names = build_file.filter_packages(all_pkg_names)
     for pkg_name in sorted(pkg_names):
-        debian_pkg_name = get_debian_package_name(rosdistro_name, pkg_name)
+        debian_pkg_name = get_os_package_name(rosdistro_name, pkg_name)
         binary_packages[pkg_name] = debian_pkg_name in repo_index
 
     # check that all elements from whitelist are present

--- a/scripts/release/create_binarydeb_task_generator.py
+++ b/scripts/release/create_binarydeb_task_generator.py
@@ -34,7 +34,7 @@ from ros_buildfarm.argument import add_argument_package_name
 from ros_buildfarm.argument import add_argument_rosdistro_index_url
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.common import get_binary_package_versions
-from ros_buildfarm.common import get_debian_package_name
+from ros_buildfarm.common import get_os_package_name
 from ros_buildfarm.common import get_distribution_repository_keys
 from ros_buildfarm.common import get_user_id
 from ros_buildfarm.templates import create_dockerfile
@@ -58,7 +58,7 @@ def main(argv=sys.argv[1:]):
     add_argument_env_vars(parser)
     args = parser.parse_args(argv)
 
-    debian_package_name = get_debian_package_name(
+    debian_package_name = get_os_package_name(
         args.rosdistro_name, args.package_name)
 
     # get expected package version from rosdistro

--- a/scripts/release/create_binarydeb_task_generator.py
+++ b/scripts/release/create_binarydeb_task_generator.py
@@ -34,8 +34,8 @@ from ros_buildfarm.argument import add_argument_package_name
 from ros_buildfarm.argument import add_argument_rosdistro_index_url
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.common import get_binary_package_versions
-from ros_buildfarm.common import get_os_package_name
 from ros_buildfarm.common import get_distribution_repository_keys
+from ros_buildfarm.common import get_os_package_name
 from ros_buildfarm.common import get_user_id
 from ros_buildfarm.templates import create_dockerfile
 from rosdistro import get_distribution_file


### PR DESCRIPTION
This is a straight rename operation - no logical changes.

I'd like to use this same method for RPM packages.