### PR TITLE
 Add RPM support for sync-to-testing job 

### DIFF
--- a/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
@@ -1,0 +1,177 @@
+<project>
+  <actions/>
+  <description>Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+@(SNIPPET(
+    'property_log-rotator',
+    days_to_keep=100,
+    num_to_keep=100,
+))@
+@(SNIPPET(
+    'property_job-priority',
+    priority=-1,
+))@
+@(SNIPPET(
+    'property_requeue-job',
+))@
+  </properties>
+@(SNIPPET(
+    'scm_git',
+    url=ros_buildfarm_repository.url,
+    branch_name=ros_buildfarm_repository.version or 'master',
+    relative_target_dir='ros_buildfarm',
+    refspec=None,
+))@
+  <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
+  <assignedNode>building_repository</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>true</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+@(SNIPPET(
+    'builder_shell_docker-info',
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        '# generate key files',
+        'echo "# BEGIN SECTION: Write PGP repository keys"',
+        'mkdir -p $WORKSPACE/keys',
+        'rm -fr $WORKSPACE/keys/*',
+        'echo "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v1\n\n\nmQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc\nVFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro\nu5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4\nK/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG\naIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+\nTwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz\npwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p\nV5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT\nhM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/\n/SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV\nokdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB\ntCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQoA\nPhYhBMHPbjHmut6IaLFytPQu1vurF8ZUBQJc7yaWAhsDBQkDwmcABQsJCAcCBhUK\nCQgLAgQWAgMBAh4BAheAAAoJEPQu1vurF8ZUkhIP/RbZY1ErvCEUy8iLJm9aSpLQ\nnDZl5xILOxyZlzpg+Ml5bb0EkQDr92foCgcvLeANKARNCaGLyNIWkuyDovPV0xZJ\nrEy0kgBrDNb3++NmdI/+GA92pkedMXXioQvqdsxUagXAIB/sNGByJEhs37F05AnF\nvZbjUhceq3xTlvAMcrBWrgB4NwBivZY6IgLvl/CRQpVYwANShIQdbvHvZSxRonWh\nNXr6v/Wcf8rsp7g2VqJ2N2AcWT84aa9BLQ3Oe/SgrNx4QEhA1y7rc3oaqPVu5ZXO\nK+4O14JrpbEZ3Xs9YEjrcOuEDEpYktA8qqUDTdFyZrxb9S6BquUKrA6jZgT913kj\nJ4e7YAZobC4rH0w4u0PrqDgYOkXA9Mo7L601/7ZaDJob80UcK+Z12ZSw73IgBix6\nDiJVfXuWkk5PM2zsFn6UOQXUNlZlDAOj5NC01V0fJ8P0v6GO9YOSSQx0j5UtkUbR\nfp/4W7uCPFvwAatWEHJhlM3sQNiMNStJFegr56xQu1a/cbJH7GdbseMhG/f0BaKQ\nqXCI3ffB5y5AOLc9Hw7PYiTFQsuY1ePRhE+J9mejgWRZxkjAH/FlAubqXkDgterC\nh+sLkzGf+my2IbsMCuc+3aeNMJ5Ej/vlXefCH/MpPWAHCqpQhe2DET/jRSaM53US\nAHNx8kw4MPUkxExgI7Sd\n=4Ofr\n-----END PGP PUBLIC KEY BLOCK-----" > $WORKSPACE/keys/0.key',
+        'echo "# END SECTION"',
+    ]),
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'rm -fr $WORKSPACE/docker_check_sync_criteria',
+        'mkdir -p $WORKSPACE/docker_check_sync_criteria',
+        '',
+        '# monitor all subprocesses and enforce termination',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/subprocess_reaper.py $$ --cid-file $WORKSPACE/docker_check_sync_criteria/docker.cid > $WORKSPACE/docker_check_sync_criteria/subprocess_reaper.log 2>&1 &',
+        '# sleep to give python time to startup',
+        'sleep 1',
+        '',
+        '# generate Dockerfile, build and run it',
+        '# checking the sync criteria',
+        'echo "# BEGIN SECTION: Generate Dockerfile - check sync condition"',
+        'export TZ="%s"' % timezone,
+        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/release/run_check_sync_criteria_job.py' +
+        ' ' + config_url +
+        ' ' + rosdistro_name +
+        ' ' + release_build_name +
+        ' ' + os_name +
+        ' ' + os_code_name +
+        ' ' + arch +
+        ' --distribution-repository-urls http://repositories.ros.org/ubuntu/main' +
+        ' --distribution-repository-key-files $WORKSPACE/keys/0.key' +
+        ' --cache-dir /tmp/package_repo_cache' +
+        ' --dockerfile-dir $WORKSPACE/docker_check_sync_criteria',
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: Build Dockerfile - check sync condition"',
+        'cd $WORKSPACE/docker_check_sync_criteria',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
+        'docker build --force-rm -t check_sync_condition .',
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: Run Dockerfile - check sync condition"',
+        'rm -fr $WORKSPACE/package_repo_cache',
+        'mkdir -p $WORKSPACE/package_repo_cache',
+        'docker run' +
+        ' --rm ' +
+        ' --cidfile=$WORKSPACE/docker_check_sync_criteria/docker.cid' +
+        ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
+        ' -v $WORKSPACE/package_repo_cache:/tmp/package_repo_cache' +
+        ' check_sync_condition',
+        'echo "# END SECTION"',
+    ]),
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'echo "# BEGIN SECTION: determine source packages to sync"',
+        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/release/rpm/list_packages.py' +
+        ' --pulp-base-url http://repo:24817' +
+        ' --pulp-distribution-name ros-building-%s-%s-SRPMS' % (os_name, os_code_name) +
+        ' --package-name-expression "^ros-%s-.*"' % rosdistro_name +
+        ' --pulp-resource-record $WORKSPACE/ros-building-source.txt',
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: determine binary packages to sync"',
+        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/release/rpm/list_packages.py' +
+        ' --pulp-base-url http://repo:24817' +
+        ' --pulp-distribution-name ros-building-%s-%s-%s' % (os_name, os_code_name, arch) +
+        ' --package-name-expression "^ros-%s-.*"' % rosdistro_name +
+        ' --pulp-resource-record $WORKSPACE/ros-building-binary.txt',
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: determine binary debug packages to testing repo"',
+        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/release/rpm/list_packages.py' +
+        ' --pulp-base-url http://repo:24817' +
+        ' --pulp-distribution-name ros-building-%s-%s-%s-debug' % (os_name, os_code_name, arch) +
+        ' --package-name-expression "^ros-%s-.*"' % rosdistro_name +
+        ' --pulp-resource-record $WORKSPACE/ros-building-binary-debug.txt',
+        'echo "# END SECTION"',
+    ]),
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'echo "# BEGIN SECTION: sync source packages to testing repo"',
+        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
+        'sed "s/^PULP_RESOURCES=//" $WORKSPACE/ros-building-source.txt | xargs' +
+        ' python3 -u $WORKSPACE/ros_buildfarm/scripts/release/rpm/import_package.py' +
+        ' --pulp-base-url http://repo:24817' +
+        ' --pulp-distribution-name ros-testing-%s-%s-SRPMS' % (os_name, os_code_name) +
+        ' --invalidate-expression "^ros-%s-.*"' % rosdistro_name,
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: sync binary packages to testing repo"',
+        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
+        'sed "s/^PULP_RESOURCES=//" $WORKSPACE/ros-building-binary.txt | xargs' +
+        ' python3 -u $WORKSPACE/ros_buildfarm/scripts/release/rpm/import_package.py' +
+        ' --pulp-base-url http://repo:24817' +
+        ' --pulp-distribution-name ros-testing-%s-%s-%s' % (os_name, os_code_name, arch) +
+        ' --invalidate-expression "^ros-%s-.*"' % rosdistro_name,
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: sync binary debug packages to testing repo"',
+        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
+        'sed "s/^PULP_RESOURCES=//" $WORKSPACE/ros-building-binary-debug.txt | xargs' +
+        ' python3 -u $WORKSPACE/ros_buildfarm/scripts/release/rpm/import_package.py' +
+        ' --pulp-base-url http://repo:24817' +
+        ' --pulp-distribution-name ros-testing-%s-%s-%s-debug' % (os_name, os_code_name, arch) +
+        ' --invalidate-expression "^ros-%s-.*"' % rosdistro_name,
+        'echo "# END SECTION"',
+    ]),
+))@
+  </builders>
+  <publishers>
+@(SNIPPET(
+    'publisher_mailer',
+    recipients=notify_emails,
+    dynamic_recipients=[],
+    send_to_individuals=False,
+))@
+  </publishers>
+  <buildWrappers>
+@(SNIPPET(
+    'credentials_binding_plugin',
+    credential_id=credential_id,
+    env_var_prefix='PULP',
+))@
+@(SNIPPET(
+    'build-wrapper_timestamper',
+))@
+  </buildWrappers>
+</project>

--- a/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
@@ -114,7 +114,7 @@
         ' --pulp-resource-record $WORKSPACE/ros-building-binary.txt',
         'echo "# END SECTION"',
         '',
-        'echo "# BEGIN SECTION: determine binary debug packages to testing repo"',
+        'echo "# BEGIN SECTION: determine binary debug packages to sync"',
         'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/release/rpm/list_packages.py' +
         ' --pulp-base-url http://repo:24817' +

--- a/scripts/release/rpm/list_packages.py
+++ b/scripts/release/rpm/list_packages.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import re
+import sys
+
+from pulpcore.client import pulp_rpm
+from ros_buildfarm.argument import add_argument_pulp_base_url
+from ros_buildfarm.argument import add_argument_pulp_distribution_name
+from ros_buildfarm.argument import add_argument_pulp_password
+from ros_buildfarm.argument import add_argument_pulp_resource_record
+from ros_buildfarm.argument import add_argument_pulp_task_timeout
+from ros_buildfarm.argument import add_argument_pulp_username
+from ros_buildfarm.common import Scope
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description='List the pulp IDs of packages provided at a given pulp distribution endpoint')
+    add_argument_pulp_base_url(parser)
+    add_argument_pulp_distribution_name(parser)
+    add_argument_pulp_password(parser)
+    add_argument_pulp_resource_record(parser)
+    add_argument_pulp_task_timeout(parser)
+    add_argument_pulp_username(parser)
+    parser.add_argument(
+        '--package-name-expression', default=None,
+        help='Expression to match against packages in the repository')
+
+    args = parser.parse_args(argv)
+
+    pulp_config = pulp_rpm.Configuration(
+        args.pulp_base_url, username=args.pulp_username,
+        password=args.pulp_password)
+
+    # https://pulp.plan.io/issues/5932
+    pulp_config.safe_chars_for_path_param = '/'
+
+    pulp_rpm_client = pulp_rpm.ApiClient(pulp_config)
+    pulp_packages_api = pulp_rpm.ContentPackagesApi(pulp_rpm_client)
+    pulp_distributions_api = pulp_rpm.DistributionsRpmApi(pulp_rpm_client)
+    pulp_publications_api = pulp_rpm.PublicationsRpmApi(pulp_rpm_client)
+
+    with Scope('SUBSECTION', 'list packages in the distribution'):
+        distribution = pulp_distributions_api.list(
+            name=args.pulp_distribution_name).results[0]
+        print('Pulp Distribution: ' + pulp_config.host + distribution.pulp_href)
+
+        publication = pulp_publications_api.read(distribution.publication)
+        print('Pulp Publication: %s%s' % (pulp_config.host, publication.pulp_href))
+        print('Pulp Repository: %s%s' % (pulp_config.host, publication.repository))
+        print('Pulp Repository Version: %s%s' % (pulp_config.host, publication.repository_version))
+
+        packages_in_version_page = pulp_packages_api.list(
+            repository_version=publication.repository_version, limit=200)
+        packages_in_version = list(packages_in_version_page.results)
+        while packages_in_version_page.next:
+            packages_in_version_page = pulp_packages_api.list(
+                repository_version=publication.repository_version, limit=200,
+                offset=len(packages_in_version))
+            packages_in_version += packages_in_version_page.results
+
+        print('Total packages in repository: %d' % len(packages_in_version))
+
+        if args.package_name_expression:
+            compiled_expression = re.compile(args.package_name_expression)
+            packages_in_version = [
+                pkg for pkg in packages_in_version if compiled_expression.match(pkg.name)]
+
+        print('Found %d packages:' % len(packages_in_version))
+        for pkg in packages_in_version:
+            print('- %s-%s%s-%s' % (
+                pkg.name,
+                (pkg.epoch + ':') if pkg.epoch != '0' else '',
+                pkg.version,
+                pkg.release))
+
+        if args.pulp_resource_record:
+            print("Saving pulp resource record to '%s'." % args.pulp_resource_record)
+            with open(args.pulp_resource_record, 'w') as resource_record:
+                resource_record.write('PULP_RESOURCES=%s\n' % (
+                    ' '.join([pkg.pulp_href for pkg in packages_in_version])))
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This implements a repository sync operation by enumerating the matching packages in the source repository and using the import script to bring them over to another repository.

Requires #721