### PR TITLE
Update Jenkins plugin versions used by ros_buildfarm.

### DIFF
--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -19,6 +19,9 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 ))@
 @[end if]@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
 @{
@@ -81,6 +84,7 @@ parameters = [
     project_authorization_xml=project_authorization_xml
 ))@
   </properties>
+  <scm class="hudson.scm.NullSCM"/>
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
   <assignedNode>@(node_label)</assignedNode>
   <canRoam>false</canRoam>

--- a/ros_buildfarm/templates/ci/ci_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_reconfigure-jobs_job.xml.em
@@ -13,6 +13,9 @@
     priority=30,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/dashboard_view_devel_jobs.xml.em
+++ b/ros_buildfarm/templates/dashboard_view_devel_jobs.xml.em
@@ -32,7 +32,7 @@
       </tools>
       <name># Issues</name>
       <labelProviderFactory>
-        <jenkins plugin="plugin-util-api@@1.0.2"/>
+        <jenkins plugin="plugin-util-api@@1.2.2"/>
       </labelProviderFactory>
       <type>TOTAL</type>
     </io.jenkins.plugins.analysis.core.columns.IssuesTotalColumn>

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -25,6 +25,9 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 ))@
 @[end if]@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
 @{

--- a/ros_buildfarm/templates/devel/devel_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_reconfigure-jobs_job.xml.em
@@ -13,6 +13,9 @@
     priority=30,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
@@ -15,6 +15,9 @@
 ))@
 @[end if]@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
   </properties>

--- a/ros_buildfarm/templates/doc/doc_independent_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_job.xml.em
@@ -15,6 +15,9 @@
 ))@
 @[end if]@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
   </properties>

--- a/ros_buildfarm/templates/doc/doc_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_job.xml.em
@@ -26,6 +26,9 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 ))@
 @[end if]@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
@@ -15,6 +15,9 @@
 ))@
 @[end if]@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
   </properties>

--- a/ros_buildfarm/templates/doc/doc_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_reconfigure-jobs_job.xml.em
@@ -13,6 +13,9 @@
     priority=30,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/misc/check_agents_job.xml.em
+++ b/ros_buildfarm/templates/misc/check_agents_job.xml.em
@@ -16,9 +16,6 @@
     'property_rebuild-settings',
 ))@
 @(SNIPPET(
-    'property_rebuild-settings',
-))@
-@(SNIPPET(
     'property_requeue-job',
 ))@
   </properties>

--- a/ros_buildfarm/templates/misc/check_agents_job.xml.em
+++ b/ros_buildfarm/templates/misc/check_agents_job.xml.em
@@ -13,6 +13,12 @@
     priority=20,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
   </properties>

--- a/ros_buildfarm/templates/misc/check_failing_jobs.xml.em
+++ b/ros_buildfarm/templates/misc/check_failing_jobs.xml.em
@@ -13,6 +13,9 @@
     priority=20,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
   </properties>

--- a/ros_buildfarm/templates/misc/dashboard_job.xml.em
+++ b/ros_buildfarm/templates/misc/dashboard_job.xml.em
@@ -13,6 +13,9 @@
     priority=20,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
   </properties>

--- a/ros_buildfarm/templates/misc/rosdistro_cache_job.xml.em
+++ b/ros_buildfarm/templates/misc/rosdistro_cache_job.xml.em
@@ -13,6 +13,9 @@
     priority=10,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
   </properties>

--- a/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
@@ -23,6 +23,9 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 ))@
 @[end if]@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/release/deb/import_package_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/import_package_job.xml.em
@@ -13,6 +13,9 @@
     priority=-1,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/release/deb/import_upstream_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/import_upstream_job.xml.em
@@ -17,6 +17,9 @@ Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'</descriptio
     priority=20,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/release/deb/sourcepkg_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/sourcepkg_job.xml.em
@@ -23,6 +23,9 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 ))@
 @[end if]@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/release/deb/sync_packages_to_main_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/sync_packages_to_main_job.xml.em
@@ -13,6 +13,9 @@
     priority=-1,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
   </properties>

--- a/ros_buildfarm/templates/release/deb/sync_packages_to_testing_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/sync_packages_to_testing_job.xml.em
@@ -13,6 +13,9 @@
     priority=-1,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
   </properties>

--- a/ros_buildfarm/templates/release/release_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/release/release_reconfigure-jobs_job.xml.em
@@ -13,6 +13,9 @@
     priority=30,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/release/release_trigger-broken-with-non-broken-upstream_job.xml.em
+++ b/ros_buildfarm/templates/release/release_trigger-broken-with-non-broken-upstream_job.xml.em
@@ -13,6 +13,9 @@
     priority=35,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
   </properties>

--- a/ros_buildfarm/templates/release/release_trigger-jobs_job.xml.em
+++ b/ros_buildfarm/templates/release/release_trigger-jobs_job.xml.em
@@ -13,6 +13,9 @@
     priority=35,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
     <hudson.model.ParametersDefinitionProperty>

--- a/ros_buildfarm/templates/release/rpm/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_job.xml.em
@@ -23,6 +23,9 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 ))@
 @[end if]@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/release/rpm/import_package_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/import_package_job.xml.em
@@ -13,6 +13,9 @@
     priority=-1,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/release/rpm/import_upstream_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/import_upstream_job.xml.em
@@ -13,6 +13,9 @@
     priority=20,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/release/rpm/sourcepkg_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sourcepkg_job.xml.em
@@ -23,6 +23,9 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 ))@
 @[end if]@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/release/rpm/sync_packages_to_main_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sync_packages_to_main_job.xml.em
@@ -13,6 +13,9 @@
     priority=-1,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
   </properties>

--- a/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
@@ -13,6 +13,9 @@
     priority=-1,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
   </properties>

--- a/ros_buildfarm/templates/snippet/build-wrapper_timestamper.xml.em
+++ b/ros_buildfarm/templates/snippet/build-wrapper_timestamper.xml.em
@@ -1,1 +1,1 @@
-    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.8.10"/>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@@1.11.3"/>

--- a/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
@@ -1,7 +1,7 @@
     <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.2">
 @[if command]@
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
-        <script plugin="script-security@@1.70">
+        <script plugin="script-security@@1.74">
           <script>@ESCAPE(command)</script>
           <sandbox>false</sandbox>
         </script>

--- a/ros_buildfarm/templates/snippet/plot_plugin.xml.em
+++ b/ros_buildfarm/templates/snippet/plot_plugin.xml.em
@@ -1,7 +1,7 @@
 @{
 import html
 }@
-    <hudson.plugins.plot.PlotPublisher plugin="plot@@2.1.3">
+    <hudson.plugins.plot.PlotPublisher plugin="plot@@2.1.6">
       <plots>
 @[for plot_group, plot_list in sorted(plots.items())]@
 @[for plot in plot_list]@

--- a/ros_buildfarm/templates/snippet/property_rebuild-settings.xml.em
+++ b/ros_buildfarm/templates/snippet/property_rebuild-settings.xml.em
@@ -1,0 +1,4 @@
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@@1.31">
+      <autoRebuild>false</autoRebuild>
+      <rebuildDisabled>false</rebuildDisabled>
+    </com.sonyericsson.rebuild.RebuildSettings>

--- a/ros_buildfarm/templates/snippet/publisher_groovy-postbuild.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_groovy-postbuild.xml.em
@@ -1,5 +1,5 @@
     <org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder plugin="groovy-postbuild@@2.4.3">
-      <script plugin="script-security@@1.70">
+      <script plugin="script-security@@1.74">
         <script>@ESCAPE(script)</script>
         <sandbox>false</sandbox>
       </script>

--- a/ros_buildfarm/templates/snippet/publisher_mailer.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_mailer.xml.em
@@ -1,5 +1,5 @@
 @[if recipients or dynamic_recipients or send_to_individuals]@
-    <hudson.tasks.Mailer plugin="mailer@@1.29">
+    <hudson.tasks.Mailer plugin="mailer@@1.32">
       <recipients>@ESCAPE(' '.join(sorted(recipients)))@ESCAPE(('\t' + ' '.join(sorted(dynamic_recipients))) if dynamic_recipients else '')</recipients>
       <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
       <sendToIndividuals>@(send_to_individuals ? 'true' ! 'false')</sendToIndividuals>

--- a/ros_buildfarm/templates/snippet/publisher_publish-over-git.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_publish-over-git.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.git.GitPublisher plugin="git@@4.0.0">
+    <hudson.plugins.git.GitPublisher plugin="git@@4.3.0">
       <configVersion>2</configVersion>
       <pushMerge>false</pushMerge>
       <pushOnlyIfSuccess>true</pushOnlyIfSuccess>

--- a/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
@@ -1,4 +1,4 @@
-<io.jenkins.plugins.analysis.core.steps.IssuesRecorder plugin="warnings-ng@@7.3.0">
+<io.jenkins.plugins.analysis.core.steps.IssuesRecorder plugin="warnings-ng@@8.1.0">
   <analysisTools>
     <io.jenkins.plugins.analysis.warnings.Cmake>
       <id></id>
@@ -23,7 +23,7 @@
   <failOnError>false</failOnError>
   <healthy>0</healthy>
   <unhealthy>0</unhealthy>
-  <minimumSeverity plugin="analysis-model-api@@7.0.2">
+  <minimumSeverity plugin="analysis-model-api@@8.0.1">
     <name>LOW</name>
   </minimumSeverity>
   <filters>

--- a/ros_buildfarm/templates/snippet/publisher_xunit.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_xunit.xml.em
@@ -3,7 +3,7 @@
 if 'types' not in vars() and 'pattern' in vars():
     types = [('GoogleTestType', pattern)]
 }@
-    <xunit plugin="xunit@@2.3.8">
+    <xunit plugin="xunit@@2.3.9">
       <types>
 @[for type_tag_and_pattern in types]@
 @{

--- a/ros_buildfarm/templates/snippet/scm_git.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_git.xml.em
@@ -1,4 +1,4 @@
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@@4.0.0">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@@4.3.0">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>

--- a/ros_buildfarm/templates/snippet/scm_git.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_git.xml.em
@@ -48,6 +48,7 @@
         <trackingSubmodules>false</trackingSubmodules>
         <reference></reference>
         <parentCredentials>false</parentCredentials>
+        <shallow>false</shallow>
       </hudson.plugins.git.extensions.impl.SubmoduleOption>
     </extensions>
   </scm>

--- a/ros_buildfarm/templates/snippet/trigger-jobs_job.xml.em
+++ b/ros_buildfarm/templates/snippet/trigger-jobs_job.xml.em
@@ -13,6 +13,9 @@
     priority=35,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
     <hudson.model.ParametersDefinitionProperty>

--- a/ros_buildfarm/templates/status/blocked_releases_page_job.xml.em
+++ b/ros_buildfarm/templates/status/blocked_releases_page_job.xml.em
@@ -13,6 +13,9 @@
     priority=20,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
   </properties>

--- a/ros_buildfarm/templates/status/blocked_source_entries_page_job.xml.em
+++ b/ros_buildfarm/templates/status/blocked_source_entries_page_job.xml.em
@@ -13,6 +13,9 @@
     priority=20,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
   </properties>

--- a/ros_buildfarm/templates/status/release_compare_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_compare_page_job.xml.em
@@ -13,6 +13,9 @@
     priority=20,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
   </properties>

--- a/ros_buildfarm/templates/status/release_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_status_page_job.xml.em
@@ -13,6 +13,9 @@
     priority=20,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
   </properties>

--- a/ros_buildfarm/templates/status/repos_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/repos_status_page_job.xml.em
@@ -13,6 +13,9 @@
     priority=20,
 ))@
 @(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
     'property_requeue-job',
 ))@
   </properties>


### PR DESCRIPTION
In addition to the version updates there have also been a few additions or structural changes in the configurations.

The broadest is that the rebuild plugin now adds a configuration element to every job.
I've extracted that configuration element into a snippet and hard-coded the default value of false for both auto rebuilding and disabling rebuilding. If, in the future we want to change these properties for a job we can parameterize the snippet but I don't see a reason to do so pre-emptively.

When updating CI jobs I also noticed the addition of an scm element specifying a null scm property since the job itself is not tied to any scm repository.

There now appears to be a `<shallow>` tag in the Git SCM configuration.