### PR TITLE
use GoogleTest / JUnit test result parser based on file pattern in ROS 2

### DIFF
--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -23,6 +23,7 @@ from ros_buildfarm.common import get_default_node_label
 from ros_buildfarm.common import get_node_label
 from ros_buildfarm.common \
     import get_repositories_and_script_generating_key_files
+from ros_buildfarm.common import get_xunit_publisher_types_and_patterns
 from ros_buildfarm.common import JobValidationError
 from ros_buildfarm.common import write_groovy_script_and_configs
 from ros_buildfarm.config import get_ci_build_files
@@ -293,6 +294,9 @@ def _get_ci_job_config(
 
         'show_images': build_file.show_images,
         'show_plots': build_file.show_plots,
+
+        'xunit_publisher_types': get_xunit_publisher_types_and_patterns(
+            ros_version),
     }
     job_config = expand_template(template_name, job_data)
     return job_config

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -593,8 +593,7 @@ def get_package_repo_data(repository_baseurl, targets, cache_dir):
 
 def get_xunit_publisher_types_and_patterns(ros_version):
     types = []
-    # TODO remove the second condition after confirming this doesn't change any jobs
-    if ros_version == 1 or ros_version == 2:
+    if ros_version == 1:
         types.append(('GoogleTestType', 'ws/test_results/**/*.xml'))
     elif ros_version == 2:
         types.append(('GoogleTestType', 'ws/test_results/**/*.gtest.xml'))

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -589,3 +589,16 @@ def get_package_repo_data(repository_baseurl, targets, cache_dir):
             repository_baseurl, target, cache_dir)
         data[target] = index
     return data
+
+
+def get_xunit_publisher_types_and_patterns(ros_version):
+    types = []
+    if ros_version == 1:
+        types.append(('GoogleTestType', 'ws/test_results/**/*.xml'))
+    elif ros_version == 2:
+        types.append(('GoogleTestType', 'ws/test_results/**/*.gtest.xml'))
+        types.append(('JUnitType', 'ws/test_results/**/pytest.xml'))
+        types.append(('JUnitType', 'ws/test_results/**/*.xunit.xml'))
+    else:
+        assert False, 'Unsupported ROS version: ' + str(ros_version)
+    return types

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -593,7 +593,8 @@ def get_package_repo_data(repository_baseurl, targets, cache_dir):
 
 def get_xunit_publisher_types_and_patterns(ros_version):
     types = []
-    if ros_version == 1:
+    # TODO remove the second condition after confirming this doesn't change any jobs
+    if ros_version == 1 or ros_version == 2:
         types.append(('GoogleTestType', 'ws/test_results/**/*.xml'))
     elif ros_version == 2:
         types.append(('GoogleTestType', 'ws/test_results/**/*.gtest.xml'))

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -25,6 +25,7 @@ from ros_buildfarm.common import get_github_project_url
 from ros_buildfarm.common import get_node_label
 from ros_buildfarm.common \
     import get_repositories_and_script_generating_key_files
+from ros_buildfarm.common import get_xunit_publisher_types_and_patterns
 from ros_buildfarm.common import git_github_orgunit
 from ros_buildfarm.common import JobValidationError
 from ros_buildfarm.common import write_groovy_script_and_configs
@@ -433,6 +434,9 @@ def _get_devel_job_config(
         'notify_pull_requests': build_file.notify_pull_requests,
 
         'timeout_minutes': build_file.jenkins_job_timeout,
+
+        'xunit_publisher_types': get_xunit_publisher_types_and_patterns(
+            ros_version),
 
         'git_ssh_credential_id': config.git_ssh_credential_id,
 

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -436,10 +436,12 @@ parameters = [
     plots=show_plots,
 ))@
 @[end if]@
+@[if xunit_publisher_types]@
 @(SNIPPET(
     'publisher_xunit',
-    pattern='ws/test_results/**/*.xml',
+    types=xunit_publisher_types,
 ))@
+@[end if]@
   </publishers>
   <buildWrappers>
 @[if timeout_minutes is not None]@

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -264,10 +264,12 @@ if pull_request:
     'publisher_warnings',
     unstable_threshold=0 if notify_compiler_warnings else '',
 ))@
+@[if xunit_publisher_types]@
 @(SNIPPET(
     'publisher_xunit',
-    pattern='ws/test_results/**/*.xml',
+    types=xunit_publisher_types,
 ))@
+@[end if]@
 @[if (not pull_request) and collate_test_stats]@
 @(SNIPPET(
     'publisher_groovy-postbuild',

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -264,12 +264,10 @@ if pull_request:
     'publisher_warnings',
     unstable_threshold=0 if notify_compiler_warnings else '',
 ))@
-@[if xunit_publisher_types]@
 @(SNIPPET(
     'publisher_xunit',
-    types=xunit_publisher_types,
+    pattern='ws/test_results/**/*.xml',
 ))@
-@[end if]@
 @[if (not pull_request) and collate_test_stats]@
 @(SNIPPET(
     'publisher_groovy-postbuild',

--- a/ros_buildfarm/templates/snippet/publisher_xunit.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_xunit.xml.em
@@ -5,8 +5,12 @@ if 'types' not in vars() and 'pattern' in vars():
 }@
     <xunit plugin="xunit@@2.3.1">
       <types>
-@[for type_tag, pattern in types]@
-@{assert type_tag in ('GoogleTestType', 'JUnitType'), 'Unsupported test type tag: ' + type_tag}@
+@[for type_tag_and_pattern in types]@
+@{
+# expanding these within the for statement leads to a TypeError in empy version 3.3.4 and older
+type_tag, pattern = type_tag_and_pattern
+assert type_tag in ('GoogleTestType', 'JUnitType'), 'Unsupported test type tag: ' + type_tag
+}@
         <@(type_tag)>
           <pattern>@ESCAPE(pattern)</pattern>
           <skipNoTestFiles>true</skipNoTestFiles>

--- a/ros_buildfarm/templates/snippet/publisher_xunit.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_xunit.xml.em
@@ -1,12 +1,20 @@
+@{
+# for backward compatibility only
+if 'types' not in vars() and 'pattern' in vars():
+    types = [('GoogleTestType', pattern)]
+}@
     <xunit plugin="xunit@@2.3.1">
       <types>
-        <GoogleTestType>
+@[for type_tag, pattern in types]@
+@{assert type_tag in ('GoogleTestType', 'JUnitType'), 'Unsupported test type tag: ' + type_tag}@
+        <@(type_tag)>
           <pattern>@ESCAPE(pattern)</pattern>
           <skipNoTestFiles>true</skipNoTestFiles>
           <failIfNotNew>true</failIfNotNew>
           <deleteOutputFiles>true</deleteOutputFiles>
           <stopProcessingIfError>true</stopProcessingIfError>
-        </GoogleTestType>
+        </@(type_tag)>
+@[end for]@
       </types>
       <thresholds>
         <org.jenkinsci.plugins.xunit.threshold.FailedThreshold>


### PR DESCRIPTION
For ROS 1 the logic keeps using only `GoogleTest` for all XML results.

The change matches the logic of ci.ros2.org except that there is no CTest type configured since the build directory is wiped before test results are collected. This will make Jenkins render better error messages for failed test: e.g. [bad](http://build.ros2.org/view/Eci/job/Eci__nightly-fastrtps_ubuntu_bionic_amd64/216/testReport/ros2launch.test/test_flake8/test_flake8/) vs. [good](https://ci.ros2.org/view/nightly/job/nightly_linux_debug/1438/testReport/rqt_reconfigure.test/test_flake8/test_flake8/).

* http://build.ros2.org/job/Ddev_reconfigure-jobs/494/ used this branch for a dry run and successfully reconfigured `devel` jobs (with no changes) while their template wasn't update to the modified arguments of the `publisher_junit` snippet: https://github.com/ros-infrastructure/ros_buildfarm/commit/9139aa9068b3f2e991d69766daa238041e0b7ad9#diff-5cf979d1d9687b7cad0d95e630cc87c6R269. This ensured the backward compatibility of the changed snippet arguments works.

* http://build.ros.org/job/Nci_reconfigure-jobs/186/ used this branch for a dry run and successfully reconfigured `ci` jobs (with no changes): https://github.com/ros-infrastructure/ros_buildfarm/commit/9139aa9068b3f2e991d69766daa238041e0b7ad9#diff-7b020c516b04814ffc3fc28ed8fac0deR597. This ensures ROS 1 stays untouched.

* http://build.ros2.org/job/Fci_reconfigure-jobs/5/ (dry run) reconfigured ROS 2 CI jobs to use the more specific xunit types bases on the various patterns.