### PR TITLE
Process conditional dependencies in release jobs

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -509,7 +509,8 @@ def topological_order_packages(packages):
             decorator.package.run_depends + decorator.package.test_depends
         # skip external dependencies, meaning names that are not known packages
         unique_depend_names = set([
-            d.name for d in all_depends if d.name in decorators_by_name.keys()])
+            d.name for d in all_depends if d.name in decorators_by_name.keys() and
+            d.evaluated_condition is not False])
         for name in unique_depend_names:
             if name in decorator.depends_for_topological_order:
                 # avoid function call to improve performance
@@ -613,7 +614,8 @@ def get_direct_dependencies(pkg_name, cached_pkgs, pkg_names):
             pkg.build_export_depends +
             pkg.exec_depends +
             pkg.test_depends)
-        if d.name in pkg_names])
+        if d.name in pkg_names and
+        d.evaluated_condition is not False])
     return depends
 
 

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -24,6 +24,7 @@ from ros_buildfarm.common import get_github_project_url
 from ros_buildfarm.common import get_implicitly_ignored_package_names
 from ros_buildfarm.common import get_node_label
 from ros_buildfarm.common import get_os_package_name
+from ros_buildfarm.common import get_package_condition_context
 from ros_buildfarm.common import get_release_binary_view_name
 from ros_buildfarm.common import get_release_job_prefix
 from ros_buildfarm.common import get_release_source_view_name
@@ -321,6 +322,10 @@ def _get_and_parse_distribution_cache(index, rosdistro_name, pkg_names):
         for pkg_name, pkg_xml in dist_cache.release_package_xmls.items()
         if pkg_name in pkg_names
     }
+
+    condition_context = get_package_condition_context(index, rosdistro_name)
+    for pkg in cached_pkgs.values():
+        pkg.evaluate_conditions(condition_context)
 
     # for ROS 2 distributions bloom injects a dependency on ros_workspace
     # into almost all packages (except its dependencies)


### PR DESCRIPTION
This change adds the same conditional variables as are used during blooming, so a conditional dependency on a ROS package should now be possible.

I don't know of any packages _in the wild_ that are attempting conditional dependencies on other ROS packages, so I verified this functionality by creating a dummy package that took a conditional dependency.

Since some of the common methods may be called from code which doesn't evaluate the conditionals, I took a backwards-compatible approach by checking if `evaluated_condition is not False` rather than `evaluated_condition is True`.

I placed the methods in `common.py` because I'd like to reuse them for the status page generation, but I need to do a little more refactoring for that.