### PR TITLE
Improve performance of RPM repo sync operations

### DIFF
--- a/scripts/release/rpm/import_package.py
+++ b/scripts/release/rpm/import_package.py
@@ -137,9 +137,9 @@ def main(argv=sys.argv[1:]):
             if pkg.name in package_names:
                 packages_to_remove[pkg.pulp_href] = pkg
 
-        package_provides = package_names.union(
-            prov[0] for pkg in packages_to_add.values() for prov in pkg.provides)
         if args.invalidate:
+            package_provides = package_names.union(
+                prov[0] for pkg in packages_to_add.values() for prov in pkg.provides)
             packages_to_remove.update(
                 _get_recursive_dependencies(packages_in_version, package_provides))
 


### PR DESCRIPTION
These two changes brought RPM sync-to-testing jobs down from about ~3:00 to ~0:18 for no-op or small syncs.

A full and consecutive rebuild of Eloquent could still take ~3:00 to sync despite these changes, but one-off jobs are now WAY more efficient than they used to be.