### PR TITLE
limit JUnit type for pytest.xml to Focal, otherwise fall back to GoogleTest

### DIFF
--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -295,8 +295,10 @@ def _get_ci_job_config(
         'show_images': build_file.show_images,
         'show_plots': build_file.show_plots,
 
+        # only Ubuntu Focal has a new enough pytest version which generates
+        # JUnit compliant result files
         'xunit_publisher_types': get_xunit_publisher_types_and_patterns(
-            ros_version),
+            ros_version, os_name == 'ubuntu' and os_code_name != 'bionic'),
     }
     job_config = expand_template(template_name, job_data)
     return job_config

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -591,13 +591,17 @@ def get_package_repo_data(repository_baseurl, targets, cache_dir):
     return data
 
 
-def get_xunit_publisher_types_and_patterns(ros_version):
+def get_xunit_publisher_types_and_patterns(
+    ros_version, pytest_junit_compliant,
+):
     types = []
     if ros_version == 1:
         types.append(('GoogleTestType', 'ws/test_results/**/*.xml'))
     elif ros_version == 2:
         types.append(('GoogleTestType', 'ws/test_results/**/*.gtest.xml'))
-        types.append(('JUnitType', 'ws/test_results/**/pytest.xml'))
+        types.append((
+            'JUnitType' if pytest_junit_compliant else 'GoogleTestType',
+            'ws/test_results/**/pytest.xml'))
         types.append(('JUnitType', 'ws/test_results/**/*.xunit.xml'))
     else:
         assert False, 'Unsupported ROS version: ' + str(ros_version)

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -435,8 +435,10 @@ def _get_devel_job_config(
 
         'timeout_minutes': build_file.jenkins_job_timeout,
 
+        # only Ubuntu Focal has a new enough pytest version which generates
+        # JUnit compliant result files
         'xunit_publisher_types': get_xunit_publisher_types_and_patterns(
-            ros_version),
+            ros_version, os_name == 'ubuntu' and os_code_name != 'bionic'),
 
         'git_ssh_credential_id': config.git_ssh_credential_id,
 


### PR DESCRIPTION
Follow up of #723.

`pytest` in Ubuntu Bionic and all target Debian distros are too old to generate a `pytest.xml` whiich conforms to JUnit type of the Jenkins xUnit plugin. Therefore this patch keeps using the `GoogleTest` type for older distros and only uses `JUnit` (which provides more context) for Focal (and newer).