### PR TITLE
Assume ros_buildfarm RPM repos will sign metadata

### DIFF
--- a/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
+++ b/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
@@ -44,7 +44,8 @@ config_opts['yum.conf'] += """
 name=ROS Buildfarm Repository @(i) - $basearch
 baseurl=@(url)
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ros-buildfarm-@(i)
-gpgcheck=@(1 if i < len(distribution_repository_keys) and distribution_repository_keys[i] else 0)
+repo_gpgcheck=@(1 if i < len(distribution_repository_keys) and distribution_repository_keys[i] else 0)
+gpgcheck=0
 enabled=1
 
 @[end for]@
@@ -52,6 +53,7 @@ enabled=1
 [ros-buildfarm-target-source]
 name=ROS Buildfarm Repository Target - SRPMS
 baseurl=@(target_repository)
+repo_gpgcheck=0
 gpgcheck=0
 enabled=0
 


### PR DESCRIPTION
Fedora and CentOS repositories contain packages that are individually GPG signed. Repository metadata is not typically signed. However, YUM and DNF support signed repository metadata.

There are two reasons that this is a good idea for ros_buildfarm, even though it deviates from the typical OS strategy:
1. It's what we're already doing in the debian repositories.
2. There is repository metadata signing support in the works for pulp.