### PR TITLE
Use get_short_os_code_name in release status page

### DIFF
--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -135,8 +135,8 @@ def build_release_status_page(
         'targets': targets,
         'short_arches': dict(
             [(t.arch, get_short_arch(t.arch)) for t in targets]),
-        'short_code_names': dict(
-            [(t.os_code_name, get_short_os_code_name(t.os_code_name)) for t in targets]),
+        'short_code_names': {
+            t.os_code_name: get_short_os_code_name(t.os_code_name) for t in targets},
         'repos_data': repos_data,
 
         'affected_by_sync': affected_by_sync,
@@ -233,8 +233,8 @@ def build_debian_repos_status_page(
         'targets': targets,
         'short_arches': dict(
             [(t.arch, get_short_arch(t.arch)) for t in targets]),
-        'short_code_names': dict(
-            [(t.os_code_name, get_short_os_code_name(t.os_code_name)) for t in targets]),
+        'short_code_names': {
+            t.os_code_name: get_short_os_code_name(t.os_code_name) for t in targets},
         'repos_data': repos_data,
 
         'affected_by_sync': None,

--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -30,6 +30,7 @@ from .common import get_debian_package_name
 from .common import get_package_repo_data
 from .common import get_release_view_name
 from .common import get_short_arch
+from .common import get_short_os_code_name
 from .common import Target
 from .config import get_index as get_config_index
 from .config import get_release_build_files
@@ -134,6 +135,8 @@ def build_release_status_page(
         'targets': targets,
         'short_arches': dict(
             [(t.arch, get_short_arch(t.arch)) for t in targets]),
+        'short_code_names': dict(
+            [(t.os_code_name, get_short_os_code_name(t.os_code_name)) for t in targets]),
         'repos_data': repos_data,
 
         'affected_by_sync': affected_by_sync,
@@ -230,6 +233,8 @@ def build_debian_repos_status_page(
         'targets': targets,
         'short_arches': dict(
             [(t.arch, get_short_arch(t.arch)) for t in targets]),
+        'short_code_names': dict(
+            [(t.os_code_name, get_short_os_code_name(t.os_code_name)) for t in targets]),
         'repos_data': repos_data,
 
         'affected_by_sync': None,

--- a/ros_buildfarm/templates/status/release_status_page.html.em
+++ b/ros_buildfarm/templates/status/release_status_page.html.em
@@ -102,7 +102,7 @@
         <th class="sortable"><div>Maintainer</div></th>
 @[end if]@
 @[for target in targets]@
-        <th><div title="@(target.os_name.capitalize()) @(target.os_code_name.capitalize()) @(target.arch)">@(target.os_code_name[0].upper())@(short_arches[target.arch])</div>@
+        <th><div title="@(target.os_name.capitalize()) @(target.os_code_name.capitalize()) @(target.arch)">@(short_code_names[target.os_code_name])@(short_arches[target.arch])</div>@
 @[for count in package_counts[target]]@
 <span class="sum">@count</span>@
 @[end for]@


### PR DESCRIPTION
The existing logic assumes the first letter of the OS code name. Since that is already the scheme used to populate the common short code name mapping, this should result in no change in behavior for Ubuntu and Debian, but will leave the RPM code names (i.e. `31`) intact.