### PR TITLE
Add sync-to-main job for RPM repos

### DIFF
--- a/ros_buildfarm/templates/release/rpm/sync_packages_to_main_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sync_packages_to_main_job.xml.em
@@ -1,0 +1,72 @@
+<project>
+  <actions/>
+  <description>Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+@(SNIPPET(
+    'property_log-rotator',
+    days_to_keep=100,
+    num_to_keep=100,
+))@
+@(SNIPPET(
+    'property_job-priority',
+    priority=-1,
+))@
+@(SNIPPET(
+    'property_requeue-job',
+))@
+  </properties>
+@(SNIPPET(
+    'scm_git',
+    url=ros_buildfarm_repository.url,
+    branch_name=ros_buildfarm_repository.version or 'master',
+    relative_target_dir='ros_buildfarm',
+    refspec=None,
+))@
+  <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
+  <assignedNode>building_repository</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+@(SNIPPET(
+    'trigger_reverse-build',
+    upstream_projects=[deb_sync_to_main_job_name],
+))@
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'echo "# BEGIN SECTION: sync packages to main repos"',
+        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/release/rpm/sync_repo.py' +
+        ' --pulp-base-url http://repo:24817' +
+        ' --distribution-source-expression "^ros-testing-([^-]*-[^-]*-[^-]*(-debug)?)$"' +
+        ' --distribution-dest-expression "ros-main-\\1"' +
+        ' --package-name-expression "^ros-%s-.*"' % rosdistro_name,
+        'echo "# END SECTION"',
+    ]),
+))@
+  </builders>
+  <publishers>
+@(SNIPPET(
+    'publisher_mailer',
+    recipients=notify_emails,
+    dynamic_recipients=[],
+    send_to_individuals=False,
+))@
+  </publishers>
+  <buildWrappers>
+@(SNIPPET(
+    'credentials_binding_plugin',
+    credential_id=credential_id,
+    env_var_prefix='PULP',
+))@
+@(SNIPPET(
+    'build-wrapper_timestamper',
+))@
+  </buildWrappers>
+</project>


### PR DESCRIPTION
This job will trigger off from the deb job if present, which is why the `deb_sync_to_main_job_name` parameter was added.