### PR TITLE
Add --dry-run option to generate_release_job

### DIFF
--- a/scripts/release/generate_release_job.py
+++ b/scripts/release/generate_release_job.py
@@ -20,6 +20,7 @@ import sys
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_name
 from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_dry_run
 from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
 from ros_buildfarm.argument import add_argument_package_name
@@ -37,11 +38,12 @@ def main(argv=sys.argv[1:]):
     add_argument_os_name(parser)
     add_argument_os_code_name(parser)
     add_argument_arch(parser)
+    add_argument_dry_run(parser)
     args = parser.parse_args(argv)
 
     configure_release_job(
         args.config_url, args.rosdistro_name, args.release_build_name,
-        args.package_name, args.os_name, args.os_code_name)
+        args.package_name, args.os_name, args.os_code_name, dry_run=args.dry_run)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I'm not sure why this option is present on the other scripts but left out here.

It's convenient to have.