### PR TITLE
Avoid peak loads

### DIFF
--- a/ros_buildfarm/templates/misc/dashboard_job.xml.em
+++ b/ros_buildfarm/templates/misc/dashboard_job.xml.em
@@ -27,7 +27,7 @@
   <triggers>
 @(SNIPPET(
     'trigger_timer',
-    spec='0 */6 * * *',
+    spec='0 H/6 * * *',
 ))@
   </triggers>
   <concurrentBuild>false</concurrentBuild>

--- a/ros_buildfarm/templates/misc/rosdistro_cache_job.xml.em
+++ b/ros_buildfarm/templates/misc/rosdistro_cache_job.xml.em
@@ -32,7 +32,7 @@
   <triggers>
 @(SNIPPET(
     'trigger_timer',
-    spec='*/5 * * * *',
+    spec='H/5 * * * *',
 ))@
   </triggers>
   <concurrentBuild>false</concurrentBuild>

--- a/ros_buildfarm/templates/release/release_trigger-jobs_job.xml.em
+++ b/ros_buildfarm/templates/release/release_trigger-jobs_job.xml.em
@@ -61,7 +61,7 @@ if missed_jobs:
 @[if not missed_jobs]@
 @(SNIPPET(
     'trigger_timer',
-    spec='*/15 * * * *',
+    spec='H/15 * * * *',
 ))@
 @[else]@
 @(SNIPPET(

--- a/ros_buildfarm/templates/status/blocked_releases_page_job.xml.em
+++ b/ros_buildfarm/templates/status/blocked_releases_page_job.xml.em
@@ -32,7 +32,7 @@
   <triggers>
 @(SNIPPET(
     'trigger_timer',
-    spec='5 */6 * * *',
+    spec='5 H/6 * * *',
 ))@
   </triggers>
   <concurrentBuild>false</concurrentBuild>

--- a/ros_buildfarm/templates/status/blocked_source_entries_page_job.xml.em
+++ b/ros_buildfarm/templates/status/blocked_source_entries_page_job.xml.em
@@ -32,7 +32,7 @@
   <triggers>
 @(SNIPPET(
     'trigger_timer',
-    spec='5 */6 * * *',
+    spec='5 H/6 * * *',
 ))@
   </triggers>
   <concurrentBuild>false</concurrentBuild>

--- a/ros_buildfarm/templates/status/release_compare_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_compare_page_job.xml.em
@@ -32,7 +32,7 @@
   <triggers>
 @(SNIPPET(
     'trigger_timer',
-    spec='35 */6 * * *',
+    spec='35 H/6 * * *',
 ))@
   </triggers>
   <concurrentBuild>false</concurrentBuild>

--- a/ros_buildfarm/templates/status/release_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_status_page_job.xml.em
@@ -32,7 +32,7 @@
   <triggers>
 @(SNIPPET(
     'trigger_timer',
-    spec='*/20 * * * *',
+    spec='H/20 * * * *',
 ))@
   </triggers>
   <concurrentBuild>false</concurrentBuild>

--- a/ros_buildfarm/templates/status/repos_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/repos_status_page_job.xml.em
@@ -32,7 +32,7 @@
   <triggers>
 @(SNIPPET(
     'trigger_timer',
-    spec='H/15 * * * *',
+    spec='H * * * *',
 ))@
   </triggers>
   <concurrentBuild>false</concurrentBuild>

--- a/ros_buildfarm/templates/status/repos_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/repos_status_page_job.xml.em
@@ -32,7 +32,7 @@
   <triggers>
 @(SNIPPET(
     'trigger_timer',
-    spec='*/15 * * * *',
+    spec='H/15 * * * *',
 ))@
   </triggers>
   <concurrentBuild>false</concurrentBuild>


### PR DESCRIPTION
This will will distribute our periodic jobs out over the same period so that we don't have as much spike loading. This will not change the frequency with which they run, but will provide a more even execution.

We historically didn't do this as we wanted to know when things would run. But as we're scaling up the peak loading makes it harder for our servers. And we're still subject to unknown caching delays with github hosting and if they all run at once they don't execute exactly when scheduled because they all get into a queue anyway. 

I also noticed that we're running the repository status every 15 minutes but the release status which is our primary tool every 20 minutes because the load was too high. Slowing down the repo status page to hourly.