### PR TITLE
Use directory arguments on deb job scripts for decoupling

### DIFF
--- a/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
@@ -102,7 +102,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' ' + os_code_name +
         ' ' + arch +
         ' ' + ' '.join(repository_args) +
-        ' --binarypkg-dir $WORKSPACE/binarydeb' +
+        ' --binarypkg-dir /tmp/binarydeb' +
         ' --dockerfile-dir $WORKSPACE/docker_generating_docker' +
         ' --env-vars ' + ' '.join(build_environment_variables) +
         (' --append-timestamp' if append_timestamp else ''),

--- a/ros_buildfarm/templates/release/deb/sourcepkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/deb/sourcepkg_task.Dockerfile.em
@@ -68,13 +68,13 @@ cmds = [
     ' ' + os_name +
     ' ' + os_code_name +
     ' ' + ' '.join(distribution_repository_urls) +
-    ' --source-dir /tmp/sourcedeb/source',
+    ' --source-dir ' + source_dir,
 
     'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' +
     ' /tmp/ros_buildfarm/scripts/release/build_sourcedeb.py' +
     ' ' + os_name +
     ' ' + os_code_name +
-    ' --source-dir /tmp/sourcedeb/source',
+    ' --source-dir ' + source_dir,
 ]
 }@
 CMD ["@(' && '.join(cmds))"]

--- a/scripts/release/run_sourcedeb_job.py
+++ b/scripts/release/run_sourcedeb_job.py
@@ -16,6 +16,7 @@
 
 import argparse
 import copy
+import os
 import sys
 
 from ros_buildfarm.argument import \
@@ -45,8 +46,10 @@ def main(argv=sys.argv[1:]):
     add_argument_distribution_repository_key_files(parser)
     parser.add_argument(
         '--source-dir',
-        required=True,
-        help='The directory where the package sources will be stored')
+        required=False,
+        help='DEPRECATED')
+    parser.add_argument(
+        '--sourcepkg-dir', default='/tmp/sourcedeb')
     add_argument_dockerfile_dir(parser)
     args = parser.parse_args(argv)
 
@@ -59,6 +62,7 @@ def main(argv=sys.argv[1:]):
             args.distribution_repository_urls,
             args.distribution_repository_key_files),
 
+        'source_dir': os.path.join(args.sourcepkg_dir, 'source'),
         'uid': get_user_id(),
     })
     create_dockerfile(


### PR DESCRIPTION
This is the first part of a staged change to use the currently unused directory arguments to the `run_{binary,source}deb_job.py` scripts to decouple the templates from the container mount points.

Inspired by conversation in #709.