### PR TITLE
Update import path for get_package_repo_data.

### DIFF
--- a/scripts/release/check_sync_criteria.py
+++ b/scripts/release/check_sync_criteria.py
@@ -27,10 +27,10 @@ from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.common import get_os_package_name
-from ros_buildfarm.common import get_package_repo_data
 from ros_buildfarm.common import Target
 from ros_buildfarm.config import get_index as get_config_index
 from ros_buildfarm.config import get_release_build_files
+from ros_buildfarm.package_repo import get_package_repo_data
 from rosdistro import get_distribution_file
 from rosdistro import get_index
 


### PR DESCRIPTION
https://github.com/ros-infrastructure/ros_buildfarm/pull/783 refactored this function out of common but this script didn't get the updated import path.