### PR TITLE
Support --build-tool-args in generate_ci_script.py

### DIFF
--- a/scripts/ci/generate_ci_script.py
+++ b/scripts/ci/generate_ci_script.py
@@ -23,6 +23,7 @@ from em import Hook
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_name
 from ros_buildfarm.argument import add_argument_build_tool
+from ros_buildfarm.argument import add_argument_build_tool_args
 from ros_buildfarm.argument import add_argument_config_url
 from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
@@ -31,6 +32,7 @@ from ros_buildfarm.argument import add_argument_repos_file_urls
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.argument import add_argument_skip_cleanup
 from ros_buildfarm.argument import add_argument_test_branch
+from ros_buildfarm.argument import extract_multiple_remainders
 from ros_buildfarm.ci_job import configure_ci_job
 from ros_buildfarm.common import get_ci_job_name
 from ros_buildfarm.config import get_ci_build_files
@@ -51,14 +53,19 @@ def main(argv=sys.argv[1:]):
     add_argument_arch(parser)
 
     add_argument_build_tool(parser)
-    add_argument_package_selection_args(parser)
+    a1 = add_argument_package_selection_args(parser)
+    a2 = add_argument_build_tool_args(parser)
     add_argument_repos_file_urls(parser)
     add_argument_skip_cleanup(parser)
     add_argument_test_branch(parser)
     parser.add_argument(
         '--underlay-source-path', nargs='*', metavar='DIR_NAME',
         help='Path to one or more install spaces to use as an underlay')
+
+    remainder_args = extract_multiple_remainders(argv, (a1, a2))
     args = parser.parse_args(argv)
+    for k, v in remainder_args.items():
+        setattr(args, k, v)
 
     # collect all template snippets of specific types
     class IncludeHook(Hook):
@@ -77,6 +84,8 @@ def main(argv=sys.argv[1:]):
                 self.parameters['test_branch'] = args.test_branch
             if args.package_selection_args is not None:
                 self.parameters['package_selection_args'] = ' '.join(args.package_selection_args)
+            if args.build_tool_args is not None:
+                self.parameters['build_tool_args'] = ' '.join(args.build_tool_args)
 
         def beforeInclude(self, *_, **kwargs):
             template_path = kwargs['file'].name


### PR DESCRIPTION
It would be nice to be able to change the `build_tool_args` when invoking a CI job as a script.