### PR TITLE
Enable RPM debug packages

### DIFF
--- a/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
+++ b/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
@@ -18,8 +18,9 @@ config_opts[f'{config_opts.package_manager}_builddep_opts'] = config_opts.get(f'
 config_opts['environment']['@env_key'] = '@env_val'
 @[end for]
 @[end if]@
-# Disable debug packages until infrastructure can handle it
-config_opts['macros']['%debug_package'] = '%{nil}'
+# Make debuginfo/debugsource packages best-effort
+config_opts['macros']['%_empty_manifest_terminate_build'] = '%{nil}'
+config_opts['macros']['%_missing_build_ids_terminate_build'] = '%{nil}'
 
 # Hack the %{dist} macro to allow release suffixing
 config_opts['macros']['%dist'] = '.' + config_opts['dist'] + '%{?dist_suffix}'


### PR DESCRIPTION
Now that the pulp infrastructure can handle the separate debug packages, enable RPM debuginfo extraction. This should reduce the install size substantially.

The `_empty_manifest_terminate_build` option is used to suppress build failures when the `debugsource` package ends up empty. This usually happens when either the package didn't produce any symbols and should thus be "noarch", or when the package doesn't respect the provided C/CXX flags.

The `_missing_build_ids_terminate_build` makes the build continue when build IDs weren't part of the produced symbols, which usually happens when the package doesn't respect the provided C/CXX flags.

Ideally, these problems should be fixed in the individual packages, but the problems are too widespread to tackle at this time, so a best-effort approach will have to do for now.