### PR TITLE
Add a new rosdistro audit tool for release managers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -517,5 +517,28 @@ jobs:
         - build_release_status_page.py $CONFIG_URL $ROS_DISTRO_NAME default
         - build_repos_status_page.py $ROS_DISTRO_NAME http://packages.ros.org/ros-shadow-fixed/ubuntu http://packages.ros.org/ros/ubuntu --os-code-name-and-arch-tuples bionic:source bionic:amd64 bionic:arm64 bionic:armhf bionic:i386 --cache-dir ./debian_repo_cache --output-name melodic_bionic
         - ls -al
+    - python: "2.7"
+      services:
+        - docker
+      env: JOB_TYPE=rosdistro_audit
+      before_script:
+        # pin pyparsing to the last version that supports Python 3.4 and below
+        # see https://github.com/pyparsing/pyparsing/blob/72f2c5a67b4a26f584104b9ff63e1f272f54c5df/CHANGES#L5-L9
+        - pip install pyparsing==2.4.7
+        - python setup.py install
+      script:
+        - audit_rosdistro.py $CONFIG_URL $ROS_DISTRO_NAME --return-zero
+        - audit_rosdistro.py $CONFIG2_URL $ROS2_DISTRO_NAME --return-zero
+    - python: "3.6"
+      services:
+        - docker
+      env: JOB_TYPE=rosdistro_audit
+      before_script:
+        - python setup.py install
+      script:
+        - audit_rosdistro.py $CONFIG_URL $ROS_DISTRO_NAME --return-zero
+        - audit_rosdistro.py $CONFIG2_URL $ROS2_DISTRO_NAME --return-zero
+        - check_sync_criteria.py $CONFIG_URL $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH
+        - check_sync_criteria.py $CONFIG2_URL $ROS2_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -15,3 +15,13 @@ to configure the jobs being generated (e.g.
 If you are going to use any of the provided infrastructure please consider
 watching the [buildfarm Discourse category](https://discourse.ros.org/c/buildfarm)
 in order to receive notifications e.g. about any upcoming changes.
+
+For quick reference to run scripts:
+
+ ## Check Sync Criteria
+
+    ./scripts/release/check_sync_criteria.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml melodic default ubuntu bionic amd64
+
+## Audit rosdistro
+
+    ./scripts/release/audit_rosdistro.py --cache-dir /tmp/rosdistrocache https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml noetic

--- a/doc/ongoing_operations.rst
+++ b/doc/ongoing_operations.rst
@@ -40,14 +40,30 @@ The sync to the ``main`` repository affects all architectures.
 Guidelines for gating a sync to main
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When preparing for a sync it is recommended to review the
-*release status page*.
-There are filters for viewing regressions, and what packages will sync if the
-sync to main is run as well as the ability to search.
+There is a manual process to go from testing to main.
+We refer to this as a sync.
 
-Note: A version downgrade is also marked as a regression since if users have
-already installed the previous package with the higher version number apt will
-not install the newer package with a lower version automatically.
+When you are preparing for a sync:
+
+* Run the ``rosdistro_audit.py`` script.
+  It will output text which is appropriate for posting to Discourse as a triage list.
+  The ``rosdistro_audit.py`` will report all packages which are failing to build for a whole buildfile.
+
+  * If it's failing on specific architectures, ticket it upstream and blacklist it in the config with a cross reference.
+  * If it's failing on all platforms, rollback or remove the release from the distro.
+* Check the list of packages comes from the status page, e.g. http://repositories.ros.org/status_page/ros_melodic_default.html
+  Click “REGRESSION” to find the list of regressions, click “SYNC” to see how many packages there are to sync.
+  Make sure there are no major regressions and ticket any with the maintainers.
+
+  Note: A version downgrade is also marked as a regression since apt will not automatically install a newer package with a lower version.
+
+* Announce the intent to sync with the above information.
+  Example: https://discourse.ros.org/t/preparing-for-kinetic-sync-2020-08-20/16002/5
+
+* After a period of time for resolving the identified issues above run the sync on Jenkins.
+* Once sync is done: announce on discourse. The details of the sync is in the console output of the "sync to main" job (make sure to not take the ones that generate debug packages otherwise the package count is off by a factor 2)
+* Tag the rosdistro with the format ``ROSDISTRO/YYYY-MM-DD``
+
 
 Importing new upstream packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -474,6 +474,14 @@ def add_argument_testing(parser):
              'them.')
 
 
+def add_argument_return_zero(parser):
+    parser.add_argument(
+        '--return-zero', action='store_true',
+        help='Always return zero, success, even if there are errors. '
+             'This is used for testing, and scripting. It is not generally'
+             ' recommended for use.')
+
+
 def check_len_action(minargs, maxargs):
     class CheckLength(argparse.Action):
 

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -649,14 +649,26 @@ def get_downstream_package_names(pkg_names, dependencies):
     return downstream_pkg_names
 
 
-def get_implicitly_ignored_package_names(cached_pkgs, explicitly_ignored_pkg_names):
-    pkg_names = set(cached_pkgs.keys())
+def get_package_manifests(dist):
+    cached_pkgs = {}
+    for pkg_name in dist.release_packages.keys():
+        pkg_xml = dist.get_release_package_xml(pkg_name)
+        if pkg_xml is not None:
+            from catkin_pkg.package import InvalidPackage, parse_package_string
+            try:
+                pkg_manifest = parse_package_string(pkg_xml)
+            except InvalidPackage:
+                continue
+            cached_pkgs[pkg_name] = pkg_manifest
+    return cached_pkgs
 
+
+def get_implicitly_ignored_package_names(cached_pkgs, explicitly_ignored_pkg_names):
     # get direct dependencies from distro cache for each package
     direct_dependencies = {}
-    for pkg_name in pkg_names:
+    for pkg_name in cached_pkgs.keys():
         direct_dependencies[pkg_name] = get_direct_dependencies(
-            pkg_name, cached_pkgs, pkg_names) or set([])
+            pkg_name, cached_pkgs, cached_pkgs) or set([])
 
     # find recursive downstream deps for all explicitly ignored packages
     ignored_pkg_names = set(explicitly_ignored_pkg_names)
@@ -669,6 +681,46 @@ def get_implicitly_ignored_package_names(cached_pkgs, explicitly_ignored_pkg_nam
         break
 
     return ignored_pkg_names.difference(explicitly_ignored_pkg_names)
+
+
+def filter_blocked_dependent_package_names(cached_pkgs, failed_pkg_names):
+    """Return the list of packages that are missing and not blocked.
+
+    Return the list of packages that are missing that are not depending
+    on other missing packages.
+    """
+    # get direct dependencies from distro cache for each package
+    direct_dependencies = {}
+    for pkg_name in cached_pkgs:
+        direct_dependencies[pkg_name] = get_direct_dependencies(
+            pkg_name, cached_pkgs, cached_pkgs) or set([])
+
+    # find recursive downstream deps for all explicitly ignored packages
+    all_deps = get_downstream_package_names(
+            failed_pkg_names, direct_dependencies)
+    while True:
+        blocked_pkgs = get_downstream_package_names(
+            all_deps, direct_dependencies)
+        if blocked_pkgs - all_deps:
+            all_deps |= blocked_pkgs
+            continue
+        break
+
+    return failed_pkg_names.difference(all_deps)
+
+
+def filter_buildfile_packages_recursively(package_names, buildfile, rosdistro_name):
+    """Filter packages based on the build including recursively blocked packages.
+
+    Filter a list of packages based on a build file's blacklist and whitelist
+    including implicit blacklisting of dependent packages for a specific rosdistro.
+    """
+    res = buildfile.filter_packages(package_names)
+    cached_pkgs = get_package_manifests(rosdistro_name)
+    implicitly_ignored = get_implicitly_ignored_package_names(
+        cached_pkgs, buildfile.package_blacklist)
+    res -= implicitly_ignored
+    return res
 
 
 def get_package_condition_context(index, rosdistro_name):

--- a/ros_buildfarm/config/build_file.py
+++ b/ros_buildfarm/config/build_file.py
@@ -15,6 +15,8 @@
 import json
 from xml.etree import ElementTree
 
+from ros_buildfarm.common import Target
+
 
 class BuildFile(object):
 
@@ -94,6 +96,16 @@ class BuildFile(object):
                 res.append(dist_file)
 
         return res
+
+    def get_targets_list(self):
+        target_list = []
+        for os_name, os_name_v in self.targets.items():
+            if os_name == '_config':
+                continue
+            for os_code_name, os_code_name_v in os_name_v.items():
+                for arch in os_code_name_v.keys():
+                    target_list.append(Target(os_name, os_code_name, arch))
+        return target_list
 
     def _assert_valid_benchmark_schema(self):
         assert isinstance(self.benchmark_schema, str)

--- a/ros_buildfarm/status_page_input.py
+++ b/ros_buildfarm/status_page_input.py
@@ -16,6 +16,7 @@ from collections import namedtuple
 
 from .common import get_implicitly_ignored_package_names
 from .common import get_os_package_name
+from .common import get_package_manifests
 
 MaintainerDescriptor = namedtuple('Maintainer', 'name email')
 
@@ -40,16 +41,7 @@ class RosPackage(object):
 
 def get_rosdistro_info(dist, build_file):
     pkg_names = dist.release_packages.keys()
-    cached_pkgs = {}
-    for pkg_name in pkg_names:
-        pkg_xml = dist.get_release_package_xml(pkg_name)
-        if pkg_xml is not None:
-            from catkin_pkg.package import InvalidPackage, parse_package_string
-            try:
-                pkg_manifest = parse_package_string(pkg_xml)
-            except InvalidPackage:
-                continue
-            cached_pkgs[pkg_name] = pkg_manifest
+    cached_pkgs = get_package_manifests(dist)
 
     filtered_pkg_names = build_file.filter_packages(pkg_names)
     explicitly_ignored_pkg_names = set(pkg_names) - set(filtered_pkg_names)

--- a/scripts/release/audit_rosdistro.py
+++ b/scripts/release/audit_rosdistro.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+import copy
+import sys
+
+from ros_buildfarm.argument import add_argument_cache_dir
+from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_return_zero
+from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.config import get_index as get_config_index
+from ros_buildfarm.config import get_release_build_files
+from ros_buildfarm.release_job import partition_packages
+from ros_buildfarm.status_page import get_jenkins_job_urls
+from rosdistro import get_distribution_cache
+from rosdistro import get_distribution_file
+from rosdistro import get_index
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description='Audit the rosdistro for packages failing to build.')
+    add_argument_config_url(parser)
+    add_argument_rosdistro_name(parser)
+    add_argument_cache_dir(parser, '/tmp/package_repo_cache')
+    add_argument_return_zero(parser)
+    args = parser.parse_args(argv)
+
+    recommended_action_count = run_audit(args.config_url, args.rosdistro_name, args.cache_dir)
+    return 1 if recommended_action_count and not args.return_zero else 0
+
+
+def run_audit(config_url, rosdistro_name, cache_dir):
+    config = get_config_index(config_url)
+    index = get_index(config.rosdistro_index_url)
+    dist_file = get_distribution_file(index, rosdistro_name)
+    dist_cache = get_distribution_cache(index, rosdistro_name)
+    build_files = get_release_build_files(config, rosdistro_name)
+    missing_packages = {}
+    for bf_name, bf_value in build_files.items():
+        missing_packages[bf_name] = copy.deepcopy(bf_value.targets)
+        for target in bf_value.get_targets_list():
+            all_pkgs, missing_pkgs = partition_packages(
+                config_url, rosdistro_name, bf_name, target, cache_dir,
+                deduplicate_dependencies=True, dist_cache=dist_cache)
+            missing_packages[bf_name][target] = missing_pkgs
+            if 'all' in missing_packages[bf_name]:
+                missing_packages[bf_name]['all'] &= missing_pkgs
+            else:
+                missing_packages[bf_name]['all'] = missing_pkgs
+
+            if 'all' in missing_packages:
+                missing_packages['all'] &= missing_pkgs
+            else:
+                missing_packages['all'] = missing_pkgs
+
+    recommended_actions = len(missing_packages['all'])
+    print('# Sync preparation report for %s' % rosdistro_name)
+    print('Prepared for configuration: %s' % config_url)
+    print('Prepared for rosdistro index: %s' % config.rosdistro_index_url)
+    print('\n\n')
+
+    if missing_packages['all']:
+        print('## Packages failing on all platforms\n\n'
+              'These releases are recommended to be rolled back:\n')
+        for mp in sorted(missing_packages['all']):
+            print(' - %s ' % mp)
+        print('\n\n')
+    else:
+        print('## No packages detected failing on all platforms\n\n')
+
+    def get_package_repository_link(dist_file, pkg_name):
+        """Return the best guess of the url for filing a ticket against the package."""
+        pkg = dist_file.release_packages[pkg_name]
+        repo_name = pkg.repository_name
+        repo = dist_file.repositories[repo_name]
+        if repo.source_repository and repo.source_repository.url:
+            return repo.source_repository.url
+        if repo.release_repository and repo.release_repository.url:
+            return repo.release_repository.url
+        return None
+
+    for bf_name in build_files.keys():
+        print('## Audit of buildfile %s\n\n' % bf_name)
+        # TODO(tfoote) use rosdistro API to print the release build config for editing
+        recommended_blacklists = sorted(missing_packages[bf_name]['all'] - missing_packages['all'])
+        recommended_actions += len(recommended_blacklists)
+        if not recommended_blacklists:
+            print('Congratulations! '
+                  'No packages are failing to build on all targets for this buildfile.\n\n')
+            continue
+        print('Attention! '
+              'The following packages are failing to build on all targets for this buildfile. '
+              'It is recommended to blacklist them in the buildfile.\n\n')
+        for rb in recommended_blacklists:
+            print(' - %s:' % rb)
+            jenkins_urls = get_jenkins_job_urls(
+                rosdistro_name,
+                config.jenkins_url,
+                bf_name,
+                build_files[bf_name].get_targets_list())
+            url = get_package_repository_link(dist_file, rb)
+            print('   - Suggested ticket location [%s](%s)' % (url, url))
+            print('')
+            print('   Title:')
+            print('')
+            print('       %s in %s fails to build on %s targets' % (rb, rosdistro_name, bf_name))
+            print('')
+            print('   Body:')
+            print('')
+            print('       The package %s in %s has been detected as not building'
+                  % (rb, rosdistro_name) +
+                  ' on all platforms in the buildfile %s.' % (bf_name) +
+                  ' The release manager for %s will consider disabling' % (rosdistro_name) +
+                  ' this build if it continues to fail to build.')
+            print('       - jenkins_urls:')
+            for target, ju in jenkins_urls.items():
+                target_str = ' '.join([x for x in target])
+                url = ju.format(pkg=rb)
+                print('          - [%s](%s)' % (target_str, url))
+                # TODO(tfoote) embed build status when buildfarm has https
+                # print('    - %s [![Build Status](%s)](%s)' % (' '.join([x for x in target]),
+                #       ju.format(pkg = rb) + '/badge/icon', ju.format(pkg = rb)))
+            print('       This is being filed because this package is about to be blacklisted.'
+                  ' If this ticket is resolved please review whether it can be removed from'
+                  ' the blacklist that should cross reference here.')
+            print('')
+
+    return recommended_actions
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/release/check_sync_criteria.py
+++ b/scripts/release/check_sync_criteria.py
@@ -25,6 +25,7 @@ from ros_buildfarm.argument import add_argument_cache_dir
 from ros_buildfarm.argument import add_argument_config_url
 from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
+from ros_buildfarm.argument import add_argument_return_zero
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.common import get_os_package_name
 from ros_buildfarm.common import Target
@@ -46,12 +47,13 @@ def main(argv=sys.argv[1:]):
     add_argument_os_code_name(parser)
     add_argument_arch(parser)
     add_argument_cache_dir(parser, '/tmp/package_repo_cache')
+    add_argument_return_zero(parser)
     args = parser.parse_args(argv)
 
     success = check_sync_criteria(
         args.config_url, args.rosdistro_name, args.release_build_name,
         args.os_name, args.os_code_name, args.arch, args.cache_dir)
-    return 0 if success else 1
+    return 0 if success or args.return_zero else 1
 
 
 def check_sync_criteria(


### PR DESCRIPTION
This tool will help them audit all missing packages in the rosdistro to eliminate any missing packages before a sync. 

It will say what's failing to build on all platforms to be removed from the rosdistro. And say what's failing on specific build configs and should be blacklisted. 

Still pending is an additional capability to link into jenkins to get build status and links for easier debugging. It also could help with providing urls for ticketing the issues upstream and possibly opening blacklist and rosdistro delisting tickets automatically or at least providing a template for the manager to copy and paste.

Basic usage `./scripts/release/audit_rosdistro.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml melodic`

