### PR TITLE
only show failed test numbers in chart

### DIFF
--- a/ros_buildfarm/templates/dashboard_view_devel_jobs.xml.em
+++ b/ros_buildfarm/templates/dashboard_view_devel_jobs.xml.em
@@ -48,7 +48,7 @@
       <graphHeight>220</graphHeight>
       <dateRange>0</dateRange>
       <dateShift>0</dateShift>
-      <displayStatus>ALL</displayStatus>
+      <displayStatus>FAILED</displayStatus>
     </hudson.plugins.view.dashboard.test.TestTrendChart>
   </rightPortlets>
   <topPortlets/>


### PR DESCRIPTION
For large number of tests the failing tests are almost not visible in the chart. Only showing the history of failed tests is more useful.