### PR TITLE
clear log directory before / after a build

### DIFF
--- a/ros_buildfarm/workspace.py
+++ b/ros_buildfarm/workspace.py
@@ -40,6 +40,9 @@ def clean_workspace(workspace_root):
     test_results_dir = os.path.join(workspace_root, 'test_results')
     if os.path.exists(test_results_dir):
         shutil.rmtree(test_results_dir)
+    log_dir = os.path.join(workspace_root, 'log')
+    if os.path.exists(log_dir):
+        shutil.rmtree(log_dir)
 
 
 def call_build_tool(


### PR DESCRIPTION
Follow up of #812 

When parsing the `stdout_stderr.log` files to extract warnings it needs to be made that no log files from previous builds are still in the workspace.