### PR TITLE
only pass catkin specific CMake definition for ROS 1 jobs

### DIFF
--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -115,7 +115,8 @@ if not testing:
 else:
     cmd += \
         ' /tmp/ros_buildfarm/scripts/devel/build_and_test.py' + \
-        ' --rosdistro-name %s' % rosdistro_name
+        ' --rosdistro-name %s' % rosdistro_name + \
+        ' --ros-version ' + str(ros_version)
     if require_gpu_support:
         cmd += ' --require-gpu-support'
 cmd += \

--- a/scripts/devel/build_and_install.py
+++ b/scripts/devel/build_and_install.py
@@ -103,9 +103,12 @@ def main(argv=sys.argv[1:]):
             parent_result_spaces = None
             if args.parent_result_space:
                 parent_result_spaces = args.parent_result_space
+            cmake_args = ['-DBUILD_TESTING=0']
+            if args.ros_version == 1:
+                cmake_args.append('-DCATKIN_SKIP_TESTING=1')
             rc = call_build_tool(
                 args.build_tool, args.rosdistro_name, args.workspace_root,
-                cmake_args=['-DBUILD_TESTING=0', '-DCATKIN_SKIP_TESTING=1'],
+                cmake_args=cmake_args,
                 args=args.build_tool_args,
                 install=True,
                 parent_result_spaces=parent_result_spaces, env=env)

--- a/scripts/devel/build_and_test.py
+++ b/scripts/devel/build_and_test.py
@@ -22,6 +22,7 @@ from ros_buildfarm.argument import add_argument_build_tool
 from ros_buildfarm.argument import add_argument_build_tool_args
 from ros_buildfarm.argument import add_argument_build_tool_test_args
 from ros_buildfarm.argument import add_argument_require_gpu_support
+from ros_buildfarm.argument import add_argument_ros_version
 from ros_buildfarm.argument import extract_multiple_remainders
 from ros_buildfarm.common import Scope
 from ros_buildfarm.workspace import call_build_tool
@@ -38,6 +39,7 @@ def main(argv=sys.argv[1:]):
         required=True,
         help='The name of the ROS distro to identify the setup file to be '
              'sourced (if available)')
+    add_argument_ros_version(parser)
     add_argument_build_tool(parser, required=True)
     a1 = add_argument_build_tool_args(parser)
     a2 = add_argument_build_tool_test_args(parser)
@@ -78,10 +80,11 @@ def main(argv=sys.argv[1:]):
         with Scope('SUBSECTION', 'build workspace in isolation'):
             test_results_dir = os.path.join(
                 args.workspace_root, 'test_results')
-            cmake_args = [
-                '-DBUILD_TESTING=1',
-                '-DCATKIN_ENABLE_TESTING=1', '-DCATKIN_SKIP_TESTING=0',
-                '-DCATKIN_TEST_RESULTS_DIR=%s' % test_results_dir]
+            cmake_args = ['-DBUILD_TESTING=1']
+            if args.ros_version == 1:
+                cmake_args += [
+                    '-DCATKIN_ENABLE_TESTING=1', '-DCATKIN_SKIP_TESTING=0',
+                    '-DCATKIN_TEST_RESULTS_DIR=%s' % test_results_dir]
             additional_args = args.build_tool_args or []
             if args.build_tool == 'colcon':
                 additional_args += ['--test-result-base', test_results_dir]


### PR DESCRIPTION
This avoid the following type of CMake warning in ROS 2 jobs:

> Manually-specified variables were not used by the project: