### PR TITLE
Enable mock postinstall feature in RPM builds

### DIFF
--- a/ros_buildfarm/binaryrpm_job.py
+++ b/ros_buildfarm/binaryrpm_job.py
@@ -64,6 +64,7 @@ def build_binaryrpm(
         '--no-cleanup-after',
         '--verbose',
         '--root', 'ros_buildfarm',
+        '--postinstall',
         '--rebuild', source_packages[0]]
 
     if append_timestamp:


### PR DESCRIPTION
This flag causes mock to attempt to install the packages it just built after the build succeeds. I left this feature out initially because there was a bug that caused the `--no-cleanup-after` flag to be ignored when it is used, but the fix was merged and released upstream.