### PR TITLE
install pytest-rerunfailures for colcon --retest-until-pass

### DIFF
--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -62,8 +62,9 @@ RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python
 
 @[if build_tool == 'colcon']@
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-pip
-@# colcon-core.package_identification.python needs at least version 30.3.0
-RUN pip3 install -U setuptools
+@# colcon-core.package_identification.python needs at least setuptools 30.3.0
+@# pytest-rerunfailures enables usage of --retest-until-pass
+RUN pip3 install -U setuptools pytest-rerunfailures
 @[end if]@
 @[if ros_version == 2]@
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ros-@(rosdistro_name)-ros-workspace


### PR DESCRIPTION
Necessary for the CI configuration from ros2/ros_buildfarm_config#114.

Before:

* e.g. http://build.ros2.org/view/Rci/job/Rci__nightly-cyclonedds_ubuntu_focal_amd64/24/ shows the following warning for 64 pkgs:

     > WARNING:colcon.colcon_core.verb.test:Ignored '--retest-until-pass' for package 'action_tutorials_py' since pytest extension 'rerunfailures' was not found

After: http://build.ros2.org/view/Rci/job/Rci__nightly-cyclonedds_ubuntu_focal_amd64/25/