### PR TITLE
Fine-tune the behavior of the rpm/sync_repo.py script

### DIFF
--- a/ros_buildfarm/templates/release/rpm/sync_packages_to_main_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sync_packages_to_main_job.xml.em
@@ -46,7 +46,8 @@
         ' --pulp-base-url http://repo:24817' +
         ' --distribution-source-expression "^ros-testing-([^-]*-[^-]*-[^-]*(-debug)?)$"' +
         ' --distribution-dest-expression "^ros-main-\\1$"' +
-        ' --package-name-expression "^ros-%s-.*"' % rosdistro_name,
+        ' --package-name-expression "^ros-%s-.*"' % rosdistro_name +
+        ' --invalidate-expression "^ros-%s-.*"' % rosdistro_name,
         'echo "# END SECTION"',
     ]),
 ))@

--- a/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
@@ -102,7 +102,8 @@
         ' --pulp-base-url http://repo:24817' +
         ' --distribution-source-expression "^ros-building-%s-%s-(SRPMS|%s(-debug)?)$"' % (os_name, os_code_name, arch) +
         ' --distribution-dest-expression "^ros-testing-%s-%s-\\1$"' % (os_name, os_code_name) +
-        ' --package-name-expression "^ros-%s-.*"' % rosdistro_name,
+        ' --package-name-expression "^ros-%s-.*"' % rosdistro_name +
+        ' --invalidate-expression "^ros-%s-.*"' % rosdistro_name,
         'echo "# END SECTION"',
     ]),
 ))@

--- a/scripts/release/rpm/sync_repo.py
+++ b/scripts/release/rpm/sync_repo.py
@@ -19,6 +19,7 @@ import re
 import sys
 
 from ros_buildfarm.argument import add_argument_dry_run
+from ros_buildfarm.argument import add_argument_invalidate
 from ros_buildfarm.argument import add_argument_pulp_base_url
 from ros_buildfarm.argument import add_argument_pulp_password
 from ros_buildfarm.argument import add_argument_pulp_task_timeout
@@ -32,12 +33,17 @@ def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
         description='Sync packages between pulp distributions')
     add_argument_dry_run(parser)
+    add_argument_invalidate(parser)
+    parser.add_argument(
+        '--invalidate-expression',
+        default=None,
+        help='Any existing package names matching this expression will be removed')
     add_argument_pulp_base_url(parser)
     add_argument_pulp_password(parser)
     add_argument_pulp_task_timeout(parser)
     add_argument_pulp_username(parser)
     parser.add_argument(
-        '--package-name-expression', required=True,
+        '--package-name-expression', default='.*',
         help='Expression to match against packages in the repositories')
     parser.add_argument(
         '--distribution-source-expression', required=True,
@@ -97,8 +103,8 @@ def main(argv=sys.argv[1:]):
                 len(packages_to_sync), dist_source, dist_dest,
                 ' (dry run)' if args.dry_run else ''))
             new_pkgs, pkgs_removed = pulp_client.import_and_invalidate(
-                dist_dest, packages_to_sync, args.package_name_expression,
-                False, package_cache=packages_to_sync, dry_run=args.dry_run)
+                dist_dest, packages_to_sync, args.invalidate_expression,
+                args.invalidate, package_cache=packages_to_sync, dry_run=args.dry_run)
             print('- Added %d packages%s' % (
                 len(new_pkgs), ' (dry run)' if args.dry_run else ''))
             for pkg in sorted(new_pkgs, key=lambda pkg: pkg.name):


### PR DESCRIPTION
Specifically:
* Refactor a useful portion of sync_and_invalidate to a new function
* Allow a sync to invalidate downstream packages
* Allow a sync to invalidate a different expression than the packages being imported from the source distribution
* Change the default behavior to: sync all packages packages from the source distribution and delete only packages with matching names. This makes the sync script behave in a more expected manner by default - "take the packages from here and put them there."

The motivation for this change is to support upstream repository imports. More on that in the next PR.

This change does not intentionally modify the behavior of any of the jobs.