### PR TITLE
Run upload jobs after import_upstream.

### DIFF
--- a/scripts/release/generate_release_trigger_upload_jobs.py
+++ b/scripts/release/generate_release_trigger_upload_jobs.py
@@ -81,6 +81,7 @@ def get_upstream_job_names(config, repo):
                             arch=arch))
     else:
         raise JobValidationError("Unknown upstream jobs for job 'upload_{}'." % repo)
+    upstream_job_names.append('import_upstream')
     return ','.join(sorted(upstream_job_names))
 
 


### PR DESCRIPTION
The import_upstream job does not currently trigger an upload from the
buildfarm repository to the primary packages.ros.org mirrors. This
occassionally causes issues if someone triggering an import after
updating the bootstrap repository fails to return after the import is
complete and trigger the uploads manually.

There's no situation I can see where we would want to update the build
farm repositories from the bootstrap repo without pushing those changes
to the primary mirror and the buildfarm testing and main repositories
should always be in a ready state for sync otherwise since the sync jobs
trigger uploads already so I also don't see a situation where an upload
due to import_upstream would contain ROS packages that were not yet
supposed to be part of the primary mirror in their respective
repositories.

Example diff from a dry-run:

```
Connecting to Jenkins 'http://build.ros2.org'
Connected to Jenkins version '2.235.2'
Updating job 'upload_main' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -26 +26 @@
    -      <upstreamProjects>Drel_sync-packages-to-main,Erel_sync-packages-to-main,Frel_sync-packages-to-main,Rrel_sync-packages-to-main</upstreamProjects>
    +      <upstreamProjects>Drel_sync-packages-to-main,Erel_sync-packages-to-main,Frel_sync-packages-to-main,Rrel_sync-packages-to-main,import_upstream</upst
reamProjects>
    >>>
Updating job 'upload_testing' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -26 +26 @@
    -      <upstreamProjects>Drel_sync-packages-to-testing_bionic_amd64,Drel_sync-packages-to-testing_bionic_arm64,Drel_sync-packages-to-testing_bionic_armhf,
Erel_sync-packages-to-testing_bionic_amd64,Erel_sync-packages-to-testing_bionic_arm64,Erel_sync-packages-to-testing_bionic_armhf,Frel_sync-packages-to-testing
_focal_amd64,Frel_sync-packages-to-testing_focal_arm64,Rrel_sync-packages-to-testing_focal_amd64,Rrel_sync-packages-to-testing_focal_arm64</upstreamProjects>
    +      <upstreamProjects>Drel_sync-packages-to-testing_bionic_amd64,Drel_sync-packages-to-testing_bionic_arm64,Drel_sync-packages-to-testing_bionic_armhf,
Erel_sync-packages-to-testing_bionic_amd64,Erel_sync-packages-to-testing_bionic_arm64,Erel_sync-packages-to-testing_bionic_armhf,Frel_sync-packages-to-testing
_focal_amd64,Frel_sync-packages-to-testing_focal_arm64,Rrel_sync-packages-to-testing_focal_amd64,Rrel_sync-packages-to-testing_focal_arm64,import_upstream</up
streamProjects>
    >>>
```

This change affects only the generate_release_trigger_upload.py script which is not part of the default configurations and is used on build.ros{,2}.org to trigger a sync to packages.ros.org.