### PR TITLE
Don't show subpackage source packages as missing

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -51,12 +51,15 @@ class PlatformPackageDescriptor(str):
     You should not rely on this but use the `version` property instead.
 
     To be replaced with:
-    namedtuple('PlatformPackageDescriptor', 'name version')
+    namedtuple('PlatformPackageDescriptor', 'version source_name')
     """
 
     @staticmethod
-    def __new__(cls, version):
+    def __new__(cls, version, source_name):
         return str.__new__(cls, version)
+
+    def __init__(self, version, source_name):
+        self.source_name = source_name
 
     @property
     def version(self):

--- a/ros_buildfarm/debian_repo.py
+++ b/ros_buildfarm/debian_repo.py
@@ -46,6 +46,10 @@ def get_debian_repo_index(debian_repository_baseurl, target, cache_dir):
         versions = [l[len(prefix):] for l in lines if l.startswith(prefix)]
         version = versions[0] if len(versions) == 1 else None
 
-        package_versions[debian_pkg_name] = PlatformPackageDescriptor(version)
+        prefix = 'Source: '
+        source_names = [l[len(prefix):] for l in lines if l.startswith(prefix)]
+        source_name = source_names[0] if len(source_names) == 1 else None
+
+        package_versions[debian_pkg_name] = PlatformPackageDescriptor(version, source_name)
 
     return package_versions

--- a/ros_buildfarm/rpm_repo.py
+++ b/ros_buildfarm/rpm_repo.py
@@ -56,8 +56,14 @@ def get_rpm_repo_index(rpm_repository_baseurl, target, cache_dir):
         pkg_version_obj = pkg.getElementsByTagName('version')[0]
         pkg_version = pkg_version_obj.getAttribute('ver')
         pkg_release = pkg_version_obj.getAttribute('rel')
+        pkg_format = pkg.getElementsByTagName('format')[0]
+        pkg_sourcerpm = pkg_format.getElementsByTagName('rpm:sourcerpm')[0].firstChild
+        if pkg_sourcerpm:
+            pkg_source_name = pkg_sourcerpm.data.rsplit('-', 2)[0]
+        else:
+            pkg_source_name = None
         package_versions[pkg_name] = PlatformPackageDescriptor(
-            pkg_version + '-' + pkg_release)
+            pkg_version + '-' + pkg_release, pkg_source_name)
 
     return package_versions
 


### PR DESCRIPTION
Subpackages (e.x. -dev, -dbgsym) are never expected to have a source package with the same name.

This change makes the 'source' column for a subpackage appear as 'intentionally missing' instead of 'missing'.
