### PR TITLE
Extract empty group dependencies for topological ordering.

### DIFF
--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -152,6 +152,15 @@ def configure_release_jobs(
     for pkg_name in set(pkg_names).difference(cached_pkgs.keys()):
         print("Skipping package '%s': no released package.xml in cache" %
               (pkg_name), file=sys.stderr)
+    # topological_order_packages will assert if the members attribute of any
+    # group dependency is None. This works around this by extracting group
+    # members from an empty set. This is preferable to honoring group
+    # dependencies as bloom does not currently support them so this matches
+    # that behavior.
+    for pkg, pkgdata in cached_pkgs:
+        if pkgdata.group_depends:
+            for group_depend in pkgdata.group_depends:
+                group_depend.extract_group_members({})
     ordered_pkg_tuples = topological_order_packages(cached_pkgs)
 
     other_build_files = [v for k, v in build_files.items() if k != release_build_name]


### PR DESCRIPTION
This is a fix for an issue introduced by #758. Now that conditional
dependencies are being evaluated and checked, an assert is triggering
during release jobs since group memberships are not being extracted.

However, if we were to extract true group memberships we could create a
discrepancy between the topological order according to ros_buildfarm and
the dependency tree used by bloom as bloom does not currently support
group dependencies.

[Drel_reconfigure-jobs#762](http://build.ros2.org/job/Drel_reconfigure-jobs/762/) is an example of the failure this is meant to mitigate.
[Drel_reconfigure-jobs#761](http://build.ros2.org/job/Drel_reconfigure-jobs/761/) used a modified config targeting the previous commit which is how I know #758 introduced the issue.