### PR TITLE
Handle 'None' job weight configuration

### DIFF
--- a/ros_buildfarm/templates/snippet/property_job-weight.xml.em
+++ b/ros_buildfarm/templates/snippet/property_job-weight.xml.em
@@ -1,3 +1,3 @@
     <hudson.plugins.heavy__job.HeavyJobProperty plugin="heavy-job@@1.1">
-      <weight>@(weight if 'weight' in vars() else 1)</weight>
+      <weight>@(weight if 'weight' in vars() and weight is not None else 1)</weight>
     </hudson.plugins.heavy__job.HeavyJobProperty>


### PR DESCRIPTION
A bit of an oversight in #839. When the job weight is unspecified in the build configuration, it should default to `1`, and not an empty XML element.

This will only affect CI jobs, since that is the only job type where `weight` was specified at all.