### PR TITLE
Allow status page jobs to run on any agent.

### DIFF
--- a/ros_buildfarm/templates/status/blocked_releases_page_job.xml.em
+++ b/ros_buildfarm/templates/status/blocked_releases_page_job.xml.em
@@ -24,7 +24,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master</assignedNode>
+  <assignedNode>agent_on_master||buildagent</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/status/blocked_source_entries_page_job.xml.em
+++ b/ros_buildfarm/templates/status/blocked_source_entries_page_job.xml.em
@@ -24,7 +24,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master</assignedNode>
+  <assignedNode>agent_on_master||buildagent</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/status/release_compare_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_compare_page_job.xml.em
@@ -24,7 +24,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master</assignedNode>
+  <assignedNode>agent_on_master||buildagent</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/status/release_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_status_page_job.xml.em
@@ -24,7 +24,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master</assignedNode>
+  <assignedNode>agent_on_master||buildagent</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/status/repos_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/repos_status_page_job.xml.em
@@ -24,7 +24,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master</assignedNode>
+  <assignedNode>agent_on_master||buildagent</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>


### PR DESCRIPTION
The status pages jobs query the public api of the repo for status and upload to a specific non-overlapping scope of files. The uploads are managed by the ssh publisher with the credentials on the master already so they will work on any agent.

With the number of status jobs and reconfigure jobs we are actually almost at 100% duty cycle for the agent_on_master instance. Allowing these to parallelize will lower the load on the master instance. It will also allow more prompt performance of the status and reconfigure jobs.

This is a rework of #327 That was closed due to incorrect logic in https://github.com/ros-infrastructure/ros_buildfarm/issues/331#issuecomment-251174703 the sync jobs run on the repository not the master (or even agent_on_master) so single threading this does not provide any protections.

Time and resources on the agents are cheaper. If anything I might even propose removing the agent_on_master to leave it available for the reconfigure and trigger jobs. These jobs run quickly so would not starve any of the other builds. And if anything will allow the master to have less resource contention which might actually increase throughput as jobs can be dispatched more effectively without having one process dedicated to generating the status pages. 

Here's a successful build on `buildagent` http://build.ros.org/job/Krel_release-status-page/23650/console
