### PR TITLE
Front-load manifest parsing and ros_workspace dep injection

### DIFF
--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -332,8 +332,9 @@ def _get_and_parse_distribution_cache(index, rosdistro_name, pkg_names):
     dist_cache = get_distribution_cache(index, rosdistro_name)
     pkg_names = set(['ros_workspace']).union(pkg_names)
     cached_pkgs = {
-        pkg_name: parse_package_string(pkg_xml) for pkg_name, pkg_xml in
-        dist_cache.release_package_xmls.items() if pkg_name in pkg_names
+        pkg_name: parse_package_string(pkg_xml)
+        for pkg_name, pkg_xml in dist_cache.release_package_xmls.items()
+        if pkg_name in pkg_names
     }
 
     # for ROS 2 distributions bloom injects a dependency on ros_workspace

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -331,8 +331,10 @@ def _get_and_parse_distribution_cache(index, rosdistro_name, pkg_names):
     from catkin_pkg.package import Dependency
     dist_cache = get_distribution_cache(index, rosdistro_name)
     pkg_names = set(['ros_workspace']).union(pkg_names)
-    cached_pkgs = dict((pkg_name, parse_package_string(pkg_xml)) for pkg_name, pkg_xml in
-                       dist_cache.release_package_xmls.items() if pkg_name in pkg_names)
+    cached_pkgs = {
+        pkg_name: parse_package_string(pkg_xml) for pkg_name, pkg_xml in
+        dist_cache.release_package_xmls.items() if pkg_name in pkg_names
+    }
 
     # for ROS 2 distributions bloom injects a dependency on ros_workspace
     # into almost all packages (except its dependencies)


### PR DESCRIPTION
These changes move the package manifest parsing to the same location as the distribution index acquisition.

The main motivations are:
1. Avoid parsing a manifest multiple times (performance)
2. Create a single location to augment dependencies (i.e. `ros_workspace`)

The latter allows the topological ordering and implicit package ignoring to correctly resolve the dependency on the `ros_workspace` package.

This change results in the following change to the topological ordering, demonstrating the bug in the existing behavior:
```diff
@@ -1,8 +1,6 @@
-ament_cppcheck
-ament_lint
-ament_flake8
 ament_package
 ament_cmake_core
+ros_workspace
 ament_cmake_export_definitions
 ament_cmake_export_dependencies
 ament_cmake_export_include_directories
@@ -20,7 +18,10 @@
 ament_cmake_test
 ament_cmake
 ament_cmake_auto
+ament_cppcheck
 ament_download
+ament_lint
+ament_flake8
 ament_lint_auto
 ament_pep257
 ament_copyright
@@ -153,7 +154,6 @@
 h264_encoder_core
 kinesis_manager
 lex_common
-ros_workspace
 rosidl_adapter
 rosidl_default_generators
 rosidl_generator_dds_idl
```