### PR TITLE
Drop manifest conditional evaluation from abi checker

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -553,13 +553,13 @@ def get_system_architecture():
     raise RuntimeError('Unable to determine architecture')
 
 
-def get_packages_in_workspaces(workspace_roots, condition_context):
+def get_packages_in_workspaces(workspace_roots, condition_context=None):
     """
     Return packages found in the passed workspaces.
 
     :param workspace_roots: A list of absolute paths to workspaces
-    :param condition_context: A dict containing environment variables for the
-      conditions in the package manifests
+    :param condition_context: An optional dict containing environment variables
+      for the conditional evaluation in the package manifests
     :returns: A list of ``Package`` objects
     """
     from catkin_pkg.packages import find_packages
@@ -569,9 +569,10 @@ def get_packages_in_workspaces(workspace_roots, condition_context):
         source_space = os.path.join(workspace_root, 'src')
         print("Crawling for packages in workspace '%s'" % source_space)
         ws_pkgs = find_packages(source_space)
-        for pkg in ws_pkgs.values():
-            pkg.evaluate_conditions(condition_context)
         pkgs.update(ws_pkgs)
+    if condition_context is not None:
+        for pkg in pkgs.values():
+            pkg.evaluate_conditions(condition_context)
     return pkgs
 
 

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -30,21 +30,16 @@ from ros_buildfarm.workspace import clean_workspace
 from ros_buildfarm.workspace import ensure_workspace_exists
 
 
-def call_abi_checker(workspace_root, ros_version, env):
+def call_abi_checker(workspace_root, rosdistro_name, env):
     import rosdistro
 
-    condition_context = {}
-    condition_context['ROS_DISTRO'] = env['ROS_DISTRO']
-    condition_context['ROS_VERSION'] = ros_version
-    condition_context['ROS_PYTHON_VERSION'] = \
-        (env or os.environ).get('ROS_PYTHON_VERSION')
-    pkgs = get_packages_in_workspaces(workspace_root, condition_context)
+    pkgs = get_packages_in_workspaces(workspace_root)
     pkg_names = [pkg.name for pkg in pkgs.values()]
     assert pkg_names, 'No packages found in the workspace'
 
     # Filter packages in source space that has been released
     index = rosdistro.get_index(rosdistro.get_index_url())
-    dist_file = rosdistro.get_distribution_file(index, env['ROS_DISTRO'])
+    dist_file = rosdistro.get_distribution_file(index, rosdistro_name)
     pkg_names_released = [
         pkg_name for pkg_name in pkg_names if pkg_name in dist_file.release_packages]
 
@@ -123,7 +118,7 @@ def main(argv=sys.argv[1:]):
         with Scope('SUBSECTION', 'use abi checker'):
             abi_rc = call_abi_checker(
                 [args.workspace_root],
-                args.ros_version,
+                args.rosdistro_name,
                 env)
         # Never fail a build because of abi errors but make them
         # unstable by printing MAKE_BUILD_UNSTABLE. Jenkins will


### PR DESCRIPTION
The package enumeration we're doing here doesn't actually require that the dependencies have their conditionals evaluated.

Inspired by https://github.com/ros-infrastructure/ros_buildfarm/pull/761#discussion_r390670955