### PR TITLE
[colcon] read stdout_stderr.log from build steps to extract CMake / compiler warnings

### DIFF
--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -421,6 +421,7 @@ parameters = [
   <publishers>
 @(SNIPPET(
     'publisher_warnings',
+    build_tool=build_tool,
     unstable_threshold='',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -268,6 +268,7 @@ if pull_request:
   <publishers>
 @(SNIPPET(
     'publisher_warnings',
+    build_tool=build_tool,
     unstable_threshold=1 if notify_compiler_warnings else '',
 ))@
 @[if xunit_publisher_types]@

--- a/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
@@ -3,14 +3,14 @@
     <io.jenkins.plugins.analysis.warnings.Cmake>
       <id></id>
       <name></name>
-      <pattern></pattern>
+      <pattern>@[if build_tool == 'colcon']ws/log/build_*/*/stdout_stderr.log@[end if]</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.Cmake>
     <io.jenkins.plugins.analysis.warnings.Gcc4>
       <id></id>
       <name></name>
-      <pattern></pattern>
+      <pattern>@[if build_tool == 'colcon']ws/log/build_*/*/stdout_stderr.log@[end if]</pattern>
       <reportEncoding></reportEncoding>
       <skipSymbolicLinks>false</skipSymbolicLinks>
     </io.jenkins.plugins.analysis.warnings.Gcc4>


### PR DESCRIPTION
Same as ros2/ci#477. Addresses ros2/ci#316 on build.ros[2].org for jobs which use `colcon`.

Before: [![Build Status](http://build.ros2.org/buildStatus/icon?job=Edev__gazebo_ros_pkgs__ubuntu_bionic_amd64&build=17)](http://build.ros2.org/job/Edev__gazebo_ros_pkgs__ubuntu_bionic_amd64/17/) (50 *false positive* compiler warnings, 1 test failure)
After: [![Build Status](http://build.ros2.org/buildStatus/icon?job=Edev__gazebo_ros_pkgs__ubuntu_bionic_amd64&build=18)](http://build.ros2.org/job/Edev__gazebo_ros_pkgs__ubuntu_bionic_amd64/18/) (*no* compiler warnings, 1 test failure)