### PR TITLE
Use debian-similar URL scheme for RPM repo URLs

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -21,7 +21,7 @@ except ImportError:
     from urlparse import urlparse
 
 from .debian_repo import get_debian_repo_index
-from .rpm_repo import get_rpm_repo_index
+from .rpm_repo import get_ros_rpm_repo_index
 
 
 package_format_mapping = {
@@ -578,7 +578,7 @@ def get_packages_in_workspaces(workspace_roots, condition_context):
 def get_package_repo_data(repository_baseurl, targets, cache_dir):
     get_index_methods = {
         'deb': get_debian_repo_index,
-        'rpm': get_rpm_repo_index,
+        'rpm': get_ros_rpm_repo_index,
     }
 
     data = {}

--- a/ros_buildfarm/rpm_repo.py
+++ b/ros_buildfarm/rpm_repo.py
@@ -20,6 +20,12 @@ from .http_cache import fetch_and_cache_gzip
 from .http_cache import fetch_and_cache_plaintext
 
 
+def get_ros_rpm_repo_index(rpm_repository_baseurl, target, cache_dir):
+    return get_rpm_repo_index(
+        os.path.join(rpm_repository_baseurl, '$releasever', '$basearch'),
+        target, cache_dir)
+
+
 def get_rpm_repo_index(rpm_repository_baseurl, target, cache_dir):
     # These variables are often included in repository base URLs by YUM/DNF
     url = rpm_repository_baseurl.replace('$releasever', target.os_code_name)


### PR DESCRIPTION
Rather than augment the URLs before they're passed to `get_package_repo_data` everywhere, assume that the RPM repository base URLs will follow the same URL scheme we're using for the debian repos, even though such URL schemes are not necessary for RPMs.

This will help align the RPM repositories with what debian users are expecting, while still allowing RPM index query using a traditional `$releasever/$basearch` repository base URL using the existing function.

For example: `http://example.com/fedora/main/31/x86_64`