### PR TITLE
Add support for the Jenkins Benchmark plugin

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -294,6 +294,13 @@ The following options are valid in version ``2`` (beside the generic options):
   A special macro in the ROS wiki will then render those test results as part of
   the auto-generated *Package Header*.
 
+* ``benchmark_patterns``: a list of file patterns relative to the Jenkins
+  workspace where benchmark result files are expected to be found.
+
+* ``benchmark_schema``: a JSON or XML schema which describes the structure of
+  the files referenced by the ``benchmark_patterns`` value, which is required
+  when this option is specified.
+
 The following options are valid as keys in the ``_config`` dict under
 ``targets``:
 
@@ -516,6 +523,13 @@ The following options are valid in version ``1`` (beside the generic options):
       For EXCLUDE\_\*, the logic is inverted and all discovered columns EXCEPT
       those matching this value are included.
     * ``url``: Hyperlink URL to redirect when a point is clicked.
+
+* ``benchmark_patterns``: a list of file patterns relative to the Jenkins
+  workspace where benchmark result files are expected to be found.
+
+* ``benchmark_schema``: a JSON or XML schema which describes the structure of
+  the files referenced by the ``benchmark_patterns`` value, which is required
+  when this option is specified.
 
 * ``skip_rosdep_keys``: a list of rosdep keys which should be ignored when
   rosdep is invoked to resolve package dependencies.

--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -305,6 +305,9 @@ def _get_ci_job_config(
         # JUnit compliant result files
         'xunit_publisher_types': get_xunit_publisher_types_and_patterns(
             ros_version, os_name == 'ubuntu' and os_code_name != 'bionic'),
+
+        'benchmark_patterns': build_file.benchmark_patterns,
+        'benchmark_schema': build_file.benchmark_schema,
     }
     job_config = expand_template(template_name, job_data)
     return job_config

--- a/ros_buildfarm/config/build_file.py
+++ b/ros_buildfarm/config/build_file.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+from xml.etree import ElementTree
+
 
 class BuildFile(object):
 
@@ -91,3 +94,16 @@ class BuildFile(object):
                 res.append(dist_file)
 
         return res
+
+    def _assert_valid_benchmark_schema(self):
+        assert isinstance(self.benchmark_schema, str)
+        if self.benchmark_schema.startswith('<'):
+            try:
+                ElementTree.fromstring(self.benchmark_schema)
+            except ElementTree.ParseError as e:
+                assert False, "The 'benchmark_schema' value contains invalid XML: " + str(e)
+        else:
+            try:
+                json.loads(self.benchmark_schema)
+            except json.decoder.JSONDecodeError as e:
+                assert False, "The 'benchmark_schema' value contains invalid JSON: " + str(e)

--- a/ros_buildfarm/config/ci_build_file.py
+++ b/ros_buildfarm/config/ci_build_file.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
-from xml.etree import ElementTree
-
 from .build_file import BuildFile
 from .plot_config import PlotConfig
 
@@ -136,16 +133,6 @@ class CIBuildFile(BuildFile):
         self.benchmark_schema = None
         if 'benchmark_schema' in data:
             self.benchmark_schema = data['benchmark_schema'].strip()
-            assert isinstance(self.benchmark_schema, str)
-            if self.benchmark_schema.startswith('<'):
-                try:
-                    ElementTree.fromstring(self.benchmark_schema)
-                except ElementTree.ParseError as e:
-                    assert False, "The 'benchmark_schema' value contains invalid XML: " + str(e)
-            else:
-                try:
-                    json.loads(self.benchmark_schema)
-                except json.decoder.JSONDecodeError as e:
-                    assert False, "The 'benchmark_schema' value contains invalid JSON: " + str(e)
+            self._assert_valid_benchmark_schema()
             assert self.benchmark_patterns, \
                 "The 'benchmark_patterns' value is required when using 'benchmark_schema'"

--- a/ros_buildfarm/config/ci_build_file.py
+++ b/ros_buildfarm/config/ci_build_file.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+from xml.etree import ElementTree
+
 from .build_file import BuildFile
 from .plot_config import PlotConfig
 
@@ -132,7 +135,14 @@ class CIBuildFile(BuildFile):
 
         self.benchmark_schema = None
         if 'benchmark_schema' in data:
-            self.benchmark_schema = data['benchmark_schema']
+            self.benchmark_schema = data['benchmark_schema'].strip()
             assert isinstance(self.benchmark_schema, str)
+            try:
+                json.loads(self.benchmark_schema)
+            except json.decoder.JSONDecodeError:
+                try:
+                    ElementTree.fromstring(self.benchmark_schema)
+                except ElementTree.ParseError:
+                    assert False, "The 'benchmark_schema' value must be valid JSON or XML"
             assert self.benchmark_patterns, \
                 "The 'benchmark_patterns' value is required when using 'benchmark_schema'"

--- a/ros_buildfarm/config/ci_build_file.py
+++ b/ros_buildfarm/config/ci_build_file.py
@@ -137,12 +137,15 @@ class CIBuildFile(BuildFile):
         if 'benchmark_schema' in data:
             self.benchmark_schema = data['benchmark_schema'].strip()
             assert isinstance(self.benchmark_schema, str)
-            try:
-                json.loads(self.benchmark_schema)
-            except json.decoder.JSONDecodeError:
+            if self.benchmark_schema.startswith('<'):
                 try:
                     ElementTree.fromstring(self.benchmark_schema)
-                except ElementTree.ParseError:
-                    assert False, "The 'benchmark_schema' value must be valid JSON or XML"
+                except ElementTree.ParseError as e:
+                    assert False, "The 'benchmark_schema' value contains invalid XML: " + str(e)
+            else:
+                try:
+                    json.loads(self.benchmark_schema)
+                except json.decoder.JSONDecodeError as e:
+                    assert False, "The 'benchmark_schema' value contains invalid JSON: " + str(e)
             assert self.benchmark_patterns, \
                 "The 'benchmark_patterns' value is required when using 'benchmark_schema'"

--- a/ros_buildfarm/config/ci_build_file.py
+++ b/ros_buildfarm/config/ci_build_file.py
@@ -133,4 +133,6 @@ class CIBuildFile(BuildFile):
         self.benchmark_schema = None
         if 'benchmark_schema' in data:
             self.benchmark_schema = data['benchmark_schema']
-            assert self.benchmark_patterns
+            assert isinstance(self.benchmark_schema, str)
+            assert self.benchmark_patterns, \
+                "The 'benchmark_patterns' value is required when using 'benchmark_schema'"

--- a/ros_buildfarm/config/ci_build_file.py
+++ b/ros_buildfarm/config/ci_build_file.py
@@ -123,3 +123,14 @@ class CIBuildFile(BuildFile):
                     assert isinstance(plot_config_data, dict)
                     self.show_plots[plot_group].append(
                         PlotConfig(name, plot_config_data))
+
+        self.benchmark_patterns = []
+        if 'benchmark_patterns' in data:
+            self.benchmark_patterns = data['benchmark_patterns']
+            assert isinstance(self.benchmark_patterns, list)
+            assert all(isinstance(pattern, str) for pattern in self.benchmark_patterns)
+
+        self.benchmark_schema = None
+        if 'benchmark_schema' in data:
+            self.benchmark_schema = data['benchmark_schema']
+            assert self.benchmark_patterns

--- a/ros_buildfarm/config/source_build_file.py
+++ b/ros_buildfarm/config/source_build_file.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+from xml.etree import ElementTree
+
 from .build_file import BuildFile
 
 
@@ -147,8 +150,20 @@ class SourceBuildFile(BuildFile):
 
         self.benchmark_schema = None
         if 'benchmark_schema' in data:
-            self.benchmark_schema = data['benchmark_schema']
-            assert self.benchmark_patterns
+            self.benchmark_schema = data['benchmark_schema'].strip()
+            assert isinstance(self.benchmark_schema, str)
+            if self.benchmark_schema.startswith('<'):
+                try:
+                    ElementTree.fromstring(self.benchmark_schema)
+                except ElementTree.ParseError as e:
+                    assert False, "The 'benchmark_schema' value contains invalid XML: " + str(e)
+            else:
+                try:
+                    json.loads(self.benchmark_schema)
+                except json.decoder.JSONDecodeError as e:
+                    assert False, "The 'benchmark_schema' value contains invalid JSON: " + str(e)
+            assert self.benchmark_patterns, \
+                "The 'benchmark_patterns' value is required when using 'benchmark_schema'"
 
     def filter_repositories(self, repository_names):
         res = set(repository_names)

--- a/ros_buildfarm/config/source_build_file.py
+++ b/ros_buildfarm/config/source_build_file.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
-from xml.etree import ElementTree
-
 from .build_file import BuildFile
 
 
@@ -151,17 +148,7 @@ class SourceBuildFile(BuildFile):
         self.benchmark_schema = None
         if 'benchmark_schema' in data:
             self.benchmark_schema = data['benchmark_schema'].strip()
-            assert isinstance(self.benchmark_schema, str)
-            if self.benchmark_schema.startswith('<'):
-                try:
-                    ElementTree.fromstring(self.benchmark_schema)
-                except ElementTree.ParseError as e:
-                    assert False, "The 'benchmark_schema' value contains invalid XML: " + str(e)
-            else:
-                try:
-                    json.loads(self.benchmark_schema)
-                except json.decoder.JSONDecodeError as e:
-                    assert False, "The 'benchmark_schema' value contains invalid JSON: " + str(e)
+            self._assert_valid_benchmark_schema()
             assert self.benchmark_patterns, \
                 "The 'benchmark_patterns' value is required when using 'benchmark_schema'"
 

--- a/ros_buildfarm/config/source_build_file.py
+++ b/ros_buildfarm/config/source_build_file.py
@@ -139,6 +139,17 @@ class SourceBuildFile(BuildFile):
 
         self.collate_test_stats = bool(data.get('collate_test_stats', False))
 
+        self.benchmark_patterns = []
+        if 'benchmark_patterns' in data:
+            self.benchmark_patterns = data['benchmark_patterns']
+            assert isinstance(self.benchmark_patterns, list)
+            assert all(isinstance(pattern, str) for pattern in self.benchmark_patterns)
+
+        self.benchmark_schema = None
+        if 'benchmark_schema' in data:
+            self.benchmark_schema = data['benchmark_schema']
+            assert self.benchmark_patterns
+
     def filter_repositories(self, repository_names):
         res = set(repository_names)
         if self.repository_whitelist:

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -445,6 +445,9 @@ def _get_devel_job_config(
         'git_ssh_credential_id': config.git_ssh_credential_id,
 
         'collate_test_stats': build_file.collate_test_stats,
+
+        'benchmark_patterns': build_file.benchmark_patterns,
+        'benchmark_schema': build_file.benchmark_schema,
     }
     job_config = expand_template(template_name, job_data)
     return job_config

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -436,6 +436,13 @@ parameters = [
       image for images in show_images.values() for image in images
     ],
 ))@
+@[if benchmark_patterns]@
+@(SNIPPET(
+    'publisher_benchmark',
+    patterns=benchmark_patterns,
+    schema=benchmark_schema,
+))@
+@[end if]@
 @[for title, artifacts in show_images.items()]@
 @(SNIPPET(
     'image_gallery',

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -274,6 +274,13 @@ if pull_request:
     build_tool=build_tool,
     unstable_threshold=1 if notify_compiler_warnings else '',
 ))@
+@[if benchmark_patterns]@
+@(SNIPPET(
+    'publisher_benchmark',
+    patterns=benchmark_patterns,
+    schema=benchmark_schema,
+))@
+@[end if]@
 @[if xunit_publisher_types]@
 @(SNIPPET(
     'publisher_xunit',

--- a/ros_buildfarm/templates/snippet/publisher_benchmark.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_benchmark.xml.em
@@ -1,0 +1,12 @@
+    <org.jenkinsci.plugins.benchmark.core.BenchmarkPublisher plugin="benchmark@@1.0.12-SNAPSHOT">
+      <inputLocation>@(';'.join(patterns))</inputLocation>
+      <schemaSelection>@('customSchema' if schema else 'defaultSchema')</schemaSelection>
+      <truncateStrings>true</truncateStrings>
+@[if schema]@
+      <altInputSchema>@(schema)</altInputSchema>
+@[else]@
+      <altInputSchema />
+@[end if]@
+      <altInputSchemaLocation />
+      <altThresholds />
+    </org.jenkinsci.plugins.benchmark.core.BenchmarkPublisher>


### PR DESCRIPTION
This plugin will be used to persist performance test results across runs of the same jobs, track which metrics are within expected ranges based on historical data, and ensure the build is marked as "warning" if the thresholds are exceeded.

I added support for CI and the "source" family of jobs.

The plugin version is a SNAPSHOT version until the feature and bugfix I'm proposing upstream have been merged.