### PR TITLE
Fix repository GPG keys for RPM

### DIFF
--- a/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
@@ -36,7 +36,7 @@ RUN echo "@(today_str)"
 RUN @(package_manager) update -y
 
 @[for i, key in enumerate(distribution_repository_keys)]@
-RUN echo "@('\\n'.join(key.splitlines()))" > /etc/pki/mock/RPM-GPG-KEY-ros-buildfarm-@(i)
+RUN echo -e "@('\\n'.join(key.splitlines()))" > /etc/pki/mock/RPM-GPG-KEY-ros-buildfarm-@(i)
 @[end for]@
 COPY mock_config.cfg /etc/mock/ros_buildfarm.cfg
 

--- a/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
+++ b/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
@@ -44,7 +44,7 @@ config_opts[f'{config_opts.package_manager}.conf'] += """
 [ros-buildfarm-@(i)]
 name=ROS Buildfarm Repository @(i) - $basearch
 baseurl=@(url)
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ros-buildfarm-@(i)
+gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-ros-buildfarm-@(i)
 repo_gpgcheck=@(1 if i < len(distribution_repository_keys) and distribution_repository_keys[i] else 0)
 gpgcheck=0
 enabled=1

--- a/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
@@ -36,7 +36,7 @@ RUN echo "@(today_str)"
 RUN @(package_manager) update -y
 
 @[for i, key in enumerate(distribution_repository_keys)]@
-RUN echo "@('\\n'.join(key.splitlines()))" > /etc/pki/mock/RPM-GPG-KEY-ros-buildfarm-@(i)
+RUN echo -e "@('\\n'.join(key.splitlines()))" > /etc/pki/mock/RPM-GPG-KEY-ros-buildfarm-@(i)
 @[end for]@
 COPY mock_config.cfg /etc/mock/ros_buildfarm.cfg
 


### PR DESCRIPTION
Now that I actually have GPG-signed metadata working in Pulp, it turns out that there were some bugs in the original implementation.