### PR TITLE
use distinct xunit pattern for ROS 2

### DIFF
--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -303,7 +303,8 @@ def _get_ci_job_config(
 
         # only Ubuntu Focal has a new enough pytest version which generates
         # JUnit compliant result files
-        'xunit_publisher_types': get_xunit_publisher_types_and_patterns(),
+        'xunit_publisher_types': get_xunit_publisher_types_and_patterns(
+            ros_version, os_name == 'ubuntu' and os_code_name != 'bionic'),
     }
     job_config = expand_template(template_name, job_data)
     return job_config

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -600,9 +600,21 @@ def get_packages_in_workspaces(workspace_roots, condition_context=None):
     return pkgs
 
 
-def get_xunit_publisher_types_and_patterns():
+def get_xunit_publisher_types_and_patterns(
+    ros_version, pytest_junit_compliant
+):
     types = []
-    types.append(('GoogleTestType', 'ws/test_results/**/*.xml'))
+    if ros_version == 1:
+        types.append(('GoogleTestType', 'ws/test_results/**/*.xml'))
+    elif ros_version == 2:
+        types.append(('CTestType', 'ws/test_results/*/Testing/*/Test.xml'))
+        types.append(('GoogleTestType', 'ws/test_results/**/*.gtest.xml'))
+        types.append((
+            'JUnitType' if pytest_junit_compliant else 'GoogleTestType',
+            'ws/test_results/*/pytest.xml'))
+        types.append(('JUnitType', 'ws/test_results/**/*.xunit.xml'))
+    else:
+        assert False, 'Unsupported ROS version: ' + str(ros_version)
     return types
 
 

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -439,7 +439,8 @@ def _get_devel_job_config(
 
         # only Ubuntu Focal has a new enough pytest version which generates
         # JUnit compliant result files
-        'xunit_publisher_types': get_xunit_publisher_types_and_patterns(),
+        'xunit_publisher_types': get_xunit_publisher_types_and_patterns(
+            ros_version, os_name == 'ubuntu' and os_code_name != 'bionic'),
 
         'git_ssh_credential_id': config.git_ssh_credential_id,
 

--- a/ros_buildfarm/templates/snippet/publisher_xunit.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_xunit.xml.em
@@ -9,7 +9,7 @@ if 'types' not in vars() and 'pattern' in vars():
 @{
 # expanding these within the for statement leads to a TypeError in empy version 3.3.4 and older
 type_tag, pattern = type_tag_and_pattern
-assert type_tag in ('GoogleTestType', 'JUnitType'), 'Unsupported test type tag: ' + type_tag
+assert type_tag in ('CTestType', 'GoogleTestType', 'JUnitType'), 'Unsupported test type tag: ' + type_tag
 }@
         <@(type_tag)>
           <pattern>@ESCAPE(pattern)</pattern>


### PR DESCRIPTION
This redoes #723 and #724 (which were reverted in #725) and also adds a specific pattern for the xUnit type `CTestType` since CTest result files are available now (see colcon/colcon-cmake#89).

Without this change Jenkins tries to interpret the newly copied CTest result files as GoogleTest results files and chokes, e.g.:
* [![Build Status](http://build.ros2.org/buildStatus/icon?job=Rdev__launch__ubuntu_focal_amd64&build=22)](http://build.ros2.org/view/Rdev/job/Rdev__launch__ubuntu_focal_amd64/22/)
* [![Build Status](http://build.ros2.org/buildStatus/icon?job=Rpr__rosidl_typesupport__ubuntu_focal_amd64&build=20)](http://build.ros2.org/job/Rpr__rosidl_typesupport__ubuntu_focal_amd64/20/)
* [![Build Status](http://build.ros2.org/buildStatus/icon?job=Fpr__message_filters__ubuntu_focal_amd64&build=3)](http://build.ros2.org/job/Fpr__message_filters__ubuntu_focal_amd64/3/)

With this patch:
* [![Build Status](http://build.ros2.org/buildStatus/icon?job=Rdev__launch__ubuntu_focal_amd64&build=23)](http://build.ros2.org/view/Rdev/job/Rdev__launch__ubuntu_focal_amd64/23/)
* [![Build Status](http://build.ros2.org/buildStatus/icon?job=Rpr__rosidl_typesupport__ubuntu_focal_amd64&build=23)](http://build.ros2.org/job/Rpr__rosidl_typesupport__ubuntu_focal_amd64/23/)
* [![Build Status](http://build.ros2.org/buildStatus/icon?job=Fpr__message_filters__ubuntu_focal_amd64&build=4)](http://build.ros2.org/job/Fpr__message_filters__ubuntu_focal_amd64/4/)

I assume this works now because both buildfarms have been updated to the latest xUnit plugin version.