### PR TITLE
Add support for the Jenkins Heavy Job plugin

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -461,7 +461,7 @@ The following options are valid in version ``1`` (beside the generic options):
 * ``jenkins_job_weight``: the number of executors on a worker which are
   required to execute the job.
   Default is ``1``.
-  Activates the Jenkins Heavy Job plugin.
+  Uses the Jenkins Heavy Job plugin.
 
 * ``package_selection_args``: package selection arguments passed to ``colcon``
   to specify which packages should be built and tested.

--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -458,6 +458,11 @@ The following options are valid in version ``1`` (beside the generic options):
 * ``jenkins_job_upstream_triggers``: names of other CI jobs which, when
   built with a stable or unstable result, should trigger this job to be built.
 
+* ``jenkins_job_weight``: the number of executors on a worker which are
+  required to execute the job.
+  Default is ``1``.
+  Activates the Jenkins Heavy Job plugin.
+
 * ``package_selection_args``: package selection arguments passed to ``colcon``
   to specify which packages should be built and tested.
   Note that ``colcon`` is always used to select packages even when

--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -256,6 +256,7 @@ def _get_ci_job_config(
 
     job_data = {
         'job_priority': build_file.jenkins_job_priority,
+        'job_weight': build_file.jenkins_job_weight,
         'node_label': get_node_label(
             build_file.jenkins_job_label,
             get_default_node_label('%s_%s' % (

--- a/ros_buildfarm/config/ci_build_file.py
+++ b/ros_buildfarm/config/ci_build_file.py
@@ -69,6 +69,7 @@ class CIBuildFile(BuildFile):
         if 'jenkins_job_upstream_triggers' in data:
             self.jenkins_job_upstream_triggers = data['jenkins_job_upstream_triggers']
             assert isinstance(self.jenkins_job_upstream_triggers, list)
+        self.jenkins_job_weight = None
         if 'jenkins_job_weight' in data:
             self.jenkins_job_weight = int(data['jenkins_job_weight'])
 

--- a/ros_buildfarm/config/ci_build_file.py
+++ b/ros_buildfarm/config/ci_build_file.py
@@ -69,6 +69,8 @@ class CIBuildFile(BuildFile):
         if 'jenkins_job_upstream_triggers' in data:
             self.jenkins_job_upstream_triggers = data['jenkins_job_upstream_triggers']
             assert isinstance(self.jenkins_job_upstream_triggers, list)
+        if 'jenkins_job_weight' in data:
+            self.jenkins_job_weight = int(data['jenkins_job_weight'])
 
         self.package_selection_args = None
         if 'package_selection_args' in data:

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -83,6 +83,10 @@ parameters = [
     'property_authorization-matrix',
     project_authorization_xml=project_authorization_xml
 ))@
+@(SNIPPET(
+    'property_job-weight',
+    weight=job_weight,
+))@
   </properties>
   <scm class="hudson.scm.NullSCM"/>
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>

--- a/ros_buildfarm/templates/ci/ci_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_reconfigure-jobs_job.xml.em
@@ -28,6 +28,9 @@
         },
     ],
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_git',

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -50,6 +50,9 @@ if pull_request:
     'property_parameters-definition',
     parameters=parameters,
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @[if not pull_request]@
 @(SNIPPET(

--- a/ros_buildfarm/templates/devel/devel_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_reconfigure-jobs_job.xml.em
@@ -33,6 +33,9 @@
         },
     ],
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_git',

--- a/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
@@ -20,6 +20,9 @@
 @(SNIPPET(
     'property_requeue-job',
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
   'scm_git',

--- a/ros_buildfarm/templates/doc/doc_independent_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_job.xml.em
@@ -20,6 +20,9 @@
 @(SNIPPET(
     'property_requeue-job',
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_null',

--- a/ros_buildfarm/templates/doc/doc_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_job.xml.em
@@ -46,6 +46,9 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         },
     ],
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm',

--- a/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
@@ -20,6 +20,9 @@
 @(SNIPPET(
     'property_requeue-job',
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_null',

--- a/ros_buildfarm/templates/doc/doc_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_reconfigure-jobs_job.xml.em
@@ -33,6 +33,9 @@
         },
     ],
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_git',

--- a/ros_buildfarm/templates/misc/check_agents_job.xml.em
+++ b/ros_buildfarm/templates/misc/check_agents_job.xml.em
@@ -18,6 +18,9 @@
 @(SNIPPET(
     'property_requeue-job',
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_null',

--- a/ros_buildfarm/templates/misc/dashboard_job.xml.em
+++ b/ros_buildfarm/templates/misc/dashboard_job.xml.em
@@ -18,6 +18,9 @@
 @(SNIPPET(
     'property_requeue-job',
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_null',

--- a/ros_buildfarm/templates/misc/rosdistro_cache_job.xml.em
+++ b/ros_buildfarm/templates/misc/rosdistro_cache_job.xml.em
@@ -18,6 +18,9 @@
 @(SNIPPET(
     'property_requeue-job',
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_git',

--- a/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
@@ -38,6 +38,9 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         },
     ],
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_null',

--- a/ros_buildfarm/templates/release/deb/import_package_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/import_package_job.xml.em
@@ -31,6 +31,9 @@
         },
     ],
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_git',

--- a/ros_buildfarm/templates/release/deb/import_upstream_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/import_upstream_job.xml.em
@@ -39,6 +39,9 @@ Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'</descriptio
         },
     ],
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_git',

--- a/ros_buildfarm/templates/release/deb/sourcepkg_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/sourcepkg_job.xml.em
@@ -38,6 +38,9 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         },
     ],
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_null',

--- a/ros_buildfarm/templates/release/deb/sync_packages_to_main_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/sync_packages_to_main_job.xml.em
@@ -18,6 +18,9 @@
 @(SNIPPET(
     'property_requeue-job',
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_git',

--- a/ros_buildfarm/templates/release/deb/sync_packages_to_testing_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/sync_packages_to_testing_job.xml.em
@@ -18,6 +18,9 @@
 @(SNIPPET(
     'property_requeue-job',
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_git',

--- a/ros_buildfarm/templates/release/release_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/release/release_reconfigure-jobs_job.xml.em
@@ -33,6 +33,9 @@
         },
     ],
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_git',

--- a/ros_buildfarm/templates/release/release_trigger-broken-with-non-broken-upstream_job.xml.em
+++ b/ros_buildfarm/templates/release/release_trigger-broken-with-non-broken-upstream_job.xml.em
@@ -18,6 +18,9 @@
 @(SNIPPET(
     'property_requeue-job',
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_null',

--- a/ros_buildfarm/templates/release/release_trigger-jobs_job.xml.em
+++ b/ros_buildfarm/templates/release/release_trigger-jobs_job.xml.em
@@ -46,6 +46,9 @@ if missed_jobs:
         </hudson.model.ChoiceParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_git',

--- a/ros_buildfarm/templates/release/rpm/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_job.xml.em
@@ -38,6 +38,9 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         },
     ],
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_null',

--- a/ros_buildfarm/templates/release/rpm/import_package_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/import_package_job.xml.em
@@ -44,6 +44,9 @@
         },
     ],
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_git',

--- a/ros_buildfarm/templates/release/rpm/import_upstream_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/import_upstream_job.xml.em
@@ -41,6 +41,9 @@
         },
     ],
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_git',

--- a/ros_buildfarm/templates/release/rpm/sourcepkg_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sourcepkg_job.xml.em
@@ -38,6 +38,9 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         },
     ],
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_null',

--- a/ros_buildfarm/templates/release/rpm/sync_packages_to_main_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sync_packages_to_main_job.xml.em
@@ -18,6 +18,9 @@
 @(SNIPPET(
     'property_requeue-job',
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_git',

--- a/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
@@ -18,6 +18,9 @@
 @(SNIPPET(
     'property_requeue-job',
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_git',

--- a/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
+++ b/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
@@ -10,6 +10,9 @@
     <org.jenkinsci.plugins.requeuejob.RequeueJobProperty plugin="jobrequeue@@1.1">
       <requeueJob>false</requeueJob>
     </org.jenkinsci.plugins.requeuejob.RequeueJobProperty>
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
   <scm class="hudson.scm.NullSCM"/>
   <assignedNode>building_repository</assignedNode>

--- a/ros_buildfarm/templates/snippet/property_job-weight.xml.em
+++ b/ros_buildfarm/templates/snippet/property_job-weight.xml.em
@@ -1,0 +1,3 @@
+    <hudson.plugins.heavy__job.HeavyJobProperty plugin="heavy-job@@1.1">
+      <weight>@(weight if 'weight' in vars() else 1)</weight>
+    </hudson.plugins.heavy__job.HeavyJobProperty>

--- a/ros_buildfarm/templates/snippet/trigger-jobs_job.xml.em
+++ b/ros_buildfarm/templates/snippet/trigger-jobs_job.xml.em
@@ -45,6 +45,9 @@
 @[end if]@
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_null',

--- a/ros_buildfarm/templates/status/blocked_releases_page_job.xml.em
+++ b/ros_buildfarm/templates/status/blocked_releases_page_job.xml.em
@@ -18,6 +18,9 @@
 @(SNIPPET(
     'property_requeue-job',
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_git',

--- a/ros_buildfarm/templates/status/blocked_source_entries_page_job.xml.em
+++ b/ros_buildfarm/templates/status/blocked_source_entries_page_job.xml.em
@@ -18,6 +18,9 @@
 @(SNIPPET(
     'property_requeue-job',
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_git',

--- a/ros_buildfarm/templates/status/release_compare_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_compare_page_job.xml.em
@@ -18,6 +18,9 @@
 @(SNIPPET(
     'property_requeue-job',
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_git',

--- a/ros_buildfarm/templates/status/release_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_status_page_job.xml.em
@@ -18,6 +18,9 @@
 @(SNIPPET(
     'property_requeue-job',
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_git',

--- a/ros_buildfarm/templates/status/repos_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/repos_status_page_job.xml.em
@@ -18,6 +18,9 @@
 @(SNIPPET(
     'property_requeue-job',
 ))@
+@(SNIPPET(
+    'property_job-weight',
+))@
   </properties>
 @(SNIPPET(
     'scm_git',


### PR DESCRIPTION
This plugin will need to be installed at the same time this PR is merged to avoid unnecessary diffs in the job configurations.

The intended use case is to allow some jobs (namely the nightly CI jobs) to take up more executor slots on the workers to avoid resource contention with other jobs.