### PR TITLE
allow SYS_PTRACE capability when running tests

### DIFF
--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -368,7 +368,8 @@ parameters = [
         'echo "# BEGIN SECTION: ccache stats (before)"',
         'mkdir -p $HOME/.ccache',
         'docker run' +
-        ' --rm ' +
+        ' --rm' +
+        ' --cap-add SYS_PTRACE' +
         ' --cidfile=$WORKSPACE/docker_build_and_test/docker_ccache_before.cid' +
         ' -e CCACHE_DIR=/home/buildfarm/.ccache' +
         ' -v $HOME/.ccache:/home/buildfarm/.ccache' +

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -233,7 +233,8 @@ if pull_request:
         'if [ ! -d "$HOME/.ccache" ]; then mkdir $HOME/.ccache; fi',
         'docker run' +
         (' --env=DISPLAY=:0.0 --env=QT_X11_NO_MITSHM=1 --volume=/tmp/.X11-unix:/tmp/.X11-unix:rw  --gpus all' if require_gpu_support else '') +
-        ' --rm ' +
+        ' --rm' +
+        ' --cap-add SYS_PTRACE' +
         ' --cidfile=$WORKSPACE/docker_build_and_test/docker.cid' +
         ' -e=TRAVIS=$TRAVIS' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +


### PR DESCRIPTION
To address test failures related to trying to use leak sanitizer:
* http://build.ros2.org/view/Rci/job/Rci__nightly-fastrtps_ubuntu_focal_amd64/58/testReport/(root)/projectroot/test_ros2_message/
* http://build.ros2.org/view/Rdev/job/Rdev__rosbag2__ubuntu_focal_amd64/31/testReport/(root)/projectroot/test_ros2_message/

See the [temporary job](http://build.ros2.org/view/Rci/job/Rci__nightly-fastrtps_ubuntu_focal_amd64-dirk/3/) which passes with this option.