### PR TITLE
Never skip ros_buildfarm RPM repositories

### DIFF
--- a/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
+++ b/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
@@ -47,6 +47,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ros-buildfarm-@(i)
 repo_gpgcheck=@(1 if i < len(distribution_repository_keys) and distribution_repository_keys[i] else 0)
 gpgcheck=0
 enabled=1
+skip_if_unavailable=False
 
 @[end for]@
 @[if target_repository]@
@@ -56,6 +57,7 @@ baseurl=@(target_repository)
 repo_gpgcheck=0
 gpgcheck=0
 enabled=0
+skip_if_unavailable=False
 
 @[end if]@
 """


### PR DESCRIPTION
For whatever reason, mock is skipping repositories if the metadata download fails, which is not the default behavior according to YUM.

Interestingly enough, the system-provided mock configs explicitly set this configuration to 'False' for all of the OS repositories. We should do the same.

This will give us a more accurate fatal error - a repository metadata error - instead of a cryptic "package not found".