### PR TITLE
quote test args containing spaces

### DIFF
--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -126,6 +126,7 @@ cmd += \
 if vars().get('build_tool_args'):
     cmd += ' --build-tool-args ' + ' '.join(build_tool_args)
 if vars().get('build_tool_test_args'):
-    cmd += ' --build-tool-test-args ' + ' '.join(build_tool_test_args)
+    cmd += ' --build-tool-test-args ' + ' '.join(
+        a if ' ' not in a else '"%s"' % a for a in build_tool_test_args)
 }@
-CMD ["@cmd"]
+CMD ["@(cmd.replace('"', '\\"'))"]

--- a/ros_buildfarm/workspace.py
+++ b/ros_buildfarm/workspace.py
@@ -85,7 +85,8 @@ def call_build_tool(
         # can't be executed in parallel
         if colcon_verb == 'test':
             cmd += [
-                '--event-handlers', 'console_direct+', '--executor sequential']
+                '--event-handlers', 'console_direct+',
+                '--executor', 'sequential']
 
     if force_cmake:
         if build_tool == 'catkin_make_isolated':

--- a/ros_buildfarm/workspace.py
+++ b/ros_buildfarm/workspace.py
@@ -128,7 +128,8 @@ def call_build_tool(
         elif build_tool == 'colcon':
             _insert_nargs_arguments(cmd, '--cmake-target', make_args)
 
-    cmd = ' '.join(cmd)
+    cmd = ' '.join(
+        c if ' ' not in c else '"%s"' % c for c in cmd)
 
     # prepend setup files if available
     if parent_result_spaces is None:


### PR DESCRIPTION
Follow up of #793 which didn't correctly preserve quoted arguments containing spaces.

Necessary for the CI configuration from ros2/ros_buildfarm_config#114.

Before: [![Build Status](http://build.ros2.org/buildStatus/icon?job=Rci__nightly-fastrtps_ubuntu_focal_amd64&build=21)](http://build.ros2.org/view/Rci/job/Rci__nightly-fastrtps_ubuntu_focal_amd64/21/)
After: [![Build Status](http://build.ros2.org/buildStatus/icon?job=Rci__nightly-fastrtps_ubuntu_focal_amd64&build=24)](http://build.ros2.org/view/Rci/job/Rci__nightly-fastrtps_ubuntu_focal_amd64/24/)