### PR TITLE
Sort CI job plot groups in Jenkins job XML

### DIFF
--- a/ros_buildfarm/templates/snippet/plot_plugin.xml.em
+++ b/ros_buildfarm/templates/snippet/plot_plugin.xml.em
@@ -3,7 +3,7 @@ import html
 }@
     <hudson.plugins.plot.PlotPublisher plugin="plot@@2.1.3">
       <plots>
-@[for plot_group, plot_list in plots.items()]@
+@[for plot_group, plot_list in sorted(plots.items())]@
 @[for plot in plot_list]@
         <hudson.plugins.plot.Plot>
           <description>@(html.escape(plot.description))</description>


### PR DESCRIPTION
The order of these key/value pairs gets lost when the YAML is deserialized. Enforce alphabetical order based on the group name so that the order is consistent across runs.

The `plot_group` value is the key in the `plots` dict, so it will always be unique.