### PR TITLE
Enable RPM debug packages

### DIFF
--- a/ros_buildfarm/templates/snippet/builder_parameterized-trigger.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_parameterized-trigger.xml.em
@@ -10,7 +10,7 @@
 @[if parameter_files]@
             <hudson.plugins.parameterizedtrigger.FileBuildParameters>
               <propertiesFile>@(','.join(ESCAPE(parameter_files)))</propertiesFile>
-              <failTriggerOnMissing>false</failTriggerOnMissing>
+              <failTriggerOnMissing>@(vars().get('missing_parameter_files_skip', False) ? 'true' : 'false')</failTriggerOnMissing>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
               <useMatrixChild>false</useMatrixChild>
               <onlyExactRuns>false</onlyExactRuns>


### PR DESCRIPTION
One caveat to this approach is that when a binary package is removed from the primary repository (likely due to invalidation because of an upstream package), it is not automatically removed from the debug repository. However, this is already the situation for source and binary packages, so I'm not concerned - it shouldn't cause any problems if we end up with excess symbol packages in the repository.

There are a couple of alternatives:
1. Put the symbol packages directly in the main repository and don't have a dedicated symbol repository. This works OK for some applications, but we're going to have a pretty fair amount of packages, so I'd like to keep the separate repository if possible.
2. Make the pulp scripts multi-repository aware. Currently all of the import and invalidation routines target a single repository. It's feasible that we could make them aware of all three repositories (source, binary, and debug) so that better invalidation could occur. This could also be done in a follow up if we find that the debug symbol invalidation becomes a problem.