### PR TITLE
Refactor pulp workflows into a common file

### DIFF
--- a/ros_buildfarm/pulp.py
+++ b/ros_buildfarm/pulp.py
@@ -12,40 +12,195 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import re
 import time
 
+from pulpcore.client import pulp_rpm
 from pulpcore.client import pulpcore
 
 
-class PulpTaskPoller:
+def format_pkg_ver(pkg):
+    return '%s%s-%s' % (
+        (pkg.epoch + ':') if pkg.epoch != '0' else '',
+        pkg.version,
+        pkg.release)
 
-    def __init__(self, pulp_configuration, timeout, interval=0.5):
-        client = pulpcore.ApiClient(pulp_configuration)
-        self._tasks_api = pulpcore.TasksApi(client)
-        self._timeout = timeout
-        self._interval = interval
 
-    def wait_for_task(self, task_href):
-        task = self._tasks_api.read(task_href)
+def _enumerate_recursive_dependencies(packages, target_names):
+    new_names = set(target_names)
 
-        print("Waiting for task '%s'..." %
-              (self._tasks_api.api_client.configuration.host + task.pulp_href))
+    while new_names:
+        target_names = new_names
+        new_names = set()
+        for pkg in packages:
+            if target_names.intersection(req[0] for req in pkg.requires):
+                yield (pkg.pulp_href, pkg)
+                new_names.add(pkg.name)
+                new_names.update(prov[0] for prov in pkg.provides)
 
-        timeout = self._timeout
+
+class PulpPageIterator:
+
+    def __init__(self, fetch_function, *args, **kwargs):
+        self._get_next = lambda offset: fetch_function(*args, **kwargs, offset=offset)
+        self._offset = 0
+        self._next_page()
+
+    def _next_page(self):
+        self._page = self._get_next(self._offset)
+        self._offset += len(self._page.results)
+        self._iter = iter(self._page.results)
+
+    def __iter__(self):
+        return self
+
+    def __len__(self):
+        return self._page.count
+
+    def __next__(self):
+        try:
+            return next(self._iter)
+        except StopIteration:
+            if not self._page.next:
+                raise
+
+        self._next_page()
+        return next(self._iter)
+
+
+class PulpRpmClient:
+
+    def __init__(
+            self, base_url, username, password, task_timeout=60.0, task_polling_interval=0.5):
+        self._task_timeout = task_timeout
+        self._task_polling_interval = task_polling_interval
+
+        self._config = pulpcore.Configuration(
+            base_url, username=username, password=password)
+
+        # https://pulp.plan.io/issues/5932
+        self._config.safe_chars_for_path_param = '/'
+
+        # Core APIs
+        self._core_client = pulpcore.ApiClient(self._config)
+        self._core_tasks_api = pulpcore.TasksApi(self._core_client)
+
+        # RPM APIs
+        self._rpm_client = pulp_rpm.ApiClient(self._config)
+        self._rpm_distributions_api = pulp_rpm.DistributionsRpmApi(self._rpm_client)
+        self._rpm_packages_api = pulp_rpm.ContentPackagesApi(self._rpm_client)
+        self._rpm_publications_api = pulp_rpm.PublicationsRpmApi(self._rpm_client)
+        self._rpm_repos_api = pulp_rpm.RepositoriesRpmApi(self._rpm_client)
+
+    def _wait_for_task(self, task_href):
+        task = self._core_tasks_api.read(task_href)
+
+        timeout = self._task_timeout
         while task.state != 'completed':
             if task.state in ['failed', 'canceled']:
                 raise RuntimeError(
                     "Pulp task '%s' did not complete (%s)" % (task.pulp_href, task.state))
-            time.sleep(self._interval)
-            timeout -= self._interval
+            time.sleep(self._task_polling_interval)
+            timeout -= self._task_polling_interval
             if timeout <= 0:
                 task_cancel = pulpcore.TaskCancel('canceled')
-                task = self._tasks_api.tasks_cancel(task.pulp_href, task_cancel)
+                task = self._core_tasks_api.tasks_cancel(task.pulp_href, task_cancel)
                 if task.state != 'completed':
                     raise RuntimeError(
                         "Pulp task '%s' did not complete (timed out)" % task.pulp_href)
 
-            task = self._tasks_api.read(task.pulp_href)
+            task = self._core_tasks_api.read(task.pulp_href)
 
-        print('...done.')
         return task
+
+    def enumerate_distributions(self):
+        return PulpPageIterator(
+            self._rpm_distributions_api.list)
+
+    def enumerate_pkgs_in_distribution_name(self, distribution_name):
+        distribution = self._rpm_distributions_api.list(
+            name=distribution_name).results[0]
+        publication = self._rpm_publications_api.read(distribution.publication)
+        return self.enumerate_pkgs_in_repo_ver(publication.repository_version)
+
+    def enumerate_pkgs_in_repo_ver(self, repo_ver_href):
+        return PulpPageIterator(
+            self._rpm_packages_api.list, repository_version=repo_ver_href)
+
+    def import_and_invalidate(
+            self, distribution_name, packages_to_add,
+            invalidate_expression, invalidate_downstream):
+        distribution = self._rpm_distributions_api.list(
+            name=distribution_name).results[0]
+        old_publication = self._rpm_publications_api.read(distribution.publication)
+
+        # Get the current packages
+        current_pkgs = {
+            pkg.pulp_href: pkg for pkg in
+            self.enumerate_pkgs_in_repo_ver(old_publication.repository_version)}
+
+        # Get the packages we're adding
+        new_pkgs = {
+            pkg.pulp_href: pkg for pkg in
+            [current_pkgs.get(pkg_href) or self._rpm_packages_api.read(pkg_href)
+                for pkg_href in packages_to_add]}
+
+        # Invalidate packages
+        pkgs_to_remove = {}
+        new_pkg_names = set([pkg.name for pkg in new_pkgs.values()])
+        # 1. Remove packages with the same name
+        pkgs_to_remove.update({
+            pkg.pulp_href: pkg for pkg in current_pkgs.values()
+            if pkg.name in new_pkg_names})
+        # 2. Remove downstream packages
+        if invalidate_downstream:
+            new_pkg_provides = new_pkg_names.union(
+                prov[0] for pkg in new_pkgs.values() for prov in pkg.provides)
+            pkgs_to_remove.update(
+                _enumerate_recursive_dependencies(current_pkgs.values(), new_pkg_provides))
+        # 3. Remove packages matching the invalidation expression
+        if invalidate_expression:
+            compiled_expression = re.compile(invalidate_expression)
+            for pkg in current_pkgs.values():
+                if compiled_expression.match(pkg.name):
+                    pkgs_to_remove[pkg.pulp_href] = pkg
+
+        # Prune the list of packages to add and remove
+        # 1. Packages being added *always* end up in the repo
+        for href_to_add in new_pkgs.keys():
+            pkgs_to_remove.pop(href_to_add, None)
+        # 2. Packages being added don't need to get re-added
+        for href_in_current in current_pkgs.keys():
+            new_pkgs.pop(href_in_current, None)
+
+        # Commit the changes
+        mod_data = pulp_rpm.RepositoryAddRemoveContent(
+            add_content_units=list(new_pkgs.keys()),
+            remove_content_units=list(pkgs_to_remove.keys()),
+            base_version=old_publication.repository_version)
+        mod_task_href = self._rpm_repos_api.modify(old_publication.repository, mod_data).task
+        mod_task = self._wait_for_task(mod_task_href)
+
+        if mod_task.created_resources:
+            # Publish the new version
+            publish_data = pulp_rpm.RpmRpmPublication(
+                repository_version=mod_task.created_resources[0])
+            publish_task_href = self._rpm_publications_api.create(publish_data).task
+            publish_task = self._wait_for_task(publish_task_href)
+
+            # Distribute the publication at the original endpoint
+            distribution.publication = publish_task.created_resources[0]
+            distribute_task_href = self._rpm_distributions_api.partial_update(
+                distribution.pulp_href, distribution).task
+            self._wait_for_task(distribute_task_href)
+
+        return (new_pkgs.values(), pkgs_to_remove.values())
+
+    def upload_pkg(self, file_path):
+        relative_path = os.path.basename(file_path)
+        upload_task_href = self._rpm_packages_api.create(
+            relative_path, file=file_path).task
+        upload_task = self._wait_for_task(upload_task_href)
+
+        return self._rpm_packages_api.read(upload_task.created_resources[0])

--- a/scripts/release/rpm/import_package.py
+++ b/scripts/release/rpm/import_package.py
@@ -15,10 +15,8 @@
 # limitations under the License.
 
 import argparse
-import re
 import sys
 
-from pulpcore.client import pulp_rpm
 from ros_buildfarm.argument import add_argument_invalidate
 from ros_buildfarm.argument import add_argument_pulp_base_url
 from ros_buildfarm.argument import add_argument_pulp_distribution_name
@@ -26,24 +24,8 @@ from ros_buildfarm.argument import add_argument_pulp_password
 from ros_buildfarm.argument import add_argument_pulp_task_timeout
 from ros_buildfarm.argument import add_argument_pulp_username
 from ros_buildfarm.common import Scope
-from ros_buildfarm.pulp import PulpTaskPoller
-
-
-def _get_recursive_dependencies(packages, target_names):
-    to_remove = dict()
-    new_names = set(target_names)
-
-    while new_names:
-        target_names = new_names
-        new_names = set()
-
-        for pkg in packages:
-            if [r for r in pkg.requires if r[0] in target_names]:
-                to_remove[pkg.pulp_href] = pkg
-                new_names.add(pkg.name)
-                new_names.update(prov[0] for prov in pkg.provides)
-
-    return to_remove
+from ros_buildfarm.pulp import format_pkg_ver
+from ros_buildfarm.pulp import PulpRpmClient
 
 
 def main(argv=sys.argv[1:]):
@@ -65,129 +47,25 @@ def main(argv=sys.argv[1:]):
     add_argument_pulp_username(parser)
     args = parser.parse_args(argv)
 
-    pulp_config = pulp_rpm.Configuration(
-        args.pulp_base_url, username=args.pulp_username,
-        password=args.pulp_password)
+    pulp_client = PulpRpmClient(
+        args.pulp_base_url, args.pulp_username, args.pulp_password,
+        task_timeout=args.pulp_task_timeout)
 
-    # https://pulp.plan.io/issues/5932
-    pulp_config.safe_chars_for_path_param = '/'
+    with Scope('SUBSECTION', 'performing repository transaction'):
+        pkgs_added, pkgs_removed = pulp_client.import_and_invalidate(
+            args.pulp_distribution_name, args.package_resources,
+            args.invalidate_expression, args.invalidate)
 
-    pulp_rpm_client = pulp_rpm.ApiClient(pulp_config)
-    pulp_packages_api = pulp_rpm.ContentPackagesApi(pulp_rpm_client)
-    pulp_distributions_api = pulp_rpm.DistributionsRpmApi(pulp_rpm_client)
-    pulp_publications_api = pulp_rpm.PublicationsRpmApi(pulp_rpm_client)
-    pulp_repos_api = pulp_rpm.RepositoriesRpmApi(pulp_rpm_client)
+    with Scope('SUBSECTION', 'enumerating results'):
+        if not pkgs_added:
+            print('Not importing any new packages)')
+        for pkg in pkgs_added:
+            print('Importing package: %s-%s.%s' % (pkg.name, format_pkg_ver(pkg), pkg.arch))
 
-    pulp_task_poller = PulpTaskPoller(pulp_config, args.pulp_task_timeout)
-
-    with Scope('SUBSECTION', 'inspecting repository state'):
-        distribution = pulp_distributions_api.list(name=args.pulp_distribution_name).results[0]
-        print('Pulp Distribution: %s%s' % (pulp_config.host, distribution.pulp_href))
-
-        old_publication = pulp_publications_api.read(distribution.publication)
-        print('Pulp Repository: %s%s' % (pulp_config.host, old_publication.repository))
-        print('Pulp Publication (current): %s%s' % (pulp_config.host, old_publication.pulp_href))
-        print('Pulp Repository Version (current): %s%s' % (
-            pulp_config.host, old_publication.repository_version))
-
-        packages_in_version_page = pulp_packages_api.list(
-            repository_version=old_publication.repository_version, limit=200)
-        packages_in_version = {pkg.pulp_href: pkg for pkg in packages_in_version_page.results}
-        while packages_in_version_page.next:
-            packages_in_version_page = pulp_packages_api.list(
-                repository_version=old_publication.repository_version, limit=200,
-                offset=len(packages_in_version))
-            packages_in_version.update(
-                {pkg.pulp_href: pkg for pkg in packages_in_version_page.results})
-
-        assert packages_in_version_page.count == len(packages_in_version)
-        print('Found %d packages in the repository' % len(packages_in_version))
-
-        packages_to_add = {}
-        packages_to_remove = {}
-
-        # First, remove packages matching the explicit expression
-        if args.invalidate_expression:
-            compiled_expression = re.compile(args.invalidate_expression)
-            for pkg in packages_in_version.values():
-                if compiled_expression.match(pkg.name):
-                    packages_to_remove[pkg.pulp_href] = pkg
-
-        # Get the metadata for the packages we're adding
-        for package_href in args.package_resources:
-            package = packages_in_version.get(package_href) or pulp_packages_api.read(package_href)
-            print('Importing package: %s-%s%s-%s.%s' % (
-                package.name,
-                (package.epoch + ':') if package.epoch != '0' else '',
-                package.version,
-                package.release,
-                package.arch))
-
-            if package.pulp_href in packages_in_version:
-                packages_to_remove.pop(package.pulp_href, None)
-                print('Package is already present - skipping: %s%s' % (
-                    pulp_config.host, package.pulp_href))
-                continue
-
-            packages_to_add[package.pulp_href] = package
-
-    with Scope('SUBSECTION', 'determining which packages to invalidate'):
-        # Remove any packages with the same name
-        package_names = set([pkg.name for pkg in packages_to_add.values()])
-        for pkg in packages_in_version.values():
-            if pkg.name in package_names:
-                packages_to_remove[pkg.pulp_href] = pkg
-
-        if args.invalidate:
-            package_provides = package_names.union(
-                prov[0] for pkg in packages_to_add.values() for prov in pkg.provides)
-            packages_to_remove.update(
-                _get_recursive_dependencies(packages_in_version.values(), package_provides))
-
-    with Scope('SUBSECTION', 'committing changes'):
-        print('Adding %d and removing %d from the repository' % (
-            len(packages_to_add), len(packages_to_remove)))
-
-        mod_data = pulp_rpm.RepositoryAddRemoveContent(
-            add_content_units=list(packages_to_add.keys()),
-            remove_content_units=list(packages_to_remove.keys()),
-            base_version=old_publication.repository_version)
-
-        print('Packages to add:\n- %s' % (
-            '\n- '.join([pkg.location_href for pkg in packages_to_add.values()])
-            if packages_to_add else '(none)'))
-        print('Packages to remove:\n- %s' % (
-            '\n- '.join([pkg.location_href for pkg in packages_to_remove.values()])
-            if packages_to_remove else '(none)'))
-
-        mod_task_href = pulp_repos_api.modify(old_publication.repository, mod_data).task
-        mod_task = pulp_task_poller.wait_for_task(mod_task_href)
-
-        try:
-            print('Pulp Repository Version (new): %s%s' % (
-                pulp_config.host, mod_task.created_resources[0]))
-        except IndexError:
-            print('The given additions result in no changes to the repository')
-            return 0
-
-    with Scope('SUBSECTION', 'publishing changes'):
-        publish_data = pulp_rpm.RpmRpmPublication(
-            repository_version=mod_task.created_resources[0])
-
-        publish_task_href = pulp_publications_api.create(publish_data).task
-        publish_task = pulp_task_poller.wait_for_task(publish_task_href)
-
-        print('Pulp Publication (new): %s%s' % (
-            pulp_config.host, publish_task.created_resources[0]))
-
-    with Scope('SUBSECTION', 'updating distribution'):
-        distribution.publication = publish_task.created_resources[0]
-
-        distribute_task_href = pulp_distributions_api.partial_update(
-            distribution.pulp_href, distribution).task
-        pulp_task_poller.wait_for_task(distribute_task_href)
-
-        print('Finished - changes are live at %s/' % distribution.base_url)
+        if not pkgs_removed:
+            print('Not removing any existing packages')
+        for pkg in pkgs_removed:
+            print('Removing package: %s-%s.%s' % (pkg.name, format_pkg_ver(pkg), pkg.arch))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
All pulp-related scripts now call into the common class instead of importing pulp resources directly from the API client.

This allows workflows to better reuse common functionality between them than if the workflows were implemented in each script.

I'm planning to build on this work to introduce a dedicated "sync" script, instead of having separate "list" and "import" scripts that are tied together with text files.

Note that this change drops a whole bunch of console output related to pulp resources. Now that the system is up-and-running, I've found the output less useful than it was. None of the URLs were accessible due to EC2 network security anyway.