### PR TITLE
fix merging hard coded args with configuration provided args

### DIFF
--- a/ros_buildfarm/workspace.py
+++ b/ros_buildfarm/workspace.py
@@ -111,17 +111,19 @@ def call_build_tool(
     if install and build_tool == 'catkin_make_isolated':
         cmd.append('--install')
 
+    if args:
+        cmd += args
+
+    # since `args` might contain the following arguments already it must be
+    # ensured that the --* is not duplicated since only the last will be used
     if cmake_args:
-        cmd += ['--cmake-args'] + cmake_args
+        _insert_nargs_arguments(cmd, '--cmake-args', cmake_args)
 
     if make_args:
         if build_tool == 'catkin_make_isolated':
-            cmd += ['--catkin-make-args'] + make_args
+            _insert_nargs_arguments(cmd, '--catkin-make-args', make_args)
         elif build_tool == 'colcon':
-            cmd += ['--cmake-target'] + make_args
-
-    if args:
-        cmd += args
+            _insert_nargs_arguments(cmd, '--cmake-target', make_args)
 
     cmd = ' '.join(cmd)
 
@@ -158,3 +160,11 @@ def call_build_tool(
     print("Invoking '%s' in '%s'" % (cmd, workspace_root))
     return subprocess.call(
         cmd, cwd=workspace_root, shell=True, stderr=subprocess.STDOUT, env=env)
+
+
+def _insert_nargs_arguments(cmd, argument_name, argument_values):
+    if argument_name not in cmd:
+        cmd += [argument_name] + argument_values
+    else:
+        index = cmd.index(argument_name)
+        cmd[index + 1:index + 1] = argument_values


### PR DESCRIPTION
Without this patch config provided arguments (like https://github.com/ros2/ros_buildfarm_config/blob/f0e0bc7c1902ba709a0c0d51819b334375f9410d/foxy/ci-nightly-fastrtps.yaml#L11) are being added after the hard coded arguments (like https://github.com/ros-infrastructure/ros_buildfarm/blob/7719e9b26a73ca6878050709b51afced67b1ecca/scripts/devel/build_and_install.py#L108), see: https://github.com/ros-infrastructure/ros_buildfarm/blob/7719e9b26a73ca6878050709b51afced67b1ecca/ros_buildfarm/workspace.py#L114-L124

This leads to an invocation with `--cmake-args` passed twice (see http://build.ros2.org/view/Fci/job/Fci__nightly-cross-vendor-connext-fastrtps_ubuntu_focal_amd64/7/consoleFull#console-section-23):

> colcon build --build-base build_isolated --install-base install_isolated --test-result-base test_results --event-handlers console_cohesion+ **--cmake-args** -DBUILD_TESTING=0 -DCATKIN_SKIP_TESTING=1 **--cmake-args** -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli

The second one effectively overwrites the first.

This fixes e.g. the ROS 2 cross vendor jobs:
* Before: [![Build Status](http://build.ros2.org/buildStatus/icon?job=Fci__nightly-cross-vendor-connext-fastrtps_ubuntu_focal_amd64&build=7)](http://build.ros2.org/view/Fci/job/Fci__nightly-cross-vendor-connext-fastrtps_ubuntu_focal_amd64/7/)
* After: [![Build Status](http://build.ros2.org/buildStatus/icon?job=Fci__nightly-cross-vendor-connext-fastrtps_ubuntu_focal_amd64&build=8)](http://build.ros2.org/view/Fci/job/Fci__nightly-cross-vendor-connext-fastrtps_ubuntu_focal_amd64/8/)