### PR TITLE
Allow file:// URLs to .repos files in CI jobs

### DIFF
--- a/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
@@ -49,6 +49,10 @@ RUN python3 -u /tmp/wrapper_scripts/apt.py update
 
 USER buildfarm
 
+@[for repos_file in repos_file_names]@
+COPY @repos_file /tmp/@repos_file
+@[end for]@
+
 ENTRYPOINT ["sh", "-c"]
 @{
 args = \
@@ -70,7 +74,7 @@ cmds = [
     ' /tmp/ros_buildfarm/scripts/ci/create_workspace_task_generator.py' + \
     args + \
     ' --dockerfile-dir /tmp/docker_create_workspace' + \
-    ' --repos-file-urls ' + ' '.join(repos_file_urls) + \
+    ' --repos-file-urls ' + ' '.join('file:///tmp/%s' % repos_file for repos_file in repos_file_names) + \
     ' --repository-names ' + ' '.join(repository_names) + \
     ' --test-branch "%s"' % (test_branch) + \
     ' --skip-rosdep-keys ' + ' '.join(skip_rosdep_keys) + \

--- a/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
@@ -82,6 +82,10 @@ RUN sudo -H -u buildfarm -- git config --global user.email "jenkins@@ros.invalid
 RUN echo "@now_str"
 RUN python3 -u /tmp/wrapper_scripts/apt.py update
 
+@[for repos_file in repos_file_names]@
+COPY @repos_file /tmp/@repos_file
+@[end for]@
+
 USER buildfarm
 ENTRYPOINT ["sh", "-c"]
 @{
@@ -94,7 +98,7 @@ cmds = [
     ' /tmp/ros_buildfarm/scripts/ci/create_workspace.py' + \
     ' ' + rosdistro_name + \
     ' --workspace-root ' + workspace_root[-1] + \
-    ' --repos-file-urls ' + ' '.join(repos_file_urls) + \
+    ' --repos-file-urls ' + ' '.join('file:///tmp/%s' % repos_file for repos_file in repos_file_names) + \
     ' --repository-names ' + ' '.join(repository_names) + \
     ' --test-branch "%s"' % (test_branch),
 

--- a/scripts/ci/create_workspace_task_generator.py
+++ b/scripts/ci/create_workspace_task_generator.py
@@ -15,7 +15,9 @@
 # limitations under the License.
 
 import argparse
+import os
 import sys
+from urllib.request import urlretrieve
 
 from apt import Cache
 from ros_buildfarm.argument import add_argument_arch
@@ -65,6 +67,12 @@ def main(argv=sys.argv[1:]):
 
     assert args.repos_file_urls or args.repository_names
 
+    repos_file_names = []
+    for index, repos_file_url in enumerate(args.repos_file_urls):
+        repos_file_name = 'repositories-%d.repos' % (index)
+        urlretrieve(repos_file_url, os.path.join(args.dockerfile_dir, repos_file_name))
+        repos_file_names.append(repos_file_name)
+
     debian_pkg_names = [
         'git',
         'python3-apt',
@@ -104,7 +112,7 @@ def main(argv=sys.argv[1:]):
         'dependencies': debian_pkg_names,
         'dependency_versions': debian_pkg_versions,
 
-        'repos_file_urls': args.repos_file_urls,
+        'repos_file_names': repos_file_names,
         'repository_names': args.repository_names,
         'test_branch': args.test_branch,
 

--- a/scripts/ci/run_ci_job.py
+++ b/scripts/ci/run_ci_job.py
@@ -16,7 +16,9 @@
 
 import argparse
 import copy
+import os
 import sys
+from urllib.request import urlretrieve
 
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_tool
@@ -77,12 +79,19 @@ def main(argv=sys.argv[1:]):
 
     assert args.repos_file_urls or args.repository_names
 
+    repos_file_names = []
+    for index, repos_file_url in enumerate(args.repos_file_urls):
+        repos_file_name = 'repositories-%d.repos' % (index)
+        urlretrieve(repos_file_url, os.path.join(args.dockerfile_dir, repos_file_name))
+        repos_file_names.append(repos_file_name)
+
     data = copy.deepcopy(args.__dict__)
     data.update({
         'distribution_repository_urls': args.distribution_repository_urls,
         'distribution_repository_keys': get_distribution_repository_keys(
             args.distribution_repository_urls,
             args.distribution_repository_key_files),
+        'repos_file_names': repos_file_names,
         'uid': get_user_id(),
     })
     create_dockerfile(


### PR DESCRIPTION
Everywhere a CI script takes repos file URLs, assume that the URL might only be accessible in the current context, and that it might not be valid inside of a docker container.

This has the added benefit of earlier failure when an invalid URL is given.