### PR TITLE
Update repository status page to support RPM

### DIFF
--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 import argparse
 from collections import OrderedDict
 import os
@@ -259,7 +261,7 @@ def add_argument_os_name_and_os_code_name_and_arch_tuples(parser, required=True)
         nargs='+', metavar='OS_NAME:OS_CODE_NAME:ARCH',
         required=required, action=colon_separated_tuple_action(3),
         help='The colon separated tuple containing an OS name, OS code name, ' +
-             "and an architecture (e.g. 'ubuntu:trusty:amd64')")
+             "and an architecture (e.g. 'ubuntu:focal:amd64')")
 
 
 def add_argument_output_name(parser):

--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -251,7 +251,7 @@ def add_argument_os_code_name_and_arch_tuples(parser, required=True):
 def add_argument_os_name_and_os_code_name_and_arch_tuples(parser, required=True):
     parser.add_argument(
         '--os-name-and-os-code-name-and-arch-tuples',
-        nargs='+',
+        nargs='+', metavar='OS_NAME:OS_CODE_NAME:ARCH',
         required=required, action=colon_separated_tuple_action(3),
         help='The colon separated tuple containing an OS name, OS code name, ' +
              "and an architecture (e.g. 'ubuntu:trusty:amd64')")

--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -253,7 +253,7 @@ def add_argument_os_name_and_os_code_name_and_arch_tuples(parser, required=True)
         '--os-name-and-os-code-name-and-arch-tuples',
         nargs='+',
         required=required, action=colon_separated_tuple_action(3),
-        help="The colon separated tuple containing an OS name, OS code name," +
+        help='The colon separated tuple containing an OS name, OS code name, ' +
              "and an architecture (e.g. 'ubuntu:trusty:amd64')")
 
 

--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -232,19 +232,24 @@ def add_argument_not_failed_only(parser):
 
 
 def add_argument_os_code_name_and_arch_tuples(parser, required=True):
-    class _PrefixUbuntuColonAction(argparse.Action):
+    class _AddUbuntuTupleAction(argparse.Action):
         def __call__(self, parser, args, values, option_string=None):
             import sys
             print('WARNING: ' + self.help, file=sys.stderr)
+            for value in values:
+                if value.count(':') != 1:
+                    raise argparse.ArgumentError(
+                        argument=self,
+                        message='expected 2 parts separated by colons')
             setattr(
                 args, 'os_name_and_os_code_name_and_arch_tuples',
-                ['ubuntu:' + value for value in values])
+                [('ubuntu:' + value).split(':') for value in values])
             setattr(args, self.dest, values)
 
     parser.add_argument(
         '--os-code-name-and-arch-tuples',
         nargs='+',
-        required=required, action=_PrefixUbuntuColonAction,
+        required=required, action=_AddUbuntuTupleAction,
         help="DEPRECATED: Use '--os-name-and-os-code-name-and-arch-tuples'")
 
 
@@ -479,7 +484,7 @@ def colon_separated_tuple_action(numparts):
                     raise argparse.ArgumentError(
                         argument=self,
                         message='expected %d parts separated by colons' % (numparts))
-            setattr(args, self.dest, values)
+                setattr(args, self.dest, [value.split(':') for value in values])
     return ColonSeparatedTupleAction
 
 

--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -172,10 +172,16 @@ def build_release_status_page(
 def build_debian_repos_status_page(
         rosdistro_name, repo_urls, os_code_name_and_arch_tuples,
         cache_dir, output_name, output_dir):
+    os_name_and_os_code_name_and_arch_tuples = []
+    for os_code_name_and_arch in os_code_name_and_arch_tuples:
+        assert os_code_name_and_arch.count(':') == 1, \
+            'The string (%s) does not contain single colon separating an ' + \
+            'OS code name and an architecture'
+        os_code_name, arch = os_code_name_and_arch.split(':')
+        os_name_and_os_code_name_and_arch_tuples.append(('ubuntu', os_code_name, arch))
+
     return build_repos_status_page(
-        rosdistro_name, repo_urls,
-        ['ubuntu:' + os_code_name_and_arch
-         for os_code_name_and_arch in os_code_name_and_arch_tuples],
+        rosdistro_name, repo_urls, os_name_and_os_code_name_and_arch_tuples,
         cache_dir, output_name, output_dir)
 
 
@@ -186,11 +192,7 @@ def build_repos_status_page(
 
     # get targets
     targets = []
-    for os_name_and_os_code_name_and_arch in os_name_and_os_code_name_and_arch_tuples:
-        assert os_name_and_os_code_name_and_arch.count(':') == 2, \
-            'The string (%s) does not contain two colons separating an ' + \
-            'OS name, OS code name, and an architecture'
-        os_name, os_code_name, arch = os_name_and_os_code_name_and_arch.split(':')
+    for os_name, os_code_name, arch in os_name_and_os_code_name_and_arch_tuples:
         targets.append(Target(os_name, os_code_name, arch))
 
     # get all input data

--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -31,6 +31,8 @@ from .common import get_package_repo_data
 from .common import get_release_view_name
 from .common import get_short_arch
 from .common import get_short_os_code_name
+from .common import get_short_os_name
+from .common import package_format_mapping
 from .common import Target
 from .config import get_index as get_config_index
 from .config import get_release_build_files
@@ -170,16 +172,26 @@ def build_release_status_page(
 def build_debian_repos_status_page(
         rosdistro_name, repo_urls, os_code_name_and_arch_tuples,
         cache_dir, output_name, output_dir):
+    return build_repos_status_page(
+        rosdistro_name, repo_urls,
+        ['ubuntu:' + os_code_name_and_arch
+         for os_code_name_and_arch in os_code_name_and_arch_tuples],
+        cache_dir, output_name, output_dir)
+
+
+def build_repos_status_page(
+        rosdistro_name, repo_urls, os_name_and_os_code_name_and_arch_tuples,
+        cache_dir, output_name, output_dir):
     start_time = time.time()
 
     # get targets
     targets = []
-    for os_code_name_and_arch in os_code_name_and_arch_tuples:
-        assert os_code_name_and_arch.count(':') == 1, \
-            'The string (%s) does not contain single colon separating an ' + \
-            'OS code name and an architecture'
-        os_code_name, arch = os_code_name_and_arch.split(':')
-        targets.append(Target('ubuntu', os_code_name, arch))
+    for os_name_and_os_code_name_and_arch in os_name_and_os_code_name_and_arch_tuples:
+        assert os_name_and_os_code_name_and_arch.count(':') == 2, \
+            'The string (%s) does not contain two colons separating an ' + \
+            'OS name, OS code name, and an architecture'
+        os_name, os_code_name, arch = os_name_and_os_code_name_and_arch.split(':')
+        targets.append(Target(os_name, os_code_name, arch))
 
     # get all input data
     repos_data = []
@@ -277,8 +289,7 @@ def get_repos_package_descriptors(repos_data, targets):
         for repo_data in repos_data:
             repo_index = repo_data[target]
             for debian_pkg_name, version in repo_index.items():
-                version = _strip_os_code_name_suffix(
-                    version, target.os_code_name)
+                version = _strip_os_code_name_suffix(version, target)
                 if debian_pkg_name not in descriptors:
                     descriptors[debian_pkg_name] = PackageDescriptor(
                         debian_pkg_name, debian_pkg_name, version)
@@ -396,8 +407,7 @@ def get_version_status(
                 if strip_version:
                     version = _strip_version_suffix(version)
                 if strip_os_code_name:
-                    version = _strip_os_code_name_suffix(
-                        version, target.os_code_name)
+                    version = _strip_os_code_name_suffix(version, target)
 
                 if ref_version:
                     if not version:
@@ -441,9 +451,13 @@ def _strip_version_suffix(version):
     return match.group(0) if match else version
 
 
-def _strip_os_code_name_suffix(version, os_code_name):
+def _strip_os_code_name_suffix(version, target):
     if version:
-        index = version.find(os_code_name)
+        if package_format_mapping[target.os_name] == 'rpm':
+            delimiter = '.' + get_short_os_name(target.os_name) + target.os_code_name
+        else:
+            delimiter = target.os_code_name
+        index = version.find(delimiter)
         if index != -1:
             version = version[:index]
     return version

--- a/ros_buildfarm/templates/status/repos_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/repos_status_page_job.xml.em
@@ -50,7 +50,7 @@
 @{
 status_page = status_pages[status_page_name]
 debian_repository_urls = status_page['debian_repository_urls']
-os_code_name_and_arch_tuples = status_page['os_code_name_and_arch_tuples']
+os_name_and_os_code_name_and_arch_tuples = status_page['os_name_and_os_code_name_and_arch_tuples']
 }@
 @(SNIPPET(
     'builder_shell',
@@ -60,8 +60,8 @@ os_code_name_and_arch_tuples = status_page['os_code_name_and_arch_tuples']
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/status/build_repos_status_page.py' +
         ' ' + rosdistro_name +
         ' ' + ' '.join(debian_repository_urls) +
-        ' --os-code-name-and-arch-tuples ' +
-        ' '.join(os_code_name_and_arch_tuples) +
+        ' --os-name-and-os-code-name-and-arch-tuples ' +
+        ' '.join(os_name_and_os_code_name_and_arch_tuples) +
         ' --cache-dir $WORKSPACE/package_repo_cache' +
         ' --output-name %s_%s' % (rosdistro_name, status_page_name) +
         ' --output-dir $WORKSPACE/status_page',

--- a/scripts/status/build_repos_status_page.py
+++ b/scripts/status/build_repos_status_page.py
@@ -20,10 +20,11 @@ import sys
 from ros_buildfarm.argument import add_argument_cache_dir
 from ros_buildfarm.argument import add_argument_debian_repository_urls
 from ros_buildfarm.argument import add_argument_os_code_name_and_arch_tuples
+from ros_buildfarm.argument import add_argument_os_name_and_os_code_name_and_arch_tuples
 from ros_buildfarm.argument import add_argument_output_dir
 from ros_buildfarm.argument import add_argument_output_name
 from ros_buildfarm.argument import add_argument_rosdistro_name
-from ros_buildfarm.status_page import build_debian_repos_status_page
+from ros_buildfarm.status_page import build_repos_status_page
 
 
 def main(argv=sys.argv[1:]):
@@ -31,15 +32,21 @@ def main(argv=sys.argv[1:]):
         description="Run the 'repos_status_page' job")
     add_argument_rosdistro_name(parser)
     add_argument_debian_repository_urls(parser)
-    add_argument_os_code_name_and_arch_tuples(parser)
+    add_argument_os_code_name_and_arch_tuples(parser, required=False)
+    add_argument_os_name_and_os_code_name_and_arch_tuples(parser, required=False)
     add_argument_cache_dir(parser, '/tmp/package_repo_cache')
     add_argument_output_name(parser)
     add_argument_output_dir(parser)
     args = parser.parse_args(argv)
 
-    return build_debian_repos_status_page(
+    # TODO: Remove when --os-code-name-and-arch-tuples is removed
+    if not args.os_name_and_os_code_name_and_arch_tuples:
+        parser.error(
+            'the following arguments are required: --os-name-and-os-code-name-and-arch-tuples')
+
+    return build_repos_status_page(
         args.rosdistro_name, args.debian_repository_urls,
-        args.os_code_name_and_arch_tuples, args.cache_dir, args.output_name,
+        args.os_name_and_os_code_name_and_arch_tuples, args.cache_dir, args.output_name,
         args.output_dir)
 
 

--- a/scripts/status/generate_repos_status_page_job.py
+++ b/scripts/status/generate_repos_status_page_job.py
@@ -102,7 +102,7 @@ def get_targets_by_repo(config, ros_distro_name):
         targets_by_repo[target_repository] = []
         targets = target_dicts_by_repo[target_repository]
         # TODO support other OS names
-        for os_name in ['debian', 'ubuntu', 'rhel']:
+        for os_name in ['debian', 'rhel', 'ubuntu']:
             if os_name not in targets:
                 continue
             for os_code_name in sorted(targets[os_name].keys()):

--- a/scripts/status/generate_repos_status_page_job.py
+++ b/scripts/status/generate_repos_status_page_job.py
@@ -61,8 +61,8 @@ def get_job_config(args, config):
         if data is not None:
             status_pages[name] = data
         else:
-            print(("Skipping repos status page '%s' since no repository URL" +
-                   'matches any of the release build files') % name)
+            print(("Skipping repos status page '%s' since no repository URLs " +
+                   'match any of the release build files') % name)
 
     job_data = copy.deepcopy(args.__dict__)
     job_data.update({
@@ -102,14 +102,14 @@ def get_targets_by_repo(config, ros_distro_name):
         targets_by_repo[target_repository] = []
         targets = target_dicts_by_repo[target_repository]
         # TODO support other OS names
-        for os_name in ['debian', 'ubuntu']:
+        for os_name in ['debian', 'ubuntu', 'rhel']:
             if os_name not in targets:
                 continue
             for os_code_name in sorted(targets[os_name].keys()):
-                target = '%s:source' % os_code_name
+                target = '%s:%s:source' % (os_name, os_code_name)
                 targets_by_repo[target_repository].append(target)
                 for arch in sorted(targets[os_name][os_code_name].keys()):
-                    target = '%s:%s' % (os_code_name, arch)
+                    target = '%s:%s:%s' % (os_name, os_code_name, arch)
                     targets_by_repo[target_repository].append(target)
     return targets_by_repo
 
@@ -125,7 +125,7 @@ def get_status_page_data(repo_urls, targets_by_repo):
 
     data = {}
     data['debian_repository_urls'] = repo_urls
-    data['os_code_name_and_arch_tuples'] = targets
+    data['os_name_and_os_code_name_and_arch_tuples'] = targets
     return data
 
 


### PR DESCRIPTION
This change involved deprecating the existing ubuntu-specific command line argument `--os-code-name-and-arch-tuples` in place of one which conveys the OS name as well.

I tried to make all of the changes backwards-compatible, and I'll make a follow-up change to remove the deprecated parts of the code:
- Drop `add_argument_os_code_name_and_arch_tuples`
- Drop `build_debian_repos_status_page`
- Make `build_repos_status_page.py` hard-require the new argument format

I also needed to modify `_strip_os_code_name_suffix` with a special case for RPM, since the code name is just a number. I combined the short OS name with the code name, yielding something like `fc31` or `el7`, which is the release suffix the RPMs will have. As it turns out, this is exactly the right place to strip to make the ROS package versions line up correctly. Non-ROS packages look OK as well.