### PR TITLE
Escape $ in repo URLs and strip() the GPG keys

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -105,7 +105,7 @@ def get_repositories_and_script_generating_key_files(
     repository_args = []
     if unique_repository_urls:
         repository_args.append('--distribution-repository-urls')
-        repository_args += unique_repository_urls
+        repository_args += [url.replace('$', '\\$') for url in unique_repository_urls]
 
     script_generating_key_files = []
     if unique_repository_keys:
@@ -144,7 +144,7 @@ def get_distribution_repository_keys(urls, key_files):
     for url, key_file in distribution_repositories:
         print('  %s%s' % (url, ' (%s)' % key_file if key_file else ''))
         with open(key_file, 'r') as h:
-            keys.append(h.read())
+            keys.append(h.read().strip())
     return keys
 
 

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -144,7 +144,7 @@ def get_distribution_repository_keys(urls, key_files):
     for url, key_file in distribution_repositories:
         print('  %s%s' % (url, ' (%s)' % key_file if key_file else ''))
         with open(key_file, 'r') as h:
-            keys.append(h.read().strip())
+            keys.append(h.read().rstrip())
     return keys
 
 


### PR DESCRIPTION
RPM repository base URLs sometimes use variables for `$releasever` and `$basearch`. When these URLs are passed on the command line, escape those $ characters so they aren't interpreted as environment variables.

Also, the GPG keys for those repositories sometimes seem to have an extra newline added to the end of the file. No need to carry that forward when the keys are read.