### PR TITLE
Install rosdoc_lite deps based on python version

### DIFF
--- a/ros_buildfarm/templates/doc/doc_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_task.Dockerfile.em
@@ -26,7 +26,7 @@ RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
     'snippet/set_environment_variables.Dockerfile.em',
-    evironment_variables=environment_variables,
+    environment_variables=environment_variables,
 ))@
 
 @(TEMPLATE(

--- a/ros_buildfarm/templates/doc/doc_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_task.Dockerfile.em
@@ -25,6 +25,11 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(
+    'snippet/set_environment_variables.Dockerfile.em',
+    evironment_variables=environment_variables,
+))@
+
+@(TEMPLATE(
     'snippet/add_distribution_repositories.Dockerfile.em',
     distribution_repository_keys=distribution_repository_keys,
     distribution_repository_urls=distribution_repository_urls,

--- a/scripts/doc/build_doc.py
+++ b/scripts/doc/build_doc.py
@@ -120,6 +120,8 @@ def main(argv=sys.argv[1:]):
                 '-t', os.path.join(
                     args.output_dir, 'rosdoc_tags', '%s.yaml' % pkg_name),
             ]
+            if '3' == os.environ.get('ROS_PYTHON_VERSION'):
+                rosdoc_lite_cmd.insert(0, 'python3')
             print("Invoking `rosdoc_lite` for package '%s': %s" %
                   (pkg_name, ' '.join(rosdoc_lite_cmd)))
             pkg_rc = subprocess.call(

--- a/scripts/doc/create_doc_task_generator.py
+++ b/scripts/doc/create_doc_task_generator.py
@@ -536,8 +536,8 @@ def main(argv=sys.argv[1:]):
                 'python3-sphinx',
                 'python3-yaml'])
         else:
-            print('Unknown python version', condition_context)
-            # Assume it's old, and using Python 2
+            if '2' != condition_context['ROS_PYTHON_VERSION']:
+                print('Unknown python version, using Python 2', condition_context)
             # the following are required by rosdoc_lite
             debian_pkg_names.extend([
                 'python-catkin-pkg-modules',

--- a/scripts/doc/create_doc_task_generator.py
+++ b/scripts/doc/create_doc_task_generator.py
@@ -527,16 +527,7 @@ def main(argv=sys.argv[1:]):
             get_os_package_name(args.rosdistro_name, 'genmsg'),
         ]
 
-        if '2' == condition_context['ROS_PYTHON_VERSION']:
-            # the following are required by rosdoc_lite
-            debian_pkg_names.extend([
-                'python-catkin-pkg-modules',
-                'python-epydoc',
-                'python-kitchen',
-                'python-rospkg',
-                'python-sphinx',
-                'python-yaml'])
-        elif '3' == condition_context['ROS_PYTHON_VERSION']:
+        if '3' == condition_context['ROS_PYTHON_VERSION']:
             # the following are required by rosdoc_lite
             debian_pkg_names.extend([
                 'python3-catkin-pkg-modules',
@@ -545,9 +536,16 @@ def main(argv=sys.argv[1:]):
                 'python3-sphinx',
                 'python3-yaml'])
         else:
-            raise RuntimeError(
-                'Unknown python version for distro {} {}'.format(
-                    args.rosdistro_name, condition_context))
+            print('Unknown python version', condition_context)
+            # Assume it's old, and using Python 2
+            # the following are required by rosdoc_lite
+            debian_pkg_names.extend([
+                'python-catkin-pkg-modules',
+                'python-epydoc',
+                'python-kitchen',
+                'python-rospkg',
+                'python-sphinx',
+                'python-yaml'])
 
         if args.build_tool == 'colcon':
             debian_pkg_names.append('python3-colcon-ros')

--- a/scripts/doc/create_doc_task_generator.py
+++ b/scripts/doc/create_doc_task_generator.py
@@ -594,7 +594,8 @@ def main(argv=sys.argv[1:]):
                 args.distribution_repository_urls,
                 args.distribution_repository_key_files),
 
-            'environment_variables': ['ROS_PYTHON_VERSION={}'.format(condition_context['ROS_PYTHON_VERSION'])],
+            'environment_variables': [
+                'ROS_PYTHON_VERSION={}'.format(condition_context['ROS_PYTHON_VERSION'])],
 
             'rosdistro_name': args.rosdistro_name,
 

--- a/scripts/doc/create_doc_task_generator.py
+++ b/scripts/doc/create_doc_task_generator.py
@@ -527,7 +527,7 @@ def main(argv=sys.argv[1:]):
             get_os_package_name(args.rosdistro_name, 'genmsg'),
         ]
 
-        if '3' == condition_context['ROS_PYTHON_VERSION']:
+        if '3' == str(condition_context['ROS_PYTHON_VERSION']):
             # the following are required by rosdoc_lite
             debian_pkg_names.extend([
                 'python3-catkin-pkg-modules',
@@ -536,7 +536,7 @@ def main(argv=sys.argv[1:]):
                 'python3-sphinx',
                 'python3-yaml'])
         else:
-            if '2' != condition_context['ROS_PYTHON_VERSION']:
+            if '2' != str(condition_context['ROS_PYTHON_VERSION']):
                 print('Unknown python version, using Python 2', condition_context)
             # the following are required by rosdoc_lite
             debian_pkg_names.extend([

--- a/scripts/doc/create_doc_task_generator.py
+++ b/scripts/doc/create_doc_task_generator.py
@@ -115,10 +115,11 @@ def main(argv=sys.argv[1:]):
     args = parser.parse_args(argv)
 
     config = get_config_index(args.config_url)
+    index = get_index(config.rosdistro_index_url)
 
     condition_context = {
         'ROS_DISTRO': args.rosdistro_name,
-        'ROS_PYTHON_VERSION': 2,
+        'ROS_PYTHON_VERSION': index.distributions[args.rosdistro_name].get('python_version'),
         'ROS_VERSION': 1,
     }
 
@@ -224,7 +225,6 @@ def main(argv=sys.argv[1:]):
           'up-to-date')
     create_stamp_files(pkg_names, os.path.join(args.output_dir, 'api_rosdoc'))
 
-    index = get_index(config.rosdistro_index_url)
     dist_file = get_distribution_file(index, args.rosdistro_name)
     assert args.repository_name in dist_file.repositories
     valid_package_names = \
@@ -521,17 +521,32 @@ def main(argv=sys.argv[1:]):
             'rsync',
             # the following are required by rosdoc_lite
             'doxygen',
-            'python-catkin-pkg-modules',
-            'python-epydoc',
-            'python-kitchen',
-            'python-rospkg',
-            'python-sphinx',
-            'python-yaml',
             # since catkin is not a run dependency but provides the setup files
             get_os_package_name(args.rosdistro_name, 'catkin'),
             # rosdoc_lite does not work without genmsg being importable
             get_os_package_name(args.rosdistro_name, 'genmsg'),
         ]
+
+        if '2' == condition_context['ROS_PYTHON_VERSION']:
+            # the following are required by rosdoc_lite
+            debian_pkg_names.extend([
+                'python-catkin-pkg-modules',
+                'python-epydoc',
+                'python-kitchen',
+                'python-rospkg',
+                'python-sphinx',
+                'python-yaml'])
+        elif '3' == condition_context['ROS_PYTHON_VERSION']:
+            # the following are required by rosdoc_lite
+            debian_pkg_names.extend([
+                'python3-catkin-pkg-modules',
+                'python3-kitchen',
+                'python3-rospkg-modules',
+                'python3-sphinx',
+                'python3-yaml'])
+        else:
+            raise RuntimeError('Unknown python version', condition_context['ROS_PYTHON_VERSION'])
+
         if args.build_tool == 'colcon':
             debian_pkg_names.append('python3-colcon-ros')
         if 'actionlib_msgs' in pkg_names:

--- a/scripts/doc/create_doc_task_generator.py
+++ b/scripts/doc/create_doc_task_generator.py
@@ -545,7 +545,9 @@ def main(argv=sys.argv[1:]):
                 'python3-sphinx',
                 'python3-yaml'])
         else:
-            raise RuntimeError('Unknown python version', condition_context['ROS_PYTHON_VERSION'])
+            raise RuntimeError(
+                'Unknown python version for distro {} {}'.format(
+                    args.rosdistro_name, condition_context))
 
         if args.build_tool == 'colcon':
             debian_pkg_names.append('python3-colcon-ros')

--- a/scripts/doc/create_doc_task_generator.py
+++ b/scripts/doc/create_doc_task_generator.py
@@ -594,6 +594,8 @@ def main(argv=sys.argv[1:]):
                 args.distribution_repository_urls,
                 args.distribution_repository_key_files),
 
+            'environment_variables': ['ROS_PYTHON_VERSION={}'.format(condition_context['ROS_PYTHON_VERSION'])],
+
             'rosdistro_name': args.rosdistro_name,
 
             'uid': get_user_id(),


### PR DESCRIPTION
Resolves #706
Requires https://github.com/ros-infrastructure/ros_buildfarm_config/pull/163

This installs the Python apt dependencies based on the distribution's ROS_PYTHON_VERSION. It looks like the least effort way to get Noetic doc jobs passing.