### PR TITLE
Ensure RPM mock macros start with % character

### DIFF
--- a/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
+++ b/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
@@ -19,7 +19,7 @@ config_opts['environment']['@env_key'] = '@env_val'
 @[end for]
 @[end if]@
 # Disable debug packages until infrastructure can handle it
-config_opts['macros']['debug_package'] = '%{nil}'
+config_opts['macros']['%debug_package'] = '%{nil}'
 
 # Hack the %{dist} macro to allow release suffixing
 config_opts['macros']['%dist'] = '.' + config_opts['dist'] + '%{?dist_suffix}'
@@ -30,10 +30,10 @@ config_opts['use_nspawn'] = False
 @[if os_name in ['centos', 'rhel'] and os_code_name == '7']@
 # Inject g++ 8 into RHEL 7 builds
 config_opts['chroot_setup_cmd'] += ' devtoolset-8-gcc-c++ devtoolset-8-make-nonblocking'
-config_opts['macros']['_buildshell'] = '/usr/bin/scl enable devtoolset-8 -- /bin/sh'
+config_opts['macros']['%_buildshell'] = '/usr/bin/scl enable devtoolset-8 -- /bin/sh'
 
 # Disable weak dependencies on RHEL 7 builds
-config_opts['macros']['_without_weak_deps'] = '1'
+config_opts['macros']['%_without_weak_deps'] = '1'
 @[else]@
 # Add g++, which is an assumed dependency in ROS
 config_opts['chroot_setup_cmd'] += ' gcc-c++ make'


### PR DESCRIPTION
This isn't supposed to be necessary, but a recent change to Python or
mock has caused it to break stuff.