### PR TITLE
Add common pulp-specific arguments and helper class

### DIFF
--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -331,6 +331,13 @@ def add_argument_install_packages(parser):
              'packages detected for installation by rosdep.')
 
 
+def add_argument_invalidate(parser):
+    parser.add_argument(
+        '--invalidate', action='store_true',
+        help='Invalidate or remove any packages which recursively '
+             'depend on the target package(s).')
+
+
 def add_argument_package_selection_args(parser):
     return parser.add_argument(
         '--package-selection-args', nargs=argparse.REMAINDER,
@@ -342,6 +349,49 @@ def add_argument_build_tool_args(parser):
     return parser.add_argument(
         '--build-tool-args', nargs=argparse.REMAINDER,
         help='Arbitrary arguments passed to the build tool.')
+
+
+def add_argument_pulp_base_url(parser):
+    from_env = os.environ.get('PULP_BASE_URL')
+    return parser.add_argument(
+        '--pulp-base-url',
+        default=from_env, required=not bool(from_env),
+        help='URL of the pulp API endpoint')
+
+
+def add_argument_pulp_distribution_name(parser):
+    return parser.add_argument(
+        '--pulp-distribution-name', required=True,
+        help='Name of the pulp distribution to target with changes')
+
+
+def add_argument_pulp_password(parser):
+    from_env = os.environ.get('PULP_PASSWORD')
+    return parser.add_argument(
+        '--pulp-password',
+        default=from_env, required=not bool(from_env),
+        help='Password used to access the pulp API endpoint')
+
+
+def add_argument_pulp_resource_record(parser):
+    return parser.add_argument(
+        '--pulp-resource-record', default=None, metavar='FILE',
+        help='File in which to record the pulp HREFs of package resources')
+
+
+def add_argument_pulp_task_timeout(parser):
+    return parser.add_argument(
+        '--pulp-task-timeout',
+        default=60.0,
+        help='Duration to wait (in seconds) for a pulp task to complete')
+
+
+def add_argument_pulp_username(parser):
+    from_env = os.environ.get('PULP_USERNAME')
+    return parser.add_argument(
+        '--pulp-username',
+        default=from_env, required=not bool(from_env),
+        help='Username used to access the pulp API endpoint')
 
 
 def add_argument_repos_file_urls(parser):

--- a/ros_buildfarm/pulp.py
+++ b/ros_buildfarm/pulp.py
@@ -1,0 +1,51 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+from pulpcore.client import pulpcore
+
+
+class PulpTaskPoller:
+
+    def __init__(self, pulp_configuration, timeout, interval=0.5):
+        client = pulpcore.ApiClient(pulp_configuration)
+        self._tasks_api = pulpcore.TasksApi(client)
+        self._timeout = timeout
+        self._interval = interval
+
+    def wait_for_task(self, task_href):
+        task = self._tasks_api.read(task_href)
+
+        print("Waiting for task '%s'..." %
+              (self._tasks_api.api_client.configuration.host + task.pulp_href))
+
+        timeout = self._timeout
+        while task.state != 'completed':
+            if task.state in ['failed', 'canceled']:
+                raise RuntimeError(
+                    "Pulp task '%s' did not complete (%s)" % (task.pulp_href, task.state))
+            time.sleep(self._interval)
+            timeout -= self._interval
+            if timeout <= 0:
+                task_cancel = pulpcore.TaskCancel('canceled')
+                task = self._tasks_api.tasks_cancel(task.pulp_href, task_cancel)
+                if task.state != 'completed':
+                    raise RuntimeError(
+                        "Pulp task '%s' did not complete (timed out)" % task.pulp_href)
+
+            task = self._tasks_api.read(task.pulp_href)
+
+        print('...done.')
+        return task


### PR DESCRIPTION
This class and these argument helpers will be used by the various scripts which interact with the pulp API for repository management.

I'm not adding pulp modules to the required modules for `ros_buildfarm` because they are not used in any common locations - only by the scripts that will live in `scripts/release/rpm/*.py`.