### PR TITLE
Only use xUnit type JUnit for *.xunit.xml results if pytest compliant

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -612,7 +612,10 @@ def get_xunit_publisher_types_and_patterns(
         types.append((
             'JUnitType' if pytest_junit_compliant else 'GoogleTestType',
             'ws/test_results/*/pytest.xml'))
-        types.append(('JUnitType', 'ws/test_results/**/*.xunit.xml'))
+        # ament_cmake_pytest doesn't produce a pytest.xml
+        types.append((
+            'JUnitType' if pytest_junit_compliant else 'GoogleTestType',
+            'ws/test_results/**/*.xunit.xml'))
     else:
         assert False, 'Unsupported ROS version: ' + str(ros_version)
     return types


### PR DESCRIPTION
Sometimes pytest results are put into files with extension *.xunit.xml,
for example, if added with `ament_cmake_pytest`.

Connects to https://github.com/ros2/ros2/issues/1016