### PR TITLE
Add support for Jenkins credential binding plugin

### DIFF
--- a/ros_buildfarm/templates/snippet/credentials_binding_plugin.xml.em
+++ b/ros_buildfarm/templates/snippet/credentials_binding_plugin.xml.em
@@ -1,0 +1,9 @@
+    <org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper plugin="credentials-binding@@1.20">
+      <bindings>
+        <org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordMultiBinding>
+          <credentialsId>@(credential_id)</credentialsId>
+          <usernameVariable>@(env_var_prefix)_USERNAME</usernameVariable>
+          <passwordVariable>@(env_var_prefix)_PASSWORD</passwordVariable>
+        </org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordMultiBinding>
+      </bindings>
+    </org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper>


### PR DESCRIPTION
Right now, I'm authenticating with pulp using a username and password. In order to store those credentials in Jenkins and make them accessible to a script, I need to bind the credentials to environment variables so that they don't get dumped to the logs as a command line argument.

This snippet takes a Jenkins credential ID and a prefix, and sets the `${PREFIX}_USERNAME` and `${PREFIX}_PASSWORD` environment variables for the scripts to access.