### PR TITLE
Pass env vars from build config to RPM build

### DIFF
--- a/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
+++ b/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
@@ -11,6 +11,12 @@ config_opts['yum_builddep_opts'] = config_opts.get('yum_builddep_opts', []) + ['
 config_opts['dnf_builddep_opts'] = config_opts.get('dnf_builddep_opts', []) + ['--setopt=install_weak_deps=True']
 config_opts['microdnf_builddep_opts'] = config_opts.get('microdnf_builddep_opts', []) + ['--setopt=install_weak_deps=True']
 
+@[if build_environment_variables]@
+# Set environment vars from the build config
+@[for env_key, env_val in [env_var.split('=', 1) for env_var in build_environment_variables]]@
+config_opts['environment']['@env_key'] = '@env_val'
+@[end for]
+@[end if]@
 # Disable debug packages until infrastructure can handle it
 config_opts['macros']['debug_package'] = '%{nil}'
 


### PR DESCRIPTION
Mock isolates the environment variables in the build environment, so setting them in the Docker container doesn't work - they need to be set explicitly in the mock config.

Closes #755