### PR TITLE
fix failing CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ jobs:
         - docker
       env: JOB_TYPE=prerelease UNDERLAY_REPOSITORY_NAMES="ament_cmake_ros" OVERLAY_PACKAGE_NAMES=rcutils ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros2/rosdistro/ros2/index-v4.yaml
       before_script:
+        - pip install -U importlib-metadata
         # install colcon for test results
         - pip install colcon-core colcon-test-result
         - python setup.py install
@@ -166,6 +167,7 @@ jobs:
         - sudo apt-get update -qq
         - sudo apt-get install dpkg -y  # necessary for catkin-pkg to be installable
         - sudo apt-get install ros-kinetic-catkin -y
+        - pip install -U importlib-metadata
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm
@@ -181,7 +183,8 @@ jobs:
       before_script:
         - sudo apt-get update
         - sudo apt-get install -y python3-pip python3-setuptools
-        - sudo pip3 install vcstool
+        - pip install -U importlib-metadata
+        - pip install vcstool
         - python setup.py install
         - mkdir job && cd job
         - ln -s .. ros_buildfarm


### PR DESCRIPTION
Separated from #821.

Without this patch the three jobs were failing with:

```
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.6.7/bin/vcs", line 33, in <module>
    sys.exit(load_entry_point('vcstool==0.2.11', 'console_scripts', 'vcs')())
  File "/home/travis/virtualenv/python3.6.7/bin/vcs", line 25, in importlib_load_entry_point
    return next(matches).load()
StopIteration
```