### PR TITLE
Replace warnings plugin by warnings next generation

### DIFF
--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -262,7 +262,7 @@ if pull_request:
   <publishers>
 @(SNIPPET(
     'publisher_warnings',
-    unstable_threshold=0 if notify_compiler_warnings else '',
+    unstable_threshold=1 if notify_compiler_warnings else '',
 ))@
 @[if xunit_publisher_types]@
 @(SNIPPET(

--- a/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
@@ -26,7 +26,11 @@
   <minimumSeverity plugin="analysis-model-api@@7.0.2">
     <name>LOW</name>
   </minimumSeverity>
-  <filters/>
+  <filters>
+    <io.jenkins.plugins.analysis.core.filter.ExcludeMessage>
+      <pattern>^Manually-specified variables were not used by the project:$</pattern>
+    </io.jenkins.plugins.analysis.core.filter.ExcludeMessage>
+  </filters>
   <isEnabledForFailure>false</isEnabledForFailure>
   <isAggregatingResults>false</isAggregatingResults>
   <isBlameDisabled>false</isBlameDisabled>

--- a/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
@@ -1,10 +1,12 @@
 <io.jenkins.plugins.analysis.core.steps.IssuesRecorder plugin="warnings-ng@@7.3.0">
   <analysisTools>
-    <!--
-         catkin inject CMake variables that are not
-         always used in build. Be careful if planning
-         to add the CMake parser
-    -->
+    <io.jenkins.plugins.analysis.warnings.Cmake>
+      <id></id>
+      <name></name>
+      <pattern></pattern>
+      <reportEncoding></reportEncoding>
+      <skipSymbolicLinks>false</skipSymbolicLinks>
+    </io.jenkins.plugins.analysis.warnings.Cmake>
     <io.jenkins.plugins.analysis.warnings.Gcc4>
       <id></id>
       <name></name>

--- a/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
@@ -1,49 +1,46 @@
-    <hudson.plugins.warnings.WarningsPublisher plugin="warnings@@4.68">
-      <healthy/>
-      <unHealthy/>
-      <thresholdLimit>low</thresholdLimit>
-      <pluginName>[WARNINGS] </pluginName>
-      <defaultEncoding/>
-      <canRunOnFailed>false</canRunOnFailed>
-      <usePreviousBuildAsReference>false</usePreviousBuildAsReference>
-      <useStableBuildAsReference>false</useStableBuildAsReference>
-      <useDeltaValues>false</useDeltaValues>
-      <thresholds plugin="analysis-core@@1.96">
+<io.jenkins.plugins.analysis.core.steps.IssuesRecorder plugin="warnings-ng@@7.3.0">
+  <analysisTools>
+    <io.jenkins.plugins.analysis.warnings.Cmake>
+      <id></id>
+      <name></name>
+      <pattern></pattern>
+      <reportEncoding></reportEncoding>
+      <skipSymbolicLinks>false</skipSymbolicLinks>
+    </io.jenkins.plugins.analysis.warnings.Cmake>
+    <io.jenkins.plugins.analysis.warnings.Gcc4>
+      <id></id>
+      <name></name>
+      <pattern></pattern>
+      <reportEncoding></reportEncoding>
+      <skipSymbolicLinks>false</skipSymbolicLinks>
+    </io.jenkins.plugins.analysis.warnings.Gcc4>
+  </analysisTools>
+  <sourceCodeEncoding></sourceCodeEncoding>
+  <sourceDirectory></sourceDirectory>
+  <ignoreQualityGate>false</ignoreQualityGate>
+  <ignoreFailedBuilds>true</ignoreFailedBuilds>
+  <referenceJobName>-</referenceJobName>
+  <failOnError>false</failOnError>
+  <healthy>0</healthy>
+  <unhealthy>0</unhealthy>
+  <minimumSeverity plugin="analysis-model-api@@7.0.2">
+    <name>LOW</name>
+  </minimumSeverity>
+  <filters/>
+  <isEnabledForFailure>false</isEnabledForFailure>
+  <isAggregatingResults>false</isAggregatingResults>
+  <isBlameDisabled>false</isBlameDisabled>
+  <isForensicsDisabled>false</isForensicsDisabled>
+  <qualityGates>
+    <io.jenkins.plugins.analysis.core.util.QualityGate>
 @[if unstable_threshold != '']@
-        <unstableTotalAll>@unstable_threshold</unstableTotalAll>
+      <threshold>@unstable_threshold</threshold>
 @[else]@
-        <unstableTotalAll/>
+      <threshold/>
 @[end if]@
-        <unstableTotalHigh/>
-        <unstableTotalNormal/>
-        <unstableTotalLow/>
-        <unstableNewAll/>
-        <unstableNewHigh/>
-        <unstableNewNormal/>
-        <unstableNewLow/>
-        <failedTotalAll/>
-        <failedTotalHigh/>
-        <failedTotalNormal/>
-        <failedTotalLow/>
-        <failedNewAll/>
-        <failedNewHigh/>
-        <failedNewNormal/>
-        <failedNewLow/>
-      </thresholds>
-      <shouldDetectModules>false</shouldDetectModules>
-      <dontComputeNew>true</dontComputeNew>
-      <doNotResolveRelativePaths>true</doNotResolveRelativePaths>
-      <includePattern/>
-      <excludePattern/>
-      <messagesPattern/>
-      <categoriesPattern/>
-      <parserConfigurations/>
-      <consoleParsers>
-        <hudson.plugins.warnings.ConsoleParser>
-          <parserName>CMake</parserName>
-        </hudson.plugins.warnings.ConsoleParser>
-        <hudson.plugins.warnings.ConsoleParser>
-          <parserName>GNU C Compiler 4 (gcc)</parserName>
-        </hudson.plugins.warnings.ConsoleParser>
-      </consoleParsers>
-    </hudson.plugins.warnings.WarningsPublisher>
+      <type>TOTAL</type>
+      <status>WARNING</status>
+    </io.jenkins.plugins.analysis.core.util.QualityGate>
+  </qualityGates>
+  <trendChartType>AGGREGATION_TOOLS</trendChartType>
+</io.jenkins.plugins.analysis.core.steps.IssuesRecorder>

--- a/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
@@ -1,12 +1,10 @@
 <io.jenkins.plugins.analysis.core.steps.IssuesRecorder plugin="warnings-ng@@7.3.0">
   <analysisTools>
-    <io.jenkins.plugins.analysis.warnings.Cmake>
-      <id></id>
-      <name></name>
-      <pattern></pattern>
-      <reportEncoding></reportEncoding>
-      <skipSymbolicLinks>false</skipSymbolicLinks>
-    </io.jenkins.plugins.analysis.warnings.Cmake>
+    <!--
+         catkin inject CMake variables that are not
+         always used in build. Be careful if planning
+         to add the CMake parser
+    -->
     <io.jenkins.plugins.analysis.warnings.Gcc4>
       <id></id>
       <name></name>

--- a/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
@@ -31,16 +31,16 @@
   <isAggregatingResults>false</isAggregatingResults>
   <isBlameDisabled>false</isBlameDisabled>
   <isForensicsDisabled>false</isForensicsDisabled>
+@[if unstable_threshold != '']@
   <qualityGates>
     <io.jenkins.plugins.analysis.core.util.QualityGate>
-@[if unstable_threshold != '']@
       <threshold>@unstable_threshold</threshold>
-@[else]@
-      <threshold/>
-@[end if]@
       <type>TOTAL</type>
       <status>WARNING</status>
     </io.jenkins.plugins.analysis.core.util.QualityGate>
   </qualityGates>
+@[else]@
+  <qualityGates/>
+@[end if]@
   <trendChartType>AGGREGATION_TOOLS</trendChartType>
 </io.jenkins.plugins.analysis.core.steps.IssuesRecorder>


### PR DESCRIPTION
The warnings plugin is deprecated. Replace it here by the [Warning next generation](https://jenkins.io/doc/pipeline/steps/warnings-ng/).

Tested it with forced warnings: http://54.162.84.148/job/Mdev__ros_comm__ubuntu_bionic_amd64/2