### PR TITLE
add missing jenkinsapi dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,6 @@ elif 'SKIP_PYTHON_SCRIPTS' in os.environ:
     kwargs['scripts'] = []
 else:
     kwargs['install_requires'] += [
-        'catkin_pkg >= 0.2.6', 'rosdistro >= 0.4.0', 'vcstool >= 0.1.37']
+        'catkin_pkg >= 0.2.6', 'jenkinsapi', 'rosdistro >= 0.4.0', 'vcstool >= 0.1.37']
 
 setup(**kwargs)


### PR DESCRIPTION
When I setup the virtualenv this dependency was missing to be able to invoke it.