### PR TITLE
Don't consider source package name if not provided

### DIFF
--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -414,7 +414,8 @@ def get_version_status(
 
                 if ref_version:
                     if not version:
-                        if target.arch == 'source' and debian_pkg_name != source_pkg_name:
+                        if target.arch == 'source' and \
+                                source_pkg_name and debian_pkg_name != source_pkg_name:
                             statuses.append('ignore')
                         else:
                             statuses.append('missing')


### PR DESCRIPTION
Evidently the `Source:` value in a debian `Packages` list is not required, so we might not know what source package corresponds to a given binary package.

If we don't know for sure, list the package as 'missing' as we did before, instead of ignoring it.

Follow-up to #787