### PR TITLE
Update Jenkins subversion plugin: from 2.12.1 to 2.13.1

### DIFF
--- a/ros_buildfarm/templates/snippet/scm_svn.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_svn.xml.em
@@ -1,4 +1,4 @@
-<scm class="hudson.scm.SubversionSCM" plugin="subversion@@2.12.1">
+<scm class="hudson.scm.SubversionSCM" plugin="subversion@@2.13.1">
   <locations>
     <hudson.scm.SubversionSCM_-ModuleLocation>
       <remote>@ESCAPE(remote)</remote>


### PR DESCRIPTION
To 2.13.1 from 2.12.1. Together with this update: DTKit 2 API and JUnit were updated.

I did not notice any problem in the testing jobs. The Changelog is not long but includes a removal of [some deprecation functions](https://github.com/jenkinsci/subversion-plugin/pull/239/files) in the API. I did not notice any use of this in our code.



