### PR TITLE
Don't inject ros_workspace dep when there is no ros_workspace

### DIFF
--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -342,7 +342,7 @@ def _get_and_parse_distribution_cache(index, rosdistro_name, pkg_names):
     # therefore the same dependency needs to to be injected here
     distribution_type = index.distributions[rosdistro_name].get(
         'distribution_type')
-    if distribution_type == 'ros2':
+    if distribution_type == 'ros2' and 'ros_workspace' in cached_pkgs:
         no_ros_workspace_dep = set(['ros_workspace']).union(
             _get_direct_dependencies('ros_workspace', cached_pkgs, pkg_names))
 


### PR DESCRIPTION
If this package isn't in the distribution cache, we won't want to inject a dependency on it.