### PR TITLE
Support custom !include directive in config files

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -66,6 +66,7 @@ Please see the documentation about using a
 `custom rosdistro database <custom_rosdistro.rst>`_ for the necessary
 configuration options and administrative tasks.
 
+
 Dealing with large and/or duplicated configuration elements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -66,6 +66,18 @@ Please see the documentation about using a
 `custom rosdistro database <custom_rosdistro.rst>`_ for the necessary
 configuration options and administrative tasks.
 
+Dealing with large and/or duplicated configuration elements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The YAML loader used to load the configuration implements a special constructor
+used to load the YAML content from another file.
+This mechanism can be used to include configuration elements from a separate
+file as if it were embedded into another file.
+The special directive takes a single URL argument, which may either be relative
+to the current URL or absolute.
+
+For example: ``large_block: !include other_file.yaml``
+
 
 Generate the Jenkins jobs
 -------------------------


### PR DESCRIPTION
This change leverage a custom constructor in PyYAML to support a new `!include` directive for including YAML content from another file. The directive's argument is a relative URL path from the currently loading YAML file.

I found this approach to be substantially cleaner to implement than plumbing knowledge of the `base_url` through the index object and into the build file parsing logic to take the same approach as was taken to reference the build files from the index.

The main motivation is to reduce the size of the build file for the CI performance jobs by pushing the plot configuration into a separate (possibly common) file. I'd also like to take advantage of it in the Benchmark plugin configuration, where we'll need to specify a JSON schema.