### PR TITLE
make docker image names unique for status pages

### DIFF
--- a/ros_buildfarm/templates/status/release_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_status_page_job.xml.em
@@ -71,7 +71,7 @@
         'echo "# BEGIN SECTION: Build Dockerfile - status page"',
         'cd $WORKSPACE/docker_generate_status_page',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
-        'docker build --force-rm -t status_page_generation .',
+        'docker build --force-rm -t status_page_generation_%s_%s .' % (rosdistro_name, release_build_name),
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - status page"',
@@ -86,7 +86,7 @@
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/package_repo_cache:/tmp/package_repo_cache' +
         ' -v $WORKSPACE/status_page:/tmp/status_page' +
-        ' status_page_generation',
+        ' status_page_generation_%s_%s' % (rosdistro_name, release_build_name),
         'echo "# END SECTION"',
     ]),
 ))@


### PR DESCRIPTION
Follow up to #799 to make the docker images unique instead of overwriting the docker image and causing a potential race condition on the same host.