### PR TITLE
Add per-project authorization for CI builds

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -80,6 +80,7 @@ A set of options which can be used in any build file.
   ``<hudson.security.AuthorizationMatrixProperty>`` in job builds.
   This property is definied for all build files but as of `#737`_ is only
   implemented for **CI jobs**.
+
   .. _#737: https://github.com/ros-infrastructure/ros_buildfarm/pull/737
 
 * ``repositories``: additional repositories to fetch packages from.

--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -76,6 +76,12 @@ A set of options which can be used in any build file.
   Note that yaml will turn bare words like ``yes`` into boolean values so it
   is recommended to quote values to avoid interpretation.
 
+* ``project_authorization_xml``: an XML blob which will be nested within a
+  ``<hudson.security.AuthorizationMatrixProperty>`` in job builds.
+  This property is definied for all build files but as of `#737`_ is only
+  implemented for **CI jobs**.
+  .. _#737: https://github.com/ros-infrastructure/ros_buildfarm/pull/737
+
 * ``repositories``: additional repositories to fetch packages from.
 
   * ``keys``: a list of PGP keys each as a multi line string.

--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -295,6 +295,9 @@ def _get_ci_job_config(
         'show_images': build_file.show_images,
         'show_plots': build_file.show_plots,
 
+        # Allow per-job authorization for CI builds.
+        'project_authorization_xml': build_file.project_authorization_xml,
+
         # only Ubuntu Focal has a new enough pytest version which generates
         # JUnit compliant result files
         'xunit_publisher_types': get_xunit_publisher_types_and_patterns(),

--- a/ros_buildfarm/config/build_file.py
+++ b/ros_buildfarm/config/build_file.py
@@ -33,6 +33,9 @@ class BuildFile(object):
             if 'maintainers' in data['notifications'] and \
                     data['notifications']['maintainers']:
                 self.notify_maintainers = True
+        self.project_authorization_xml = None
+        if 'project_authorization_xml' in data:
+            self.project_authorization_xml = data['project_authorization_xml']
 
         self.repository_keys = []
         self.repository_urls = []

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -70,6 +70,10 @@ parameters = [
     'property_parameters-definition',
     parameters=parameters,
 ))@
+@(SNIPPET(
+    'property_authorization-matrix',
+    project_authorization_xml=project_authorization_xml
+))@
   </properties>
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
   <assignedNode>@(node_label)</assignedNode>

--- a/ros_buildfarm/templates/snippet/property_authorization-matrix.xml.em
+++ b/ros_buildfarm/templates/snippet/property_authorization-matrix.xml.em
@@ -1,0 +1,7 @@
+@[if project_authorization_xml is not None]@
+    <hudson.security.AuthorizationMatrixProperty>
+@[  for line in project_authorization_xml.splitlines()]@
+      @line
+@[  end for]@
+    </hudson.security.AuthorizationMatrixProperty>
+@[end if]@


### PR DESCRIPTION
Adds the ability to specify per-job (per-project in Jenkins parlance) XML configuration for access control.

I've added config field `project_authorization_xml` to the base BuildFile class but only wired it through for CI jobs where we currently want it.

In order for this configuration to be honored Jenkins Authorization must be configured to use the Project-based Matrix Authorization Strategy whereas the current buildfarm deployment default is Matrix-based security without per-project settings.