### PR TITLE
Support RPM repo sync with multiple destinations

### DIFF
--- a/ros_buildfarm/templates/release/rpm/sync_packages_to_main_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sync_packages_to_main_job.xml.em
@@ -45,7 +45,7 @@
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/release/rpm/sync_repo.py' +
         ' --pulp-base-url http://repo:24817' +
         ' --distribution-source-expression "^ros-testing-([^-]*-[^-]*-[^-]*(-debug)?)$"' +
-        ' --distribution-dest-expression "ros-main-\\1"' +
+        ' --distribution-dest-expression "^ros-main-\\1$"' +
         ' --package-name-expression "^ros-%s-.*"' % rosdistro_name,
         'echo "# END SECTION"',
     ]),

--- a/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
@@ -101,7 +101,7 @@
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/release/rpm/sync_repo.py' +
         ' --pulp-base-url http://repo:24817' +
         ' --distribution-source-expression "^ros-building-%s-%s-(SRPMS|%s(-debug)?)$"' % (os_name, os_code_name, arch) +
-        ' --distribution-dest-expression "ros-testing-%s-%s-\\1"' % (os_name, os_code_name) +
+        ' --distribution-dest-expression "^ros-testing-%s-%s-\\1$"' % (os_name, os_code_name) +
         ' --package-name-expression "^ros-%s-.*"' % rosdistro_name,
         'echo "# END SECTION"',
     ]),

--- a/scripts/release/rpm/sync_repo.py
+++ b/scripts/release/rpm/sync_repo.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import argparse
-from collections import OrderedDict
 import re
 import sys
 


### PR DESCRIPTION
This behavior is implemented by changing the 'distribution destination expression' to itself be a regular expression. The token replacement based on the source pattern which was previously implemented will still occur as before.

I plan to use this functionality as part of the "import upstream" job, where we'll want to sync packages directly into building, testing and main at the same time.

This would be a breaking change to any current deployments, but since we haven't deployed the RPM jobs anywhere official, I'd rather not stage the changes.