### PR TITLE
Another Attempt at Status Aggregation

### DIFF
--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -1059,15 +1059,17 @@ def _maintainers(distro, pkg_name):
 
 
 def generate_version_breakdown(config, distros, pkg_names, cache_dir):
+
     """
-        Generates a multi-level dictionary, where
-            * the first key is the ROS distribution,
-            * the second key is the package name,
-            * the third key is the (stripped) version
-            * the value is a list of dictionaries describing the builds with the given version
-                    * The keys of this dictionary are
-                      repo, release_build, os_name, os_code_name, arch
+    Generate a multi-level dictionary describing all the versions.
+        * the first key is the ROS distribution,
+        * the second key is the package name,
+        * the third key is the (stripped) version
+        * the value is a list of dictionaries describing the builds with the given version
+                * The keys of this dictionary are
+                  repo, release_build, os_name, os_code_name, arch
     """
+
     data = {}
     for dist in distros:
         distro_data = {}
@@ -1252,16 +1254,17 @@ def _is_same_version_but_different_branch(version_a, version_b, branch_a, branch
 
 
 def _get_descriptive_build_status_helper(pkg_status, combo):
-    """
-        Given a package status and a set of dictionary keys,
-        determine if the different versions of the package can be evenly split
-        across the different values of the keys
 
-        For instance, if all the builds on main are version 0.1
-        and all the versions on build/test are 0.2,
-        that's an even split, so if the combo was just ['repo'], it would return
-        {0.1: [main], 0.2: [build/test]}
     """
+    Determine if the different versions of the package can be evenly split
+    across different values of the keys.
+
+    For instance, if all the builds on main are version 0.1
+    and all the versions on build/test are 0.2,
+    that's an even split, so if the combo was just ['repo'], it would return
+    {0.1: [main], 0.2: [build/test]}
+    """
+
     version_lookup = {}
     version_mapping = defaultdict(set)
     for version, keys in pkg_status.items():
@@ -1279,11 +1282,14 @@ def _get_descriptive_build_status_helper(pkg_status, combo):
 
 
 def _get_descriptive_build_status(pkg_status):
+
     """
-        Returns a descriptive string describing the build status, in terms of
-        which builds result in which versions. Uses a subset of the possible keys
-        to determine the cleanest split, which will result in the most concise description.
+    Build a descriptive string describing the build status.
+    Status is in terms of which builds result in which versions.
+    Use the subset of the possible keys to determine the cleanest split,
+    which will result in the most concise description.
     """
+
     keys = ['repo', 'release_build', 'os_name', 'os_code_name', 'arch']
     for num_keys in range(1, len(keys) + 1):
         for combo in itertools.combinations(keys, num_keys):

--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -1059,9 +1059,9 @@ def _maintainers(distro, pkg_name):
 
 
 def generate_version_breakdown(config, distros, pkg_names, cache_dir):
-
     """
     Generate a multi-level dictionary describing all the versions.
+
         * the first key is the ROS distribution,
         * the second key is the package name,
         * the third key is the (stripped) version
@@ -1069,7 +1069,6 @@ def generate_version_breakdown(config, distros, pkg_names, cache_dir):
                 * The keys of this dictionary are
                   repo, release_build, os_name, os_code_name, arch
     """
-
     data = {}
     for dist in distros:
         distro_data = {}
@@ -1254,8 +1253,9 @@ def _is_same_version_but_different_branch(version_a, version_b, branch_a, branch
 
 
 def _get_descriptive_build_status_helper(pkg_status, combo):
-
     """
+    Group packages statuses by keys specified in combo.
+
     Determine if the different versions of the package can be evenly split
     across different values of the keys.
 
@@ -1264,7 +1264,6 @@ def _get_descriptive_build_status_helper(pkg_status, combo):
     that's an even split, so if the combo was just ['repo'], it would return
     {0.1: [main], 0.2: [build/test]}
     """
-
     version_lookup = {}
     version_mapping = defaultdict(set)
     for version, keys in pkg_status.items():
@@ -1282,14 +1281,13 @@ def _get_descriptive_build_status_helper(pkg_status, combo):
 
 
 def _get_descriptive_build_status(pkg_status):
-
     """
     Build a descriptive string describing the build status.
+
     Status is in terms of which builds result in which versions.
     Use the subset of the possible keys to determine the cleanest split,
     which will result in the most concise description.
     """
-
     keys = ['repo', 'release_build', 'os_name', 'os_code_name', 'arch']
     for num_keys in range(1, len(keys) + 1):
         for combo in itertools.combinations(keys, num_keys):

--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -1065,20 +1065,20 @@ def generate_version_breakdown(config, distros, pkg_names, cache_dir):
             * the second key is the package name,
             * the third key is the (stripped) version
             * the value is a list of dictionaries describing the builds with the given version
-                    * The keys of this dictionary are repo, release_build, os_name, os_code_name, arch
+                    * The keys of this dictionary are
+                      repo, release_build, os_name, os_code_name, arch
     """
     data = {}
     for dist in distros:
-        rosdistro_name = dist.name
         distro_data = {}
-        for release_build_name, build_file in get_release_build_files(config, rosdistro_name).items():
+        for release_build_name, build_file in get_release_build_files(config, dist.name).items():
             targets = get_targets(build_file)
             repo_urls, repos_data = generate_urls_and_repo_data(build_file, targets, cache_dir)
 
             for repo_name, repo_data in zip(REPOS_DATA_NAMES, repos_data):
                 for target in targets:
                     for pkg_name in pkg_names:
-                        debian_pkg_name = get_os_package_name(rosdistro_name, pkg_name)
+                        debian_pkg_name = get_os_package_name(dist.name, pkg_name)
                         if debian_pkg_name not in repo_data[target]:
                             version = None
                         else:
@@ -1096,8 +1096,9 @@ def generate_version_breakdown(config, distros, pkg_names, cache_dir):
                         build_dict['repo'] = repo_name
                         distro_data[pkg_name][version].append(build_dict)
 
-        data[rosdistro_name] = distro_data
+        data[dist.name] = distro_data
     return data
+
 
 def build_generic_compare_page(
         pkgs_data, rosdistro_names,
@@ -1125,6 +1126,7 @@ def build_generic_compare_page(
 
     additional_resources(output_dir, copy_resources=copy_resources)
 
+
 def build_release_compare_page(
         config_url, rosdistro_names,
         output_dir, copy_resources=False):
@@ -1150,6 +1152,7 @@ def build_release_compare_page(
                                output_dir,
                                'compare_%s.html' % '_'.join(rosdistro_names),
                                copy_resources=copy_resources)
+
 
 def build_advanced_release_compare_page(
         config_url, rosdistro_names, cache_dir,
@@ -1254,7 +1257,8 @@ def _get_descriptive_build_status_helper(pkg_status, combo):
         determine if the different versions of the package can be evenly split
         across the different values of the keys
 
-        For instance, if all the builds on main are version 0.1 and all the versions on build/test are 0.2,
+        For instance, if all the builds on main are version 0.1
+        and all the versions on build/test are 0.2,
         that's an even split, so if the combo was just ['repo'], it would return
         {0.1: [main], 0.2: [build/test]}
     """
@@ -1273,11 +1277,12 @@ def _get_descriptive_build_status_helper(pkg_status, combo):
             version_mapping[version].add('/'.join(new_key))
     return version_mapping
 
+
 def _get_descriptive_build_status(pkg_status):
     """
-        Returns a descriptive string describing the build status, in terms of which builds result in which versions.
-        Uses a subset of the possible keys to determine the cleanest split, which will result in the most concise
-        description.
+        Returns a descriptive string describing the build status, in terms of
+        which builds result in which versions. Uses a subset of the possible keys
+        to determine the cleanest split, which will result in the most concise description.
     """
     keys = ['repo', 'release_build', 'os_name', 'os_code_name', 'arch']
     for num_keys in range(1, len(keys) + 1):
@@ -1289,7 +1294,8 @@ def _get_descriptive_build_status(pkg_status):
                     parts.append('%s: %s' % (version, ', '.join(keys)))
                 return '\n\n'.join(parts)
 
-    # The last iteration above will use ALL the keys, and thus get a nice split, but we return an error, just in case.
+    # The last iteration above will use ALL the keys,
+    # and thus get a nice split, but we return an error, just in case.
     return 'error in getting descriptive status'
 
 

--- a/ros_buildfarm/templates/status/css/status_page.css
+++ b/ros_buildfarm/templates/status/css/status_page.css
@@ -64,9 +64,9 @@ tbody tr td > a {
   line-height: inherit;
   text-indent: -2000em;
 }
-.squares a, tbody tr td > a { background: #a2d39c; }
-.squares a.m, tbody tr td > a.m { background: #f07878; }
-.squares a.l, tbody tr td > a.l { background: #7ea7d8; }
+.squares a, tbody tr td > a, span.ok { background: #a2d39c; }
+.squares a.m, tbody tr td > a.m, span.m { background: #f07878; }
+.squares a.l, tbody tr td > a.l, span.l { background: #7ea7d8; }
 .squares a.h, tbody tr td > a.h { background: #f0ac78; }
 .squares a.i, tbody tr td > a.i { background: #c8c8c8; }
 .squares a.o, tbody tr td > a.o { background: #f0f078; }

--- a/scripts/status/build_release_compare_page.py
+++ b/scripts/status/build_release_compare_page.py
@@ -24,11 +24,13 @@ try:
 except NameError:
     pass
 
+from ros_buildfarm.argument import add_argument_cache_dir
 from ros_buildfarm.argument import add_argument_config_url  # noqa
 from ros_buildfarm.argument import add_argument_older_rosdistro_names  # noqa
 from ros_buildfarm.argument import add_argument_output_dir  # noqa
 from ros_buildfarm.argument import add_argument_rosdistro_name  # noqa
 from ros_buildfarm.status_page import build_release_compare_page  # noqa
+from ros_buildfarm.status_page import build_advanced_release_compare_page
 
 
 def main(argv=sys.argv[1:]):
@@ -38,6 +40,7 @@ def main(argv=sys.argv[1:]):
     add_argument_rosdistro_name(parser)
     add_argument_older_rosdistro_names(parser)
     add_argument_output_dir(parser)
+    add_argument_cache_dir(parser, '/tmp/package_repo_cache')
     parser.add_argument(
         '--copy-resources',
         action='store_true',
@@ -54,6 +57,10 @@ def main(argv=sys.argv[1:]):
             build_release_compare_page(
                 args.config_url, [older_rosdistro_name, args.rosdistro_name],
                 args.output_dir, copy_resources=args.copy_resources)
+
+    build_advanced_release_compare_page(
+        args.config_url, args.older_rosdistro_names + [args.rosdistro_name],
+        args.cache_dir, args.output_dir, copy_resources=args.copy_resources)
 
 
 if __name__ == '__main__':

--- a/scripts/status/build_release_compare_page.py
+++ b/scripts/status/build_release_compare_page.py
@@ -29,8 +29,8 @@ from ros_buildfarm.argument import add_argument_config_url  # noqa
 from ros_buildfarm.argument import add_argument_older_rosdistro_names  # noqa
 from ros_buildfarm.argument import add_argument_output_dir  # noqa
 from ros_buildfarm.argument import add_argument_rosdistro_name  # noqa
-from ros_buildfarm.status_page import build_release_compare_page  # noqa
 from ros_buildfarm.status_page import build_advanced_release_compare_page
+from ros_buildfarm.status_page import build_release_compare_page  # noqa
 
 
 def main(argv=sys.argv[1:]):


### PR DESCRIPTION
Another approach to #555 and #567. This time it reuses much more of the existing infrastructure and more closely mirrors the existing compare page. 

![Preview](https://user-images.githubusercontent.com/1016143/84221494-59ba6380-aaa3-11ea-8faa-d8b23f24a408.png)

[Click here](http://metrorobots.com/active_compare.html) for a static version of the generated content.

The color indicates the (worst) status across all builds, with more information in the title text (which is hard to show in a screenshot). 

For example, hovering over `gencpp/kinetic` gets: `0.6.0-0: build/test/main`
`genjava/kinetic` gets:
```
0.3.4-0: i386, amd64, source

missing: armhf, arm64
```
and `genmsg/melodic` gets 
```
0.5.16-1: build, test

0.5.15-1: main
```



It may be easier to review commit by commit:

 * [Minor refactoring](https://github.com/ros-infrastructure/ros_buildfarm/commit/1f0c22754652e26a2ca12797df1ca4a22d2f69d5) - No functional changes to the output, but creates reusable functions
 * [Advanced Release Compare Page](https://github.com/ros-infrastructure/ros_buildfarm/commit/a0cb8357a1bf53afdc4406f10a1f34a708a927aa) - Changes to `status_page.py` and `status_page.css` to create the new aggregated status page. 
 * [Build Advanced compare page in job](https://github.com/ros-infrastructure/ros_buildfarm/commit/31adb6e98923ffe494e244ad1cfd7473f26cfea5) - Tacks on the new status page to the existing `build_release_compare_page.py`. I don't know what the methodology is between what requires a new job and not, so I just tacked it on here. I'd be happy to create an independent job if desired. 

The new page combines information from all of the status pages and the compare pages, so its not the quickest job ever. On my machine, generating `compare_melodic_noetic.html` took 7.2 seconds. Generating `active_compare.html` takes 12.6 seconds. 

Compared to prior versions of similar functionality, this PR
 * Does not rely on the generated `yaml` files, and instead uses the existing status page infrastructure for determining active version numbers, and therefore [does not require additional configuration](https://github.com/ros-infrastructure/ros_buildfarm/pull/567/files/6408099803c40caba27fb1a3b0124432bd9a684f#diff-cfb5a84b2689368cb65183029d0748fd)
* Uses a more general descriptive status compared to [the previously biased perspective](https://github.com/ros-infrastructure/ros_buildfarm/pull/567/files/6408099803c40caba27fb1a3b0124432bd9a684f#diff-cfb5a84b2689368cb65183029d0748fd). 
