### PR TITLE
Add os_name argument to check_sync_criteria

### DIFF
--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -140,7 +140,7 @@ def configure_release_jobs(
         for arch in sorted(build_file.targets[os_name][os_code_name]):
             job_name, job_config = configure_sync_packages_to_testing_job(
                 config_url, rosdistro_name, release_build_name,
-                os_code_name, arch,
+                os_name, os_code_name, arch,
                 config=config, build_file=build_file, jenkins=jenkins,
                 dry_run=dry_run)
             if not jenkins:
@@ -458,7 +458,7 @@ def configure_release_job(
         for arch in build_file.targets[os_name][os_code_name]:
             configure_sync_packages_to_testing_job(
                 config_url, rosdistro_name, release_build_name,
-                os_code_name, arch,
+                os_name, os_code_name, arch,
                 config=config, build_file=build_file, jenkins=jenkins,
                 dry_run=dry_run)
 
@@ -781,8 +781,8 @@ def _get_import_package_job_config(build_file):
 
 
 def configure_sync_packages_to_testing_job(
-        config_url, rosdistro_name, release_build_name, os_code_name, arch,
-        config=None, build_file=None, jenkins=None, dry_run=False):
+        config_url, rosdistro_name, release_build_name, os_name, os_code_name,
+        arch, config=None, build_file=None, jenkins=None, dry_run=False):
     if config is None:
         config = get_config_index(config_url)
     if build_file is None:
@@ -795,8 +795,8 @@ def configure_sync_packages_to_testing_job(
     job_name = get_sync_packages_to_testing_job_name(
         rosdistro_name, os_code_name, arch)
     job_config = _get_sync_packages_to_testing_job_config(
-        config_url, rosdistro_name, release_build_name, os_code_name, arch,
-        config, build_file)
+        config_url, rosdistro_name, release_build_name, os_name, os_code_name,
+        arch, config, build_file)
 
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
     if isinstance(jenkins, object) and jenkins is not False:
@@ -813,8 +813,8 @@ def get_sync_packages_to_testing_job_name(
 
 
 def _get_sync_packages_to_testing_job_config(
-        config_url, rosdistro_name, release_build_name, os_code_name, arch,
-        config, build_file):
+        config_url, rosdistro_name, release_build_name, os_name, os_code_name,
+        arch, config, build_file):
     template_name = 'release/deb/sync_packages_to_testing_job.xml.em'
 
     repository_args, script_generating_key_files = \
@@ -828,6 +828,7 @@ def _get_sync_packages_to_testing_job_config(
         'config_url': config_url,
         'rosdistro_name': rosdistro_name,
         'release_build_name': release_build_name,
+        'os_name': os_name,
         'os_code_name': os_code_name,
         'arch': arch,
         'repository_args': repository_args,

--- a/ros_buildfarm/templates/release/deb/sync_packages_to_testing_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/sync_packages_to_testing_job.xml.em
@@ -59,6 +59,7 @@
         ' ' + config_url +
         ' ' + rosdistro_name +
         ' ' + release_build_name +
+        ' ' + os_name +
         ' ' + os_code_name +
         ' ' + arch +
         ' ' + ' '.join(repository_args) +

--- a/ros_buildfarm/templates/release/release_check_sync_criteria_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_check_sync_criteria_task.Dockerfile.em
@@ -47,6 +47,7 @@ cmd = \
     ' ' + config_url + \
     ' ' + rosdistro_name + \
     ' ' + release_build_name + \
+    ' ' + os_name + \
     ' ' + os_code_name + \
     ' ' + arch + \
     ' --cache-dir ' + cache_dir

--- a/scripts/release/check_sync_criteria.py
+++ b/scripts/release/check_sync_criteria.py
@@ -24,12 +24,13 @@ from ros_buildfarm.argument import add_argument_build_name
 from ros_buildfarm.argument import add_argument_cache_dir
 from ros_buildfarm.argument import add_argument_config_url
 from ros_buildfarm.argument import add_argument_os_code_name
+from ros_buildfarm.argument import add_argument_os_name
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.common import get_os_package_name
+from ros_buildfarm.common import get_package_repo_data
 from ros_buildfarm.common import Target
 from ros_buildfarm.config import get_index as get_config_index
 from ros_buildfarm.config import get_release_build_files
-from ros_buildfarm.debian_repo import get_debian_repo_index
 from rosdistro import get_distribution_file
 from rosdistro import get_index
 
@@ -41,6 +42,7 @@ def main(argv=sys.argv[1:]):
     add_argument_config_url(parser)
     add_argument_rosdistro_name(parser)
     add_argument_build_name(parser, 'release')
+    add_argument_os_name(parser)
     add_argument_os_code_name(parser)
     add_argument_arch(parser)
     add_argument_cache_dir(parser, '/tmp/package_repo_cache')
@@ -48,13 +50,13 @@ def main(argv=sys.argv[1:]):
 
     success = check_sync_criteria(
         args.config_url, args.rosdistro_name, args.release_build_name,
-        args.os_code_name, args.arch, args.cache_dir)
+        args.os_name, args.os_code_name, args.arch, args.cache_dir)
     return 0 if success else 1
 
 
 def check_sync_criteria(
-        config_url, rosdistro_name, release_build_name, os_code_name, arch,
-        cache_dir):
+        config_url, rosdistro_name, release_build_name, os_name,
+        os_code_name, arch, cache_dir):
     # fetch debian package list
     config = get_config_index(config_url)
     index = get_index(config.rosdistro_index_url)
@@ -62,10 +64,10 @@ def check_sync_criteria(
     build_files = get_release_build_files(config, rosdistro_name)
     build_file = build_files[release_build_name]
 
-    target = Target('ubuntu', os_code_name, arch)
+    target = Target(os_name, os_code_name, arch)
 
-    repo_index = get_debian_repo_index(
-        build_file.target_repository, target, cache_dir)
+    repo_index = get_package_repo_data(
+        build_file.target_repository, [target], cache_dir)[target]
 
     # for each release package which matches the release build file
     # check if a binary package exists

--- a/scripts/release/run_check_sync_criteria_job.py
+++ b/scripts/release/run_check_sync_criteria_job.py
@@ -39,6 +39,10 @@ def main(argv=sys.argv[1:]):
     add_argument_config_url(parser)
     add_argument_rosdistro_name(parser)
     add_argument_build_name(parser, 'release')
+    parser.add_argument(
+        'os_name', nargs='?',
+        help='An OS name from the build file')
+    add_argument_os_name(parser)
     add_argument_os_code_name(parser)
     add_argument_arch(parser)
     add_argument_distribution_repository_urls(parser)
@@ -46,6 +50,12 @@ def main(argv=sys.argv[1:]):
     add_argument_cache_dir(parser)
     add_argument_dockerfile_dir(parser)
     args = parser.parse_args(argv)
+
+    if args.os_name is None:
+        print(
+            'WARNING: Calling %s without specifying os_name is deprecated' % argv[0],
+            file=sys.stderr)
+        args.os_name = 'ubuntu'
 
     data = copy.deepcopy(args.__dict__)
     data.update({

--- a/scripts/release/run_check_sync_criteria_job.py
+++ b/scripts/release/run_check_sync_criteria_job.py
@@ -27,6 +27,7 @@ from ros_buildfarm.argument import \
 from ros_buildfarm.argument import add_argument_distribution_repository_urls
 from ros_buildfarm.argument import add_argument_dockerfile_dir
 from ros_buildfarm.argument import add_argument_os_code_name
+from ros_buildfarm.argument import add_argument_os_name
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.common import get_distribution_repository_keys
 from ros_buildfarm.common import get_user_id


### PR DESCRIPTION
Also use the get_package_repo_data method in place of the current debian-specific one.

Since this involves changing the arguments to a script that is invoked by Jenkins jobs, I had to do it in a backwards-compatible way. If this change is approved, I'll open an issue to track follow-up changes to actually remove the deprecated behaviors at a later date.