### PR TITLE
Introduce a PlatformPackageDescriptor object

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -42,7 +42,7 @@ class JobValidationError(Exception):
         super(JobValidationError, self).__init__(message)
 
 
-class RepositoryPackageDescriptor(str):
+class PlatformPackageDescriptor(str):
     """
     Represents a package stored in a platform-specific package
     repository.
@@ -51,15 +51,12 @@ class RepositoryPackageDescriptor(str):
     You should not rely on this but use the `version` property instead.
 
     To be replaced with:
-    namedtuple('RepositoryPackageDescriptor', 'name version')
+    namedtuple('PlatformPackageDescriptor', 'name version')
     """
 
     @staticmethod
-    def __new__(cls, name, version):
+    def __new__(cls, version):
         return str.__new__(cls, version)
-
-    def __init__(self, name, version):
-        self.name = name
 
     @property
     def version(self):

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -42,6 +42,30 @@ class JobValidationError(Exception):
         super(JobValidationError, self).__init__(message)
 
 
+class RepositoryPackageDescriptor(str):
+    """
+    Represents a package stored in a platform-specific package
+    repository.
+
+    Currently the class is inheriting from str for backwards compatibility.
+    You should not rely on this but use the `version` property instead.
+
+    To be replaced with:
+    namedtuple('RepositoryPackageDescriptor', 'name version')
+    """
+
+    @staticmethod
+    def __new__(cls, name, version):
+        return str.__new__(cls, version)
+
+    def __init__(self, name, version):
+        self.name = name
+
+    @property
+    def version(self):
+        return str(self)
+
+
 next_scope_id = 1
 
 

--- a/ros_buildfarm/debian_repo.py
+++ b/ros_buildfarm/debian_repo.py
@@ -15,7 +15,7 @@
 import logging
 import os
 
-from .common import RepositoryPackageDescriptor
+from .common import PlatformPackageDescriptor
 from .http_cache import fetch_and_cache_gzip
 
 
@@ -46,7 +46,6 @@ def get_debian_repo_index(debian_repository_baseurl, target, cache_dir):
         versions = [l[len(prefix):] for l in lines if l.startswith(prefix)]
         version = versions[0] if len(versions) == 1 else None
 
-        package_versions[debian_pkg_name] = RepositoryPackageDescriptor(
-            debian_pkg_name, version)
+        package_versions[debian_pkg_name] = PlatformPackageDescriptor(version)
 
     return package_versions

--- a/ros_buildfarm/debian_repo.py
+++ b/ros_buildfarm/debian_repo.py
@@ -15,6 +15,7 @@
 import logging
 import os
 
+from .common import RepositoryPackageDescriptor
 from .http_cache import fetch_and_cache_gzip
 
 
@@ -45,6 +46,7 @@ def get_debian_repo_index(debian_repository_baseurl, target, cache_dir):
         versions = [l[len(prefix):] for l in lines if l.startswith(prefix)]
         version = versions[0] if len(versions) == 1 else None
 
-        package_versions[debian_pkg_name] = version
+        package_versions[debian_pkg_name] = RepositoryPackageDescriptor(
+            debian_pkg_name, version)
 
     return package_versions

--- a/ros_buildfarm/rpm_repo.py
+++ b/ros_buildfarm/rpm_repo.py
@@ -16,7 +16,7 @@ import logging
 import os
 from xml.dom import minidom
 
-from .common import RepositoryPackageDescriptor
+from .common import PlatformPackageDescriptor
 from .http_cache import fetch_and_cache_gzip
 from .http_cache import fetch_and_cache_plaintext
 
@@ -56,8 +56,8 @@ def get_rpm_repo_index(rpm_repository_baseurl, target, cache_dir):
         pkg_version_obj = pkg.getElementsByTagName('version')[0]
         pkg_version = pkg_version_obj.getAttribute('ver')
         pkg_release = pkg_version_obj.getAttribute('rel')
-        package_versions[pkg_name] = RepositoryPackageDescriptor(
-            pkg_name, pkg_version + '-' + pkg_release)
+        package_versions[pkg_name] = PlatformPackageDescriptor(
+            pkg_version + '-' + pkg_release)
 
     return package_versions
 

--- a/ros_buildfarm/rpm_repo.py
+++ b/ros_buildfarm/rpm_repo.py
@@ -16,6 +16,7 @@ import logging
 import os
 from xml.dom import minidom
 
+from .common import RepositoryPackageDescriptor
 from .http_cache import fetch_and_cache_gzip
 from .http_cache import fetch_and_cache_plaintext
 
@@ -55,7 +56,8 @@ def get_rpm_repo_index(rpm_repository_baseurl, target, cache_dir):
         pkg_version_obj = pkg.getElementsByTagName('version')[0]
         pkg_version = pkg_version_obj.getAttribute('ver')
         pkg_release = pkg_version_obj.getAttribute('rel')
-        package_versions[pkg_name] = pkg_version + '-' + pkg_release
+        package_versions[pkg_name] = RepositoryPackageDescriptor(
+            pkg_name, pkg_version + '-' + pkg_release)
 
     return package_versions
 

--- a/ros_buildfarm/templates/status/release_status_page.html.em
+++ b/ros_buildfarm/templates/status/release_status_page.html.em
@@ -189,12 +189,12 @@ if regressions and True in regressions[pkg.name].values():
 @
 @ @# a square for each repo
 @
-@ @ @[if status == 'equal' and repos_data[i][target][pkg.debian_name] == pkg.version]@
+@ @ @[if status == 'equal' and repos_data[i][target][pkg.debian_name].version == pkg.version]@
 @ @ @ <a/>@
 @ @ @[elif status in ['ignore', 'missing']]@
 @ @ @ <a class="@status[0]"/>@
 @ @ @[else]@
-@ @ @ <a class="@status[0]">@repos_data[i][target][pkg.debian_name]</a>@
+@ @ @ <a class="@status[0]">@repos_data[i][target][pkg.debian_name].version</a>@
 @ @ @[end if]@
 @ @[end for]@
 </td>@

--- a/ros_buildfarm/trigger_job.py
+++ b/ros_buildfarm/trigger_job.py
@@ -105,7 +105,7 @@ def trigger_release_jobs(
                 # check if artifact is missing
                 repo_index = repo_data[target]
                 if debian_package_name in repo_index:
-                    version = repo_index[debian_package_name]
+                    version = repo_index[debian_package_name].version
                     version = _strip_version_suffix(version)
                     if version == pkg_version:
                         print(("  Skipping job '%s' since the artifact is " +


### PR DESCRIPTION
I'd like to extract more information from the package repository metadata. To facilitate this, I'm introducing an object in place of the current package version value.

For now, I'm introducing it as a backwards-compatible `str` but this deprecated behavior will be removed in a later change.

I tried to catch every location where we're currently touching the raw package version as it was created during the repository index parsing by flagging `__str__` access in the new object, so I'm reasonably confident that I got everything.