### PR TITLE
Mark implicitly excluded packages in status pages

### DIFF
--- a/ros_buildfarm/status_page_input.py
+++ b/ros_buildfarm/status_page_input.py
@@ -14,6 +14,7 @@
 
 from collections import namedtuple
 
+from .common import get_implicitly_ignored_package_names
 from .common import get_os_package_name
 
 MaintainerDescriptor = namedtuple('Maintainer', 'name email')
@@ -51,6 +52,12 @@ def get_rosdistro_info(dist, build_file):
             cached_pkgs[pkg_name] = pkg_manifest
 
     filtered_pkg_names = build_file.filter_packages(pkg_names)
+    explicitly_ignored_pkg_names = set(pkg_names) - set(filtered_pkg_names)
+    if explicitly_ignored_pkg_names:
+        implicitly_ignored_pkg_names = get_implicitly_ignored_package_names(
+            cached_pkgs, explicitly_ignored_pkg_names)
+        filtered_pkg_names = \
+            set(filtered_pkg_names) - implicitly_ignored_pkg_names
 
     packages = {}
     for pkg_name in pkg_names:


### PR DESCRIPTION
Follow-up to #750 to mark the remaining (implicitly) ignored packages as intentionally missing on the status page.

Included are two refactor commits to bring the downstream package detection into a common location to be reused by the status page generation.

All of the refactoring leads to appending the newly aggregated `implicitly_ignored_pkg_names` set to `filtered_pkg_names`, which achieves the desired effect.