### PR TITLE
Include filtered packages in status pages

### DIFF
--- a/ros_buildfarm/status_page_input.py
+++ b/ros_buildfarm/status_page_input.py
@@ -38,8 +38,8 @@ class RosPackage(object):
 
 
 def get_rosdistro_info(dist, build_file):
-    all_pkg_names = dist.release_packages.keys()
-    pkg_names = build_file.filter_packages(all_pkg_names)
+    pkg_names = dist.release_packages.keys()
+    filtered_pkg_names = build_file.filter_packages(pkg_names)
 
     packages = {}
     for pkg_name in pkg_names:
@@ -97,6 +97,13 @@ def get_rosdistro_info(dist, build_file):
                         break
             except InvalidPackage:
                 pass
+
+        # handle ignored packages
+        if pkg_name not in filtered_pkg_names:
+            ros_pkg.version = None
+            ros_pkg.status = 'disabled'
+            ros_pkg.status_description = \
+                'disabled by the release build configuration'
 
         packages[pkg_name] = ros_pkg
     return packages

--- a/ros_buildfarm/templates/status/css/status_page.css
+++ b/ros_buildfarm/templates/status/css/status_page.css
@@ -110,11 +110,13 @@ span.developed:before { content: "developed"; color: #a2d39c; }
 span.maintained:before { content: "maintained"; color: #a2d39c; }
 span.unmaintained:before { content: "unmaintained"; color: #f0ac78; }
 span.end-of-life:before { content: "end-of-life"; color: #f07878; }
+span.disabled:before { content:"disabled"; color: #c8c8c8; }
 span.unknown:before { content:"unknown"; color: #c8c8c8; }
 span.developed,
 span.maintained,
 span.unmaintained,
 span.end-of-life,
+span.disabled,
 span.unknown { padding-right: 20px; width: auto; }
 
 .sum {


### PR DESCRIPTION
Previously, packages which were explicitly excluded from the release builds by means of white/black-listing in the release build configuration were completely excluded from the status page. Downstream dependencies of those packages are, however, included.

This doesn't align with the Jenkins jobs, where jobs are created for both explicitly and implicitly excluded packages, but are disabled.

This change leverages the already present "intentionally missing" state on the status page to reflect that the package is part of the distribution index, but isn't expected to be present in the build results. It also exposes packages which should have been missing from the build results but are present anyway.

This change doesn't handle the implicitly excluded packages, but sets a precedent for how they could be displayed in a subsequent change.