### PR TITLE
Changes for compatibility with the latest Pulp release

### DIFF
--- a/ros_buildfarm/pulp.py
+++ b/ros_buildfarm/pulp.py
@@ -256,7 +256,7 @@ class PulpRpmClient:
         distribution = self._rpm_distributions_api.list(name=distribution_name).results[0]
         old_publication = self._rpm_publications_api.read(distribution.publication)
 
-        sync_data = pulp_rpm.RepositorySyncURL(
+        sync_data = pulp_rpm.RpmRepositorySyncURL(
             remote=remote.pulp_href,
             mirror=True)
 


### PR DESCRIPTION
Looks like this changed in `pulp_rpm` 3.2.0: https://pulp-rpm.readthedocs.io/en/3.4/changes.html#id79