### PR TITLE
Refactor get_package_repo_data out of common

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -20,9 +20,6 @@ try:
 except ImportError:
     from urlparse import urlparse
 
-from .debian_repo import get_debian_repo_index
-from .rpm_repo import get_ros_rpm_repo_index
-
 
 package_format_mapping = {
     'debian': 'deb',
@@ -578,22 +575,6 @@ def get_packages_in_workspaces(workspace_roots, condition_context=None):
         for pkg in pkgs.values():
             pkg.evaluate_conditions(condition_context)
     return pkgs
-
-
-def get_package_repo_data(repository_baseurl, targets, cache_dir):
-    get_index_methods = {
-        'deb': get_debian_repo_index,
-        'rpm': get_ros_rpm_repo_index,
-    }
-
-    data = {}
-    for target in targets:
-        package_format = package_format_mapping[target.os_name]
-        get_index_method = get_index_methods[package_format]
-        index = get_index_method(
-            repository_baseurl, target, cache_dir)
-        data[target] = index
-    return data
 
 
 def get_xunit_publisher_types_and_patterns():

--- a/ros_buildfarm/package_repo.py
+++ b/ros_buildfarm/package_repo.py
@@ -1,0 +1,33 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .common import package_format_mapping
+from .debian_repo import get_debian_repo_index
+from .rpm_repo import get_ros_rpm_repo_index
+
+
+def get_package_repo_data(repository_baseurl, targets, cache_dir):
+    get_index_methods = {
+        'deb': get_debian_repo_index,
+        'rpm': get_ros_rpm_repo_index,
+    }
+
+    data = {}
+    for target in targets:
+        package_format = package_format_mapping[target.os_name]
+        get_index_method = get_index_methods[package_format]
+        index = get_index_method(
+            repository_baseurl, target, cache_dir)
+        data[target] = index
+    return data

--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -27,7 +27,6 @@ import time
 import yaml
 
 from .common import get_os_package_name
-from .common import get_package_repo_data
 from .common import get_release_view_name
 from .common import get_short_arch
 from .common import get_short_os_code_name
@@ -36,6 +35,7 @@ from .common import package_format_mapping
 from .common import Target
 from .config import get_index as get_config_index
 from .config import get_release_build_files
+from .package_repo import get_package_repo_data
 from .status_page_input import get_rosdistro_info
 from .status_page_input import RosPackage
 from .templates import expand_template

--- a/ros_buildfarm/trigger_job.py
+++ b/ros_buildfarm/trigger_job.py
@@ -20,11 +20,11 @@ from rosdistro import get_index
 
 from .common import get_binarydeb_job_name
 from .common import get_os_package_name
-from .common import get_package_repo_data
 from .common import get_sourcedeb_job_name
 from .common import Target
 from .config import get_index as get_config_index
 from .config import get_release_build_files
+from .package_repo import get_package_repo_data
 from .status_page import _strip_version_suffix
 from .templates import expand_template
 


### PR DESCRIPTION
This will allow the `*_repo.py` files to import from common.

This resolves a poor design decision I made earlier this year in #707.