### PR TITLE
Disable mock bootstrapping in RPM builds

### DIFF
--- a/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
+++ b/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
@@ -3,6 +3,9 @@ include('/etc/mock/default.cfg')
 # Change the root name since we're modifying the chroot
 config_opts['root'] += '-ros-buildfarm'
 
+# Disable mock bootstrapping
+config_opts['use_bootstrap'] = False
+
 # Add python3-rpm-macros to resolve %{python3_pkgversion} in rosdep rules
 config_opts['chroot_setup_cmd'] += ' python3-rpm-macros'
 


### PR DESCRIPTION
This mock feature was enabled by default in mock 2.0. It isn't really useful to us because the Docker container always matches the mock guest OS. It also adds at least a minute to each build.