### PR TITLE
Address Travis configuration warnings and lint 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,15 +44,13 @@ dist: xenial
 language: python
 jobs:
   include:
-    - language: python
-      python: "3.6"
+    - python: "3.6"
       install:
         - pip install catkin-pkg EmPy jenkinsapi PyYAML rosdistro vcstool
         - pip install flake8 flake8-import-order pep8 pyflakes pytest
       script:
         - py.test -s test
-    - language: python
-      python: "3.6"
+    - python: "3.6"
       services:
         - docker
       env: JOB_TYPE=devel REPOSITORY_NAME=rcutils ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros2/rosdistro/ros2/index-v4.yaml
@@ -66,8 +64,7 @@ jobs:
         - generate_devel_script.py $CONFIG2_URL $ROS2_DISTRO_NAME default $REPOSITORY_NAME $OS_NAME $OS_CODE_NAME2 $ARCH > job.sh
         - . job.sh -y
         - (exit $test_result_RC)
-    - language: python
-      python: "3.6"
+    - python: "3.6"
       services:
         - docker
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="ament_cmake_ros" OVERLAY_PACKAGE_NAMES=rcutils ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros2/rosdistro/ros2/index-v4.yaml
@@ -81,8 +78,7 @@ jobs:
         - generate_prerelease_script.py $CONFIG2_URL $ROS2_DISTRO_NAME default $OS_NAME $OS_CODE_NAME2 $ARCH $UNDERLAY_REPOSITORY_NAMES --pkg $OVERLAY_PACKAGE_NAMES --output-dir .
         - . prerelease.sh -y
         - (exit $test_result_RC_underlay) && (exit $test_result_RC_overlay)
-    - language: python
-      python: "3.6"
+    - python: "3.6"
       services:
         - docker
       env: JOB_TYPE=ci UNDERLAY1_PACKAGES="ament_flake8" UNDERLAY2_PACKAGES="ament_pep257" OVERLAY_PACKAGES="ament_cmake_ros"
@@ -101,8 +97,7 @@ jobs:
         - tar -xjf ros2-$ROS2_DISTRO_NAME-linux-$OS_CODE_NAME2-$ARCH-ci.tar.bz2 -C underlay2
         - generate_ci_script.py $CONFIG2_URL $ROS2_DISTRO_NAME nightly-release $OS_NAME $OS_CODE_NAME2 $ARCH --underlay-source-path underlay1/ros2-linux underlay2/ros2-linux --package-selection-args --packages-skip-up-to $UNDERLAY1_PACKAGES $UNDERLAY2_PACKAGES --packages-up-to $OVERLAY_PACKAGES > job.sh
         - (. job.sh -y; exit $test_result_RC)
-    - language: python
-      python: "3.6"
+    - python: "3.6"
       services:
         - docker
       env: JOB_TYPE=devel BUILD_TOOL=colcon REPOSITORY_NAME=roscpp_core ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros2/rosdistro/ros2/index-v4.yaml
@@ -116,8 +111,7 @@ jobs:
         - generate_devel_script.py $CONFIG_URL $ROS_DISTRO_NAME default $REPOSITORY_NAME $OS_NAME $OS_CODE_NAME $ARCH --build-tool $BUILD_TOOL > job.sh
         - . job.sh -y
         - (exit $test_result_RC)
-    - language: python
-      python: "3.6"
+    - python: "3.6"
       services:
         - docker
       env: JOB_TYPE=devel REPOSITORY_NAME=roscpp_core
@@ -137,8 +131,7 @@ jobs:
         - . /opt/ros/kinetic/setup.sh
         - . job.sh -y
         - (exit $test_result_RC)
-    - language: python
-      python: "3.6"
+    - python: "3.6"
       services:
         - docker
       env: JOB_TYPE=doc REPOSITORY_NAME=roscpp_core
@@ -150,8 +143,7 @@ jobs:
         - generate_doc_script.py $CONFIG_URL $ROS_DISTRO_NAME default $REPOSITORY_NAME $OS_NAME $OS_CODE_NAME $ARCH > job.sh
         - sh job.sh -y
         - ls -alR generated_documentation/api_rosdoc
-    - language: python
-      python: "3.6"
+    - python: "3.6"
       services:
         - docker
       env: JOB_TYPE=release PACKAGE_NAME=rostime
@@ -163,8 +155,7 @@ jobs:
       script:
         - generate_release_script.py $CONFIG_URL $ROS_DISTRO_NAME default $PACKAGE_NAME $OS_NAME $OS_CODE_NAME $ARCH > job.sh
         - sh job.sh -y
-    - language: python
-      python: "3.6"
+    - python: "3.6"
       services:
         - docker
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="roscpp_core" OVERLAY_PACKAGE_NAMES=roscpp
@@ -183,8 +174,7 @@ jobs:
         - . /opt/ros/kinetic/setup.sh
         - . prerelease.sh -y
         - (exit $test_result_RC_underlay) && (exit $test_result_RC_overlay)
-    - language: python
-      python: "3.6"
+    - python: "3.6"
       services:
         - docker
       env: JOB_TYPE=external_prerelease
@@ -199,8 +189,7 @@ jobs:
         - git clone -b dummy_package https://github.com/ros-infrastructure/ros_buildfarm ws/src/ros_buildfarm
         - generate_prerelease_script.py $CONFIG_URL $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH --output-dir .
         - ./prerelease.sh -y
-    - language: python
-      python: "3.6"
+    - python: "3.6"
       services:
         - docker
       env: JOB_TYPE=status_pages
@@ -213,8 +202,7 @@ jobs:
         - build_release_status_page.py $CONFIG_URL $ROS_DISTRO_NAME default
         - build_repos_status_page.py $ROS_DISTRO_NAME http://packages.ros.org/ros-shadow-fixed/ubuntu http://packages.ros.org/ros/ubuntu --os-code-name-and-arch-tuples bionic:source bionic:amd64 bionic:arm64 bionic:armhf bionic:i386 --cache-dir ./debian_repo_cache --output-name melodic_bionic
         - ls -al
-    - language: python
-      python: "3.5"
+    - python: "3.5"
       services:
         - docker
       env: JOB_TYPE=devel REPOSITORY_NAME=roscpp_core
@@ -234,8 +222,7 @@ jobs:
         - . /opt/ros/kinetic/setup.sh
         - . job.sh -y
         - (exit $test_result_RC)
-    - language: python
-      python: "3.5"
+    - python: "3.5"
       services:
         - docker
       env: JOB_TYPE=doc REPOSITORY_NAME=roscpp_core
@@ -247,8 +234,7 @@ jobs:
         - generate_doc_script.py $CONFIG_URL $ROS_DISTRO_NAME default $REPOSITORY_NAME $OS_NAME $OS_CODE_NAME $ARCH > job.sh
         - sh job.sh -y
         - ls -alR generated_documentation/api_rosdoc
-    - language: python
-      python: "3.5"
+    - python: "3.5"
       services:
         - docker
       env: JOB_TYPE=release PACKAGE_NAME=rostime
@@ -260,8 +246,7 @@ jobs:
       script:
         - generate_release_script.py $CONFIG_URL $ROS_DISTRO_NAME default $PACKAGE_NAME $OS_NAME $OS_CODE_NAME $ARCH > job.sh
         - sh job.sh -y
-    - language: python
-      python: "3.5"
+    - python: "3.5"
       services:
         - docker
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="roscpp_core" OVERLAY_PACKAGE_NAMES=roscpp
@@ -280,8 +265,7 @@ jobs:
         - . /opt/ros/kinetic/setup.sh
         - . prerelease.sh -y
         - (exit $test_result_RC_underlay) && (exit $test_result_RC_overlay)
-    - language: python
-      python: "3.5"
+    - python: "3.5"
       services:
         - docker
       env: JOB_TYPE=external_prerelease
@@ -296,8 +280,7 @@ jobs:
         - git clone -b dummy_package https://github.com/ros-infrastructure/ros_buildfarm ws/src/ros_buildfarm
         - generate_prerelease_script.py $CONFIG_URL $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH --output-dir .
         - ./prerelease.sh -y
-    - language: python
-      python: "3.5"
+    - python: "3.5"
       services:
         - docker
       env: JOB_TYPE=status_pages
@@ -310,8 +293,7 @@ jobs:
         - build_release_status_page.py $CONFIG_URL $ROS_DISTRO_NAME default
         - build_repos_status_page.py $ROS_DISTRO_NAME http://packages.ros.org/ros-shadow-fixed/ubuntu http://packages.ros.org/ros/ubuntu --os-code-name-and-arch-tuples bionic:source bionic:amd64 bionic:arm64 bionic:armhf bionic:i386 --cache-dir ./debian_repo_cache --output-name melodic_bionic
         - ls -al
-    - language: python
-      python: "3.4"
+    - python: "3.4"
       services:
         - docker
       env: JOB_TYPE=devel REPOSITORY_NAME=roscpp_core
@@ -331,8 +313,7 @@ jobs:
         - . /opt/ros/kinetic/setup.sh
         - . job.sh -y
         - (exit $test_result_RC)
-    - language: python
-      python: "3.4"
+    - python: "3.4"
       services:
         - docker
       env: JOB_TYPE=doc REPOSITORY_NAME=roscpp_core
@@ -344,8 +325,7 @@ jobs:
         - generate_doc_script.py $CONFIG_URL $ROS_DISTRO_NAME default $REPOSITORY_NAME $OS_NAME $OS_CODE_NAME $ARCH > job.sh
         - sh job.sh -y
         - ls -alR generated_documentation/api_rosdoc
-    - language: python
-      python: "3.4"
+    - python: "3.4"
       services:
         - docker
       env: JOB_TYPE=release PACKAGE_NAME=rostime
@@ -357,8 +337,7 @@ jobs:
       script:
         - generate_release_script.py $CONFIG_URL $ROS_DISTRO_NAME default $PACKAGE_NAME $OS_NAME $OS_CODE_NAME $ARCH > job.sh
         - sh job.sh -y
-    - language: python
-      python: "3.4"
+    - python: "3.4"
       services:
         - docker
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="roscpp_core" OVERLAY_PACKAGE_NAMES=roscpp
@@ -377,8 +356,7 @@ jobs:
         - . /opt/ros/kinetic/setup.sh
         - . prerelease.sh -y
         - (exit $test_result_RC_underlay) && (exit $test_result_RC_overlay)
-    - language: python
-      python: "3.4"
+    - python: "3.4"
       services:
         - docker
       env: JOB_TYPE=external_prerelease
@@ -393,8 +371,7 @@ jobs:
         - git clone -b dummy_package https://github.com/ros-infrastructure/ros_buildfarm ws/src/ros_buildfarm
         - generate_prerelease_script.py $CONFIG_URL $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH --output-dir .
         - ./prerelease.sh -y
-    - language: python
-      python: "3.4"
+    - python: "3.4"
       services:
         - docker
       env: JOB_TYPE=status_pages
@@ -407,8 +384,7 @@ jobs:
         - build_release_status_page.py $CONFIG_URL $ROS_DISTRO_NAME default
         - build_repos_status_page.py $ROS_DISTRO_NAME http://packages.ros.org/ros-shadow-fixed/ubuntu http://packages.ros.org/ros/ubuntu --os-code-name-and-arch-tuples bionic:source bionic:amd64 bionic:arm64 bionic:armhf bionic:i386 --cache-dir ./debian_repo_cache --output-name melodic_bionic
         - ls -al
-    - language: python
-      python: "2.7"
+    - python: "2.7"
       services:
         - docker
       env: JOB_TYPE=devel REPOSITORY_NAME=roscpp_core
@@ -428,8 +404,7 @@ jobs:
         - . /opt/ros/kinetic/setup.sh
         - . job.sh -y
         - (exit $test_result_RC)
-    - language: python
-      python: "2.7"
+    - python: "2.7"
       services:
         - docker
       env: JOB_TYPE=doc REPOSITORY_NAME=roscpp_core
@@ -441,8 +416,7 @@ jobs:
         - generate_doc_script.py $CONFIG_URL $ROS_DISTRO_NAME default $REPOSITORY_NAME $OS_NAME $OS_CODE_NAME $ARCH > job.sh
         - sh job.sh -y
         - ls -alR generated_documentation/api_rosdoc
-    - language: python
-      python: "2.7"
+    - python: "2.7"
       services:
         - docker
       env: JOB_TYPE=release PACKAGE_NAME=rostime
@@ -454,8 +428,7 @@ jobs:
       script:
         - generate_release_script.py $CONFIG_URL $ROS_DISTRO_NAME default $PACKAGE_NAME $OS_NAME $OS_CODE_NAME $ARCH > job.sh
         - sh job.sh -y
-    - language: python
-      python: "2.7"
+    - python: "2.7"
       services:
         - docker
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="roscpp_core" OVERLAY_PACKAGE_NAMES=roscpp
@@ -477,8 +450,7 @@ jobs:
         - . /opt/ros/kinetic/setup.sh
         - . prerelease.sh -y
         - (exit $test_result_RC_underlay) && (exit $test_result_RC_overlay)
-    - language: python
-      python: "2.7"
+    - python: "2.7"
       services:
         - docker
       env: JOB_TYPE=external_prerelease
@@ -493,8 +465,7 @@ jobs:
         - git clone -b dummy_package https://github.com/ros-infrastructure/ros_buildfarm ws/src/ros_buildfarm
         - generate_prerelease_script.py $CONFIG_URL $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH --output-dir .
         - ./prerelease.sh -y
-    - language: python
-      python: "2.7"
+    - python: "2.7"
       services:
         - docker
       env: JOB_TYPE=status_pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-ros_gpg_key_add_string: &rosgpgkeyadd |
+_ros_gpg_key_add_string: &rosgpgkeyadd |
   echo '-----BEGIN PGP PUBLIC KEY BLOCK-----
 
   mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
@@ -39,12 +39,13 @@ env:
     - OS_CODE_NAME2=bionic
     - ARCH=amd64
     - ROS_BUILDFARM_PULL_REQUEST_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
+os: linux
 dist: xenial
-matrix:
+language: python
+jobs:
   include:
     - language: python
       python: "3.6"
-      sudo: false
       install:
         - pip install catkin-pkg EmPy jenkinsapi PyYAML rosdistro vcstool
         - pip install flake8 flake8-import-order pep8 pyflakes pytest
@@ -52,7 +53,6 @@ matrix:
         - py.test -s test
     - language: python
       python: "3.6"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=devel REPOSITORY_NAME=rcutils ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros2/rosdistro/ros2/index-v4.yaml
@@ -68,7 +68,6 @@ matrix:
         - (exit $test_result_RC)
     - language: python
       python: "3.6"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="ament_cmake_ros" OVERLAY_PACKAGE_NAMES=rcutils ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros2/rosdistro/ros2/index-v4.yaml
@@ -84,7 +83,6 @@ matrix:
         - (exit $test_result_RC_underlay) && (exit $test_result_RC_overlay)
     - language: python
       python: "3.6"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=ci UNDERLAY1_PACKAGES="ament_flake8" UNDERLAY2_PACKAGES="ament_pep257" OVERLAY_PACKAGES="ament_cmake_ros"
@@ -105,7 +103,6 @@ matrix:
         - (. job.sh -y; exit $test_result_RC)
     - language: python
       python: "3.6"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=devel BUILD_TOOL=colcon REPOSITORY_NAME=roscpp_core ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros2/rosdistro/ros2/index-v4.yaml
@@ -121,7 +118,6 @@ matrix:
         - (exit $test_result_RC)
     - language: python
       python: "3.6"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=devel REPOSITORY_NAME=roscpp_core
@@ -143,7 +139,6 @@ matrix:
         - (exit $test_result_RC)
     - language: python
       python: "3.6"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=doc REPOSITORY_NAME=roscpp_core
@@ -157,7 +152,6 @@ matrix:
         - ls -alR generated_documentation/api_rosdoc
     - language: python
       python: "3.6"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=release PACKAGE_NAME=rostime
@@ -171,7 +165,6 @@ matrix:
         - sh job.sh -y
     - language: python
       python: "3.6"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="roscpp_core" OVERLAY_PACKAGE_NAMES=roscpp
@@ -192,7 +185,6 @@ matrix:
         - (exit $test_result_RC_underlay) && (exit $test_result_RC_overlay)
     - language: python
       python: "3.6"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=external_prerelease
@@ -209,7 +201,6 @@ matrix:
         - ./prerelease.sh -y
     - language: python
       python: "3.6"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=status_pages
@@ -224,7 +215,6 @@ matrix:
         - ls -al
     - language: python
       python: "3.5"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=devel REPOSITORY_NAME=roscpp_core
@@ -246,7 +236,6 @@ matrix:
         - (exit $test_result_RC)
     - language: python
       python: "3.5"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=doc REPOSITORY_NAME=roscpp_core
@@ -260,7 +249,6 @@ matrix:
         - ls -alR generated_documentation/api_rosdoc
     - language: python
       python: "3.5"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=release PACKAGE_NAME=rostime
@@ -274,7 +262,6 @@ matrix:
         - sh job.sh -y
     - language: python
       python: "3.5"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="roscpp_core" OVERLAY_PACKAGE_NAMES=roscpp
@@ -295,7 +282,6 @@ matrix:
         - (exit $test_result_RC_underlay) && (exit $test_result_RC_overlay)
     - language: python
       python: "3.5"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=external_prerelease
@@ -312,7 +298,6 @@ matrix:
         - ./prerelease.sh -y
     - language: python
       python: "3.5"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=status_pages
@@ -327,7 +312,6 @@ matrix:
         - ls -al
     - language: python
       python: "3.4"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=devel REPOSITORY_NAME=roscpp_core
@@ -349,7 +333,6 @@ matrix:
         - (exit $test_result_RC)
     - language: python
       python: "3.4"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=doc REPOSITORY_NAME=roscpp_core
@@ -363,7 +346,6 @@ matrix:
         - ls -alR generated_documentation/api_rosdoc
     - language: python
       python: "3.4"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=release PACKAGE_NAME=rostime
@@ -377,7 +359,6 @@ matrix:
         - sh job.sh -y
     - language: python
       python: "3.4"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="roscpp_core" OVERLAY_PACKAGE_NAMES=roscpp
@@ -398,7 +379,6 @@ matrix:
         - (exit $test_result_RC_underlay) && (exit $test_result_RC_overlay)
     - language: python
       python: "3.4"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=external_prerelease
@@ -415,7 +395,6 @@ matrix:
         - ./prerelease.sh -y
     - language: python
       python: "3.4"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=status_pages
@@ -430,7 +409,6 @@ matrix:
         - ls -al
     - language: python
       python: "2.7"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=devel REPOSITORY_NAME=roscpp_core
@@ -452,7 +430,6 @@ matrix:
         - (exit $test_result_RC)
     - language: python
       python: "2.7"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=doc REPOSITORY_NAME=roscpp_core
@@ -466,7 +443,6 @@ matrix:
         - ls -alR generated_documentation/api_rosdoc
     - language: python
       python: "2.7"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=release PACKAGE_NAME=rostime
@@ -480,7 +456,6 @@ matrix:
         - sh job.sh -y
     - language: python
       python: "2.7"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="roscpp_core" OVERLAY_PACKAGE_NAMES=roscpp
@@ -504,7 +479,6 @@ matrix:
         - (exit $test_result_RC_underlay) && (exit $test_result_RC_overlay)
     - language: python
       python: "2.7"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=external_prerelease
@@ -521,7 +495,6 @@ matrix:
         - ./prerelease.sh -y
     - language: python
       python: "2.7"
-      sudo: required
       services:
         - docker
       env: JOB_TYPE=status_pages


### PR DESCRIPTION
Warnings:
* `root`: deprecated key `ros_gpg_key_add_string` (anchor on a non-private key)
* `jobs.include`: deprecated key `sudo` (The key `sudo` has no effect anymore.)

Infos:
* `root`: missing `os`, using the default `linux`
* `root`: missing `language`, using the default `ruby`
* `root`: key `matrix` is an alias for `jobs`, using `jobs`