### PR TITLE
Add RPM import_upstream job

### DIFF
--- a/ros_buildfarm/pulp.py
+++ b/ros_buildfarm/pulp.py
@@ -142,8 +142,7 @@ class PulpRpmClient:
             self._rpm_packages_api.list, repository_version=repo_ver_href)
 
     def enumerate_remotes(self):
-        return PulpPageIterator(
-            self._rpm_remotes_api.list)
+        return PulpPageIterator(self._rpm_remotes_api.list)
 
     def import_and_invalidate(
             self, distribution_name, packages_to_add,

--- a/ros_buildfarm/pulp.py
+++ b/ros_buildfarm/pulp.py
@@ -91,6 +91,7 @@ class PulpRpmClient:
         self._rpm_distributions_api = pulp_rpm.DistributionsRpmApi(self._rpm_client)
         self._rpm_packages_api = pulp_rpm.ContentPackagesApi(self._rpm_client)
         self._rpm_publications_api = pulp_rpm.PublicationsRpmApi(self._rpm_client)
+        self._rpm_remotes_api = pulp_rpm.RemotesRpmApi(self._rpm_client)
         self._rpm_repos_api = pulp_rpm.RepositoriesRpmApi(self._rpm_client)
 
     def _wait_for_task(self, task_href):
@@ -139,6 +140,10 @@ class PulpRpmClient:
     def enumerate_pkgs_in_repo_ver(self, repo_ver_href):
         return PulpPageIterator(
             self._rpm_packages_api.list, repository_version=repo_ver_href)
+
+    def enumerate_remotes(self):
+        return PulpPageIterator(
+            self._rpm_remotes_api.list)
 
     def import_and_invalidate(
             self, distribution_name, packages_to_add,
@@ -204,6 +209,24 @@ class PulpRpmClient:
             self._publish_and_distribute(distribution, mod_task.created_resources[0])
 
         return (new_pkgs.values(), pkgs_to_remove.values())
+
+    def mirror_remote_to_distribution(self, remote_name, distribution_name, dry_run=False):
+        remote = self._rpm_remotes_api.list(name=remote_name).results[0]
+        distribution = self._rpm_distributions_api.list(name=distribution_name).results[0]
+        old_publication = self._rpm_publications_api.read(distribution.publication)
+
+        sync_data = pulp_rpm.RepositorySyncURL(
+            remote=remote.pulp_href,
+            mirror=True)
+
+        if dry_run:
+            return
+
+        sync_task_href = self._rpm_repos_api.sync(old_publication.repository, sync_data).task
+        sync_task = self._wait_for_task(sync_task_href)
+
+        if sync_task.created_resources:
+            self._publish_and_distribute(distribution, sync_task.created_resources[0])
 
     def upload_pkg(self, file_path):
         relative_path = os.path.basename(file_path)

--- a/ros_buildfarm/templates/release/rpm/import_upstream_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/import_upstream_job.xml.em
@@ -1,0 +1,99 @@
+<project>
+  <actions/>
+  <description>Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+@(SNIPPET(
+    'property_log-rotator',
+    days_to_keep=365 * 3,
+    num_to_keep=1000,
+))@
+@(SNIPPET(
+    'property_job-priority',
+    priority=20,
+))@
+@(SNIPPET(
+    'property_requeue-job',
+))@
+@(SNIPPET(
+    'property_parameters-definition',
+    parameters=[
+        {
+            'type': 'string',
+            'name': 'REMOTE_SOURCE_EXPRESSION',
+            'description': 'Expression to match pulp remote repositories',
+            'default_value': '^ros-bootstrap-([^-]*-[^-]*-[^-]*(-debug)?)$',
+        },
+        {
+            'type': 'string',
+            'name': 'DISTRIBUTION_DEST_EXPRESSION',
+            'description': 'Expression to transform source remote to destination pulp distribution',
+            'default_value': '^ros-(building|testing|main)-\\1$',
+        },
+        {
+            'type': 'boolean',
+            'name': 'EXECUTE_IMPORT',
+            'description': 'If this is not true, it will only do a dry run and print the expect import, but not execute.',
+            'default_value': 'false',
+        },
+    ],
+))@
+  </properties>
+@(SNIPPET(
+    'scm_git',
+    url=ros_buildfarm_repository.url,
+    branch_name=ros_buildfarm_repository.version or 'master',
+    relative_target_dir='ros_buildfarm',
+    refspec=None,
+))@
+  <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
+  <assignedNode>building_repository</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'echo "# BEGIN SECTION: mirror repositories to pulp"',
+        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/release/rpm/mirror_repo.py' +
+        ' --pulp-base-url http://repo:24817' +
+        ' --remote-source-expression $REMOTE_SOURCE_EXPRESSION' +
+        ' --distribution-dest-expression "^\\g<0>$"',
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: sync packages from mirrors to repos"',
+        'if [ "$EXECUTE_IMPORT" != "true" ]; then DRY_RUN_ARG="--dry-run"; fi',
+        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/release/rpm/sync_repo.py' +
+        ' --pulp-base-url http://repo:24817' +
+        ' --distribution-source-expression $REMOTE_SOURCE_EXPRESSION' +
+        ' --distribution-dest-expression $DISTRIBUTION_DEST_EXPRESSION' +
+        ' $DRY_RUN_ARG',
+        'echo "# END SECTION"',
+    ]),
+))@
+  </builders>
+  <publishers>
+@(SNIPPET(
+    'publisher_mailer',
+    recipients=recipients,
+    dynamic_recipients=[],
+    send_to_individuals=False,
+))@
+  </publishers>
+  <buildWrappers>
+@(SNIPPET(
+    'credentials_binding_plugin',
+    credential_id=credential_id,
+    env_var_prefix='PULP',
+))@
+@(SNIPPET(
+    'build-wrapper_timestamper',
+))@
+  </buildWrappers>
+</project>

--- a/scripts/release/rpm/mirror_repo.py
+++ b/scripts/release/rpm/mirror_repo.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import re
+import sys
+
+from ros_buildfarm.argument import add_argument_dry_run
+from ros_buildfarm.argument import add_argument_pulp_base_url
+from ros_buildfarm.argument import add_argument_pulp_password
+from ros_buildfarm.argument import add_argument_pulp_task_timeout
+from ros_buildfarm.argument import add_argument_pulp_username
+from ros_buildfarm.common import Scope
+from ros_buildfarm.pulp import PulpRpmClient
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description='Mirror a remote RPM repository to a pulp distribution')
+    add_argument_dry_run(parser)
+    add_argument_pulp_base_url(parser)
+    add_argument_pulp_password(parser)
+    add_argument_pulp_task_timeout(parser)
+    add_argument_pulp_username(parser)
+    parser.add_argument(
+        '--remote-source-expression', required=True,
+        help='Expression to match for pulp remote names')
+    parser.add_argument(
+        '--distribution-dest-expression', required=True,
+        help='Expression to transform matching source remote names '
+             'into destination distribution names')
+    args = parser.parse_args(argv)
+
+    pulp_client = PulpRpmClient(
+        args.pulp_base_url, args.pulp_username, args.pulp_password,
+        task_timeout=args.pulp_task_timeout)
+
+    dists_to_sync = []
+    with Scope('SUBSECTION', 'enumerating remotes and distributions to sync'):
+        remote_expression = re.compile(args.remote_source_expression)
+        distributions = {dist.name for dist in pulp_client.enumerate_distributions()}
+        for remote in pulp_client.enumerate_remotes():
+            (dist_dest_pattern, matched_source) = remote_expression.subn(
+                args.distribution_dest_expression, remote.name)
+            if matched_source:
+                dist_dest_matches = [
+                    dist for dist in distributions if re.match(dist_dest_pattern, dist)]
+                if not dist_dest_matches:
+                    print(
+                        "No distributions match destination pattern '%s'" % dist_dest_pattern,
+                        file=sys.stderr)
+                    return 1
+                dists_to_sync.extend((remote.name, dist_dest) for dist_dest in dist_dest_matches)
+
+        dists_to_sync = sorted(set(dists_to_sync))
+        print('Syncing %d distributions:' % len(dists_to_sync))
+        for remote_source_dist_dest in dists_to_sync:
+            print('- %s => %s' % remote_source_dist_dest)
+
+    with Scope('SUBSECTION', 'synchronizing remotes and publishing mirrors'):
+        for remote_name, dist_name in dists_to_sync:
+            pulp_client.mirror_remote_to_distribution(remote_name, dist_name, dry_run=args.dry_run)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/release/rpm/mirror_repo.py
+++ b/scripts/release/rpm/mirror_repo.py
@@ -67,8 +67,8 @@ def main(argv=sys.argv[1:]):
 
         dists_to_sync = sorted(set(dists_to_sync))
         print('Syncing %d distributions:' % len(dists_to_sync))
-        for remote_source_dist_dest in dists_to_sync:
-            print('- %s => %s' % remote_source_dist_dest)
+        for remote_name_and_dist_dest in dists_to_sync:
+            print('- %s => %s' % remote_name_and_dist_dest)
 
     with Scope('SUBSECTION', 'synchronizing remotes and publishing mirrors'):
         for remote_name, dist_name in dists_to_sync:


### PR DESCRIPTION
Add a Jenkins job to import packages from "upstream" repositories such as the bootstrap repositories.

The pulp "sync" concept takes packages from an external repository and slaps them on top of the "latest version" of a particular repository. Since we're basing our pulp model around the distributions instead, we aren't really sure which one of the sub-repositories (building/testing/main) was the last one to create a new version. Additionally, we can't see what packages were part of the external repository - we can only see what new packages were added.

Instead of a direct "sync", I'm syncing the content from the external repository into a local mirror of the repository in pulp with the same repository name and distribution name as the pulp remote's name. I'm then invoking our existing `repo_sync.py` script to sync all of the content from that mirror into the target repositories (by default, that's any matching building/testing/main repos).

Unlike the sync-to-main job, I have not configured this job to trigger off from the deb version of the job. If someone triggers the deb import_upstream with special parameters, I don't want to trigger an unexpected RPM import as well.

Requires #778