### PR TITLE
Added description field for the plot plugin

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -472,7 +472,8 @@ The following options are valid in version ``1`` (beside the generic options):
   plot group and the list contains plot definitions comprised of:
 
   * ``title``: the title of the plot.
-  * ``description``: the description of the plot.
+  * ``description``: the description of the plot. This might contains HTML such
+    as the tags: <b>, <li>, <ul>, etc.
   * ``y_axis_label``: (optional) a label for the y-axis.
   * ``master_csv_name``: the name of the CSV file in which to aggregate the
     results on the Jenkins master.

--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -472,7 +472,7 @@ The following options are valid in version ``1`` (beside the generic options):
   plot group and the list contains plot definitions comprised of:
 
   * ``title``: the title of the plot.
-  * ``Description``: the description of the plot.
+  * ``description``: the description of the plot.
   * ``y_axis_label``: (optional) a label for the y-axis.
   * ``master_csv_name``: the name of the CSV file in which to aggregate the
     results on the Jenkins master.

--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -472,6 +472,7 @@ The following options are valid in version ``1`` (beside the generic options):
   plot group and the list contains plot definitions comprised of:
 
   * ``title``: the title of the plot.
+  * ``Description``: the description of the plot.
   * ``y_axis_label``: (optional) a label for the y-axis.
   * ``master_csv_name``: the name of the CSV file in which to aggregate the
     results on the Jenkins master.

--- a/ros_buildfarm/config/plot_config.py
+++ b/ros_buildfarm/config/plot_config.py
@@ -46,6 +46,8 @@ class PlotConfig:
         self.y_axis_minimum = data.get('y_axis_minimum', None)
         self.y_axis_maximum = data.get('y_axis_maximum', None)
 
+        self.description = data.get('description', 'Please add a description')
+
         self.num_builds = data.get('num_builds', 0)
         assert isinstance(self.num_builds, int)
 

--- a/ros_buildfarm/config/plot_config.py
+++ b/ros_buildfarm/config/plot_config.py
@@ -46,7 +46,7 @@ class PlotConfig:
         self.y_axis_minimum = data.get('y_axis_minimum', None)
         self.y_axis_maximum = data.get('y_axis_maximum', None)
 
-        self.description = data.get('description', 'Please add a description')
+        self.description = data.get('description', '')
 
         self.num_builds = data.get('num_builds', 0)
         assert isinstance(self.num_builds, int)

--- a/ros_buildfarm/templates/snippet/plot_plugin.xml.em
+++ b/ros_buildfarm/templates/snippet/plot_plugin.xml.em
@@ -3,6 +3,7 @@
 @[for plot_group, plot_list in plots.items()]@
 @[for plot in plot_list]@
         <hudson.plugins.plot.Plot>
+          <description>@(plot.description)</description>
           <title>@(plot.title)</title>
           <yaxis>@(plot.y_axis_label)</yaxis>
           <series>

--- a/ros_buildfarm/templates/snippet/plot_plugin.xml.em
+++ b/ros_buildfarm/templates/snippet/plot_plugin.xml.em
@@ -1,9 +1,13 @@
+@{
+import html
+}@
+
     <hudson.plugins.plot.PlotPublisher plugin="plot@@2.1.3">
       <plots>
 @[for plot_group, plot_list in plots.items()]@
 @[for plot in plot_list]@
         <hudson.plugins.plot.Plot>
-          <description>@("".join({ "&": "&amp;", '"': "&quot;", "'": "&apos;", ">": "&gt;", "<": "&lt;"}.get(c,c) for c in plot.description))</description>
+          <description>@(html.escape(plot.description))</description>
           <title>@(plot.title)</title>
           <yaxis>@(plot.y_axis_label)</yaxis>
           <series>

--- a/ros_buildfarm/templates/snippet/plot_plugin.xml.em
+++ b/ros_buildfarm/templates/snippet/plot_plugin.xml.em
@@ -1,7 +1,6 @@
 @{
 import html
 }@
-
     <hudson.plugins.plot.PlotPublisher plugin="plot@@2.1.3">
       <plots>
 @[for plot_group, plot_list in plots.items()]@

--- a/ros_buildfarm/templates/snippet/plot_plugin.xml.em
+++ b/ros_buildfarm/templates/snippet/plot_plugin.xml.em
@@ -3,7 +3,7 @@
 @[for plot_group, plot_list in plots.items()]@
 @[for plot in plot_list]@
         <hudson.plugins.plot.Plot>
-          <description>@(plot.description.replace('<', '&lt;').replace('<', '&gt;'))</description>
+          <description>@("".join({ "&": "&amp;", '"': "&quot;", "'": "&apos;", ">": "&gt;", "<": "&lt;"}.get(c,c) for c in plot.description))</description>
           <title>@(plot.title)</title>
           <yaxis>@(plot.y_axis_label)</yaxis>
           <series>

--- a/ros_buildfarm/templates/snippet/plot_plugin.xml.em
+++ b/ros_buildfarm/templates/snippet/plot_plugin.xml.em
@@ -3,7 +3,7 @@
 @[for plot_group, plot_list in plots.items()]@
 @[for plot in plot_list]@
         <hudson.plugins.plot.Plot>
-          <description>@(plot.description)</description>
+          <description>@(plot.description.replace('<', '&lt;').replace('<', '&gt;'))</description>
           <title>@(plot.title)</title>
           <yaxis>@(plot.y_axis_label)</yaxis>
           <series>


### PR DESCRIPTION
Added description field for the plot plugin

The idea is to add a description to each plot describing it

![Selección_021](https://user-images.githubusercontent.com/1933907/75670049-5893c200-5c7c-11ea-9c46-450ba1f8629b.png)

I have created a PR in the jenkins plot-plugin meanwhile we need to install this plugin https://github.com/ahcorde/plot-plugin/tree/ahcorde/feature/description
