### PR TITLE
Add Suite3 and Python2-Depends-Name configuration for stdeb releases.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -12,6 +12,7 @@ Conflicts: python3-ros-buildfarm
 Conflicts3: python-ros-buildfarm
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan stretch buster
 Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal stretch buster
+Python2-Depends-Name: python
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
 [ros_buildfarm_modules]
@@ -23,4 +24,5 @@ Replaces: python-ros-buildfarm (<< 1.3.0)
 Replaces3: python3-ros-buildfarm (<< 1.3.0)
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan stretch buster
 Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal stretch buster
+Python2-Depends-Name: python
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -11,6 +11,7 @@ Depends3: python3-catkin-pkg-modules, python3-ros-buildfarm-modules (>= 3.0.0), 
 Conflicts: python3-ros-buildfarm
 Conflicts3: python-ros-buildfarm
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan stretch buster
+Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal stretch buster
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
 [ros_buildfarm_modules]
@@ -21,4 +22,5 @@ Conflicts3: python3-ros-buildfarm (<< 1.3.0)
 Replaces: python-ros-buildfarm (<< 1.3.0)
 Replaces3: python3-ros-buildfarm (<< 1.3.0)
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan stretch buster
+Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal stretch buster
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
This PR includes two changes:

#### Adds `Suite3` for releasing to Ubuntu Focal

The Suite3 option introduced in stdeb 0.9.0 and allows specifying
different release suites when building a python3-only deb.

#### Sets Python2-Depends-Name for releasing from Ubuntu Focal

Requires stdeb >= 0.9.1 and makes the created python2 package uninstallable on Ubuntu Focal and later where the `python` package is called `python2` instead.

---

If there is some reason why we are not planning to release ros_buildfarm into Ubuntu Focal at this time the first commit could be dropped during review.