### PR TITLE
Change --env-vars to parse as a dict

### DIFF
--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+from collections import OrderedDict
 import os
 
 
@@ -67,8 +68,8 @@ def add_argument_build_name(parser, build_file_type, nargs=None):
 
 def add_argument_env_vars(parser):
     parser.add_argument(
-        '--env-vars',
-        nargs='*', default=[],
+        '--env-vars', action=OrderedDictAction,
+        nargs='*', default=OrderedDict(),
         help="Environment variables as 'key=value' for Dockerfile "
              'ENV directives')
 
@@ -469,3 +470,16 @@ def extract_multiple_remainders(argv, arguments):
             remainders[argument.dest] = argv[index + 1:]
             del argv[index:]
     return remainders
+
+
+class OrderedDictAction(argparse.Action):
+    def __call__(self, parser, args, values, option_string=None):
+        dest = OrderedDict()
+        for value in values:
+            value_parts = value.split('=', 1)
+            if len(value_parts) != 2:
+                raise argparse.ArgumentError(
+                    argument=self,
+                    message="invalid key/value pair: '%s'" % value)
+            dest[value_parts[0].strip()] = value_parts[1].strip()
+        setattr(args, self.dest, dest)

--- a/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
@@ -59,7 +59,7 @@ args = \
     ' --workspace-root ' + ' '.join(workspace_mount_point) + \
     ' --distribution-repository-urls ' + ' '.join(distribution_repository_urls) + \
     ' --distribution-repository-key-files ' + ' ' .join(['/tmp/keys/%d.key' % i for i in range(len(distribution_repository_keys))]) + \
-    ' --env-vars ' + ' ' .join(env_vars)
+    ' --env-vars ' + ' ' .join(['%s=%s' % var for var in env_vars.items()])
 build_args = args + \
     ' --build-tool ' + build_tool + \
     ' --ros-version ' + str(ros_version) + \

--- a/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
@@ -59,7 +59,7 @@ args = \
     ' --workspace-root ' + ' '.join(workspace_mount_point) + \
     ' --distribution-repository-urls ' + ' '.join(distribution_repository_urls) + \
     ' --distribution-repository-key-files ' + ' ' .join(['/tmp/keys/%d.key' % i for i in range(len(distribution_repository_keys))]) + \
-    ' --env-vars ' + ' ' .join(['%s=%s' % var for var in env_vars.items()])
+    ' --env-vars ' + ' ' .join(['%s=%s' % key_value for key_value in env_vars.items()])
 build_args = args + \
     ' --build-tool ' + build_tool + \
     ' --ros-version ' + str(ros_version) + \

--- a/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
@@ -82,7 +82,7 @@ cmd = \
     ' --distribution-repository-key-files ' + ' ' .join(['/tmp/keys/%d.key' % i for i in range(len(distribution_repository_keys))]) + \
     ' --build-tool ' + build_tool + \
     ' --ros-version ' + str(ros_version) + \
-    ' --env-vars ' + ' ' .join(['%s=%s' % var for var in env_vars.items()])
+    ' --env-vars ' + ' ' .join(['%s=%s' % key_value for key_value in env_vars.items()])
 if run_abichecker:
     cmd += ' --run-abichecker'
 if require_gpu_support:

--- a/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_tasks.Dockerfile.em
@@ -82,7 +82,7 @@ cmd = \
     ' --distribution-repository-key-files ' + ' ' .join(['/tmp/keys/%d.key' % i for i in range(len(distribution_repository_keys))]) + \
     ' --build-tool ' + build_tool + \
     ' --ros-version ' + str(ros_version) + \
-    ' --env-vars ' + ' ' .join(env_vars)
+    ' --env-vars ' + ' ' .join(['%s=%s' % var for var in env_vars.items()])
 if run_abichecker:
     cmd += ' --run-abichecker'
 if require_gpu_support:

--- a/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
+++ b/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
@@ -13,7 +13,7 @@ config_opts['microdnf_builddep_opts'] = config_opts.get('microdnf_builddep_opts'
 
 @[if build_environment_variables]@
 # Set environment vars from the build config
-@[for env_key, env_val in [env_var.split('=', 1) for env_var in build_environment_variables]]@
+@[for env_key, env_val in env_vars]@
 config_opts['environment']['@env_key'] = '@env_val'
 @[end for]
 @[end if]@

--- a/scripts/ci/build_task_generator.py
+++ b/scripts/ci/build_task_generator.py
@@ -117,7 +117,7 @@ def main(argv=sys.argv[1:]):
         'build_tool_args': args.build_tool_args,
         'ros_version': args.ros_version,
 
-        'build_environment_variables': args.env_vars,
+        'build_environment_variables': ['%s=%s' % var for var in args.env_vars.items()],
 
         'install_lists': install_lists,
         'dependencies': [],

--- a/scripts/ci/build_task_generator.py
+++ b/scripts/ci/build_task_generator.py
@@ -117,7 +117,7 @@ def main(argv=sys.argv[1:]):
         'build_tool_args': args.build_tool_args,
         'ros_version': args.ros_version,
 
-        'build_environment_variables': ['%s=%s' % var for var in args.env_vars.items()],
+        'build_environment_variables': ['%s=%s' % key_value for key_value in args.env_vars.items()],
 
         'install_lists': install_lists,
         'dependencies': [],

--- a/scripts/ci/create_workspace_task_generator.py
+++ b/scripts/ci/create_workspace_task_generator.py
@@ -99,7 +99,7 @@ def main(argv=sys.argv[1:]):
 
         'uid': get_user_id(),
 
-        'build_environment_variables': ['%s=%s' % var for var in args.env_vars.items()],
+        'build_environment_variables': ['%s=%s' % key_value for key_value in args.env_vars.items()],
 
         'dependencies': debian_pkg_names,
         'dependency_versions': debian_pkg_versions,

--- a/scripts/ci/create_workspace_task_generator.py
+++ b/scripts/ci/create_workspace_task_generator.py
@@ -99,7 +99,7 @@ def main(argv=sys.argv[1:]):
 
         'uid': get_user_id(),
 
-        'build_environment_variables': args.env_vars,
+        'build_environment_variables': ['%s=%s' % var for var in args.env_vars.items()],
 
         'dependencies': debian_pkg_names,
         'dependency_versions': debian_pkg_versions,

--- a/scripts/devel/create_devel_task_generator.py
+++ b/scripts/devel/create_devel_task_generator.py
@@ -171,7 +171,7 @@ def main(argv=sys.argv[1:]):
         'build_tool': args.build_tool,
         'ros_version': args.ros_version,
 
-        'build_environment_variables': ['%s=%s' % var for var in args.env_vars.items()],
+        'build_environment_variables': ['%s=%s' % key_value for key_value in args.env_vars.items()],
 
         'dependencies': debian_pkg_names,
         'dependency_versions': debian_pkg_versions,

--- a/scripts/devel/create_devel_task_generator.py
+++ b/scripts/devel/create_devel_task_generator.py
@@ -77,11 +77,7 @@ def main(argv=sys.argv[1:]):
              'and instead of installing the tests are ran')
     args = parser.parse_args(argv)
 
-    condition_context = {}
-    for t in args.env_vars:
-        parts = t.split('=', 1)
-        assert len(parts) == 2, '--env-vars argument lacks equal sign: ' + t
-        condition_context[parts[0]] = parts[1]
+    condition_context = dict(args.env_vars)
     condition_context['ROS_DISTRO'] = args.rosdistro_name
     condition_context['ROS_VERSION'] = args.ros_version
 
@@ -175,7 +171,7 @@ def main(argv=sys.argv[1:]):
         'build_tool': args.build_tool,
         'ros_version': args.ros_version,
 
-        'build_environment_variables': args.env_vars,
+        'build_environment_variables': ['%s=%s' % var for var in args.env_vars.items()],
 
         'dependencies': debian_pkg_names,
         'dependency_versions': debian_pkg_versions,

--- a/scripts/release/create_binarydeb_task_generator.py
+++ b/scripts/release/create_binarydeb_task_generator.py
@@ -97,7 +97,7 @@ def main(argv=sys.argv[1:]):
             args.distribution_repository_urls,
             args.distribution_repository_key_files),
 
-        'build_environment_variables': args.env_vars,
+        'build_environment_variables': ['%s=%s' % var for var in args.env_vars.items()],
 
         'dependencies': debian_pkg_names,
         'dependency_versions': debian_pkg_versions,

--- a/scripts/release/create_binarydeb_task_generator.py
+++ b/scripts/release/create_binarydeb_task_generator.py
@@ -97,7 +97,7 @@ def main(argv=sys.argv[1:]):
             args.distribution_repository_urls,
             args.distribution_repository_key_files),
 
-        'build_environment_variables': ['%s=%s' % var for var in args.env_vars.items()],
+        'build_environment_variables': ['%s=%s' % key_value for key_value in args.env_vars.items()],
 
         'dependencies': debian_pkg_names,
         'dependency_versions': debian_pkg_versions,

--- a/scripts/release/rpm/run_binarypkg_job.py
+++ b/scripts/release/rpm/run_binarypkg_job.py
@@ -72,7 +72,6 @@ def main(argv=sys.argv[1:]):
         'skip_download_sourcepkg': args.skip_download_sourcepkg,
 
         'sourcepkg_dir': os.path.join(args.binarypkg_dir, 'source'),
-        'build_environment_variables': args.env_vars,
     })
     create_dockerfile(
         'release/rpm/binarypkg_task.Dockerfile.em',

--- a/scripts/release/rpm/run_sourcepkg_job.py
+++ b/scripts/release/rpm/run_sourcepkg_job.py
@@ -58,7 +58,6 @@ def main(argv=sys.argv[1:]):
         'target_repository': None,
 
         'uid': get_user_id(),
-        'build_environment_variables': [],
     })
     create_dockerfile(
         'release/rpm/sourcepkg_task.Dockerfile.em', data, args.dockerfile_dir)

--- a/scripts/release/run_binarydeb_job.py
+++ b/scripts/release/run_binarydeb_job.py
@@ -70,7 +70,7 @@ def main(argv=sys.argv[1:]):
         'skip_download_sourcepkg': args.skip_download_sourcepkg,
 
         'binarypkg_dir': '/tmp/binarydeb',
-        'build_environment_variables': ['%s=%s' % var for var in args.env_vars.items()],
+        'build_environment_variables': ['%s=%s' % key_value for key_value in args.env_vars.items()],
         'dockerfile_dir': '/tmp/docker_build_binarydeb',
     })
     create_dockerfile(

--- a/scripts/release/run_binarydeb_job.py
+++ b/scripts/release/run_binarydeb_job.py
@@ -70,7 +70,7 @@ def main(argv=sys.argv[1:]):
         'skip_download_sourcepkg': args.skip_download_sourcepkg,
 
         'binarypkg_dir': '/tmp/binarydeb',
-        'build_environment_variables': args.env_vars,
+        'build_environment_variables': ['%s=%s' % var for var in args.env_vars.items()],
         'dockerfile_dir': '/tmp/docker_build_binarydeb',
     })
     create_dockerfile(


### PR DESCRIPTION
In the templates, `env_vars` is now a dictionary, but `build_environment_variables` remains as a list.

This change gives us earlier feedback when invalid values are passed to `--env-vars`, and gives us greater flexibility in what we do with that value.

Inspired by https://github.com/ros-infrastructure/ros_buildfarm/pull/759#issuecomment-596869929