### PR TITLE
Add --dry-run argument to generate_devel_job.py

### DIFF
--- a/scripts/devel/generate_devel_job.py
+++ b/scripts/devel/generate_devel_job.py
@@ -20,6 +20,7 @@ import sys
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_name
 from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_dry_run
 from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
 from ros_buildfarm.argument import add_argument_repository_name
@@ -37,11 +38,14 @@ def main(argv=sys.argv[1:]):
     add_argument_os_name(parser)
     add_argument_os_code_name(parser)
     add_argument_arch(parser)
+
+    add_argument_dry_run(parser)
     args = parser.parse_args(argv)
 
     configure_devel_job(
         args.config_url, args.rosdistro_name, args.source_build_name,
-        args.repository_name, args.os_name, args.os_code_name, args.arch)
+        args.repository_name, args.os_name, args.os_code_name, args.arch,
+        dry_run=args.dry_run)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This option is available on many other `generate_*_job{,s}.py` scripts, and I found it useful to have it here.