### PR TITLE
Update subprocess_reaper.py to work with psutil 3.x to 5.x.

### DIFF
--- a/scripts/subprocess_reaper.py
+++ b/scripts/subprocess_reaper.py
@@ -64,13 +64,13 @@ def main(argv=None):
     cid_files = set()
     while proc.is_running():
         try:
-            children = proc.get_children(recursive=True)
+            children = proc.children(recursive=True)
         except psutil.NoSuchProcess:
             continue
         # check for docker since the cmdline is unavailable after termination
         for c in children:
             try:
-                cmdline = c.cmdline
+                cmdline = c.cmdline()
             except psutil.NoSuchProcess:
                 continue
             if cmdline[0] == 'docker' and cmdline[1] == 'run':


### PR DESCRIPTION
These changes were tested with psutil 3.4.2 and 5.6.7 (on Windows).

The psutil API has changed slightly and the subprocess_reaper hasn't
been running successfully. A sample of a few subprocess_reaper.log files
reveals short logs such as:

    Monitoring PID 6170...
    Traceback (most recent call last):
      File
    "/home/jenkins-agent/workspace/Krel_release-status-page/ros_buildfarm/scripts/subprocess_reaper.py",
    line 173, in <module>
        sys.exit(main())
      File
    "/home/jenkins-agent/workspace/Krel_release-status-page/ros_buildfarm/scripts/subprocess_reaper.py",
    line 67, in main
        children = proc.get_children(recursive=True)
    AttributeError: 'Process' object has no attribute 'get_children