### PR TITLE
Don't tell apt which versions of debian packages to install

### DIFF
--- a/ros_buildfarm/templates/snippet/install_dependencies_from_file.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/install_dependencies_from_file.Dockerfile.em
@@ -1,4 +1,4 @@
 @[for install_list in install_lists]@
 COPY @(install_list) .
-RUN sed '/#.*/d' @(install_list) | xargs python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y -o Debug::pkgProblemResolver=yes
+RUN sed '/^#.*/d' @(install_list) | xargs python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y -o Debug::pkgProblemResolver=yes
 @[end for]@

--- a/ros_buildfarm/templates/snippet/install_dependencies_from_file.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/install_dependencies_from_file.Dockerfile.em
@@ -1,4 +1,4 @@
 @[for install_list in install_lists]@
 COPY @(install_list) .
-RUN xargs -a @(install_list) python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y -o Debug::pkgProblemResolver=yes
+RUN sed '/#.*/d' @(install_list) | xargs python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y -o Debug::pkgProblemResolver=yes
 @[end for]@

--- a/scripts/ci/generate_install_lists.py
+++ b/scripts/ci/generate_install_lists.py
@@ -143,18 +143,13 @@ def main(argv=sys.argv[1:]):
 
         os_pkg_names_test -= os_pkg_names_build
 
-    with Scope('SUBSECTION', 'Resolving packages versions using apt cache'):
-        apt_cache = Cache()
-        os_pkg_versions = get_binary_package_versions(
-            apt_cache, os_pkg_names_build | os_pkg_names_test)
-
     with open(os.path.join(args.output_dir, 'install_list_build.txt'), 'w') as out_file:
         for package in sorted(os_pkg_names_build):
-            out_file.write('%s=%s\n' % (package, os_pkg_versions[package]))
+            out_file.write('package\n')
 
     with open(os.path.join(args.output_dir, 'install_list_test.txt'), 'w') as out_file:
         for package in sorted(os_pkg_names_test):
-            out_file.write('%s=%s\n' % (package, os_pkg_versions[package]))
+            out_file.write('package\n')
 
 
 def get_dependencies(pkgs, label, get_dependencies_callback, target_pkgs):

--- a/scripts/ci/generate_install_lists.py
+++ b/scripts/ci/generate_install_lists.py
@@ -143,13 +143,18 @@ def main(argv=sys.argv[1:]):
 
         os_pkg_names_test -= os_pkg_names_build
 
+    with Scope('SUBSECTION', 'Resolving packages versions using apt cache'):
+        apt_cache = Cache()
+        os_pkg_versions = get_binary_package_versions(
+            apt_cache, os_pkg_names_build | os_pkg_names_test)
+
     with open(os.path.join(args.output_dir, 'install_list_build.txt'), 'w') as out_file:
         for package in sorted(os_pkg_names_build):
-            out_file.write('package\n')
+            out_file.write('%s=%s\n' % (package, os_pkg_versions[package]))
 
     with open(os.path.join(args.output_dir, 'install_list_test.txt'), 'w') as out_file:
         for package in sorted(os_pkg_names_test):
-            out_file.write('package\n')
+            out_file.write('%s=%s\n' % (package, os_pkg_versions[package]))
 
 
 def get_dependencies(pkgs, label, get_dependencies_callback, target_pkgs):

--- a/scripts/ci/generate_install_lists.py
+++ b/scripts/ci/generate_install_lists.py
@@ -150,11 +150,13 @@ def main(argv=sys.argv[1:]):
 
     with open(os.path.join(args.output_dir, 'install_list_build.txt'), 'w') as out_file:
         for package in sorted(os_pkg_names_build):
-            out_file.write('%s=%s\n' % (package, os_pkg_versions[package]))
+            out_file.write('# break docker cache %s=%s\n' % (package, os_pkg_versions[package]))
+            out_file.write('%s\n' % (package))
 
     with open(os.path.join(args.output_dir, 'install_list_test.txt'), 'w') as out_file:
         for package in sorted(os_pkg_names_test):
-            out_file.write('%s=%s\n' % (package, os_pkg_versions[package]))
+            out_file.write('# break docker cache %s=%s\n' % (package, os_pkg_versions[package]))
+            out_file.write('%s\n' % (package))
 
 
 def get_dependencies(pkgs, label, get_dependencies_callback, target_pkgs):


### PR DESCRIPTION
It looks like two nightlies failed because the versions of debian packages that are test dependencies are determined at the start of the job, but before they were actually installed they had been updated in the upstream Focal repos. This PR makes it so only the names of the dependencies are given, not the versions.

http://build.ros2.org/view/Fci/job/Fci__nightly-cyclonedds_ubuntu_focal_amd64/58
https://build.ros2.org/view/Fci/job/Fci__nightly-fastrtps_ubuntu_focal_amd64/68/


```
Reading package lists...
Invoking 'apt-get install -q -y -o Debug::pkgProblemResolver=yes clang-format=1:9.0-49 clang-tidy=1:9.0-49 cppcheck=1.90-4build1 libcppunit-dev=1.15.1-2 libcunit1-dev=2.1-3-dfsg-2build1 libxml2-utils=2.9.10+dfsg-1ubuntu3 pydocstyle=2.1.1-1 pyflakes3=2.1.1-2 python3-babeltrace=1.5.8-1build1 python3-cryptography=2.8-3 python3-flake8=3.7.9-2 python3-ifcfg=0.18-2osrf~focal python3-lxml=4.5.0-1 python3-matplotlib=3.1.2-1ubuntu3 python3-mypy=0.761-1build1 python3-nose=1.3.7-5 python3-psutil=5.5.1-1ubuntu4 python3-pycodestyle=2.5.0-2 python3-pydot=1.4.1-3 python3-pygraphviz=1.5-4build1 python3-pytest-mock=1.10.4-3 python3-rosdistro-modules=0.8.0-1'
Reading package lists...
Building dependency tree...
Reading state information...
E: Version '2.9.10+dfsg-1ubuntu3' for 'libxml2-utils' was not found
```

https://packages.ubuntu.com/focal/libxml2-utils is now `2.9.10+dfsg-4build1` upstream.