### PR TITLE
Enable package selection at build time in CI

### DIFF
--- a/scripts/ci/build_task_generator.py
+++ b/scripts/ci/build_task_generator.py
@@ -76,6 +76,7 @@ def main(argv=sys.argv[1:]):
             'python3-catkin-pkg-modules',
             'python3-colcon-metadata',
             'python3-colcon-output',
+            'python3-colcon-package-selection',
             'python3-colcon-parallel-executor',
             'python3-colcon-ros',
             'python3-colcon-test-result',


### PR DESCRIPTION
The bulk of the package selection should be done before build time using `package_selection_args`. However, with the upcoming addition of `build_tool_test_args`, we may want to select a subset of packages to test and we'll need this plugin to do it.