### PR TITLE
Disable automatic out-of-source CMake builds in RPMs

### DIFF
--- a/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
+++ b/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
@@ -24,6 +24,10 @@ config_opts['macros']['%debug_package'] = '%{nil}'
 # Hack the %{dist} macro to allow release suffixing
 config_opts['macros']['%dist'] = '.' + config_opts['dist'] + '%{?dist_suffix}'
 
+# Disable automatic out-of-source CMake builds
+config_opts['macros']['%__cmake_in_source_build'] = '1'
+config_opts['macros']['%__cmake3_in_source_build'] = '1'
+
 # Required for running mock in Docker
 config_opts['use_nspawn'] = False
 


### PR DESCRIPTION
In Fedora 33, the CMake macro was changed to automatically create and use a subdirectory for build files. We're already doing that in the Bloom templates manually, so we need to specify a macro to retain the existing behavior or the two approaches will collide and make the build step fail.

Once the new behavior is reliably part of all Fedora and EPEL systems we're targeting, we can consider modifying the Bloom templates to leverage the new feature.

Unfortunately, I don't see a very good path to transitioning to the new behavior right now, so reverting to the existing behavior seems like the best path to supporting Fedora 33 and newer.