### PR TITLE
Make the doc_independent_docker_build a little more generic.

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -348,8 +348,17 @@ The following options are valid in version ``2`` (beside the generic options):
     to configure the repositories. See *doc* jobs documentation to learn
     about the expected Dockerfile structure.
 
-* ``doc_repositories``: a list of repository URLs (used when the
-  ``documentation_type`` is set to ``make_target`` or ``docker_build``).
+* ``doc_repositories``: a list of repository URLs, or a dictionary of repository
+  URLs and branches (used when the ``documentation_type`` is set to ``make_target``
+  or ``docker_build``).  When the list form is used, the default branch from each
+  repository is always used.  When the dictionary form is used, it should have
+  the following structure:
+
+::
+   repo_name:
+     url: <url_to_doc_repository>
+     branch: <branch_name_to_use>
+
 * ``install_apt_packages``: a list of packages to be installed with apt (only
   allowed when the ``documentation_type`` is set to ``make_target``).
 * ``install_pip_packages``: a list of packages to be installed with pip (only

--- a/ros_buildfarm/config/doc_build_file.py
+++ b/ros_buildfarm/config/doc_build_file.py
@@ -179,6 +179,12 @@ class DocBuildFile(BuildFile):
 
             self.doc_repository_branch = data.get('doc_repository_branch', None)
 
+        # If neither upload location is specified, fall back to a default of
+        # an upload_host of 'repo', which is valid for the publish-over-ssh
+        # configuration.
+        if self.upload_host is None and self.upload_repository_url is None:
+            self.upload_host = 'repo'
+
         # Ensure that we have one, and only one, place to upload to
         assert (self.upload_host is not None) ^ (self.upload_repository_url is not None)
 

--- a/ros_buildfarm/config/doc_build_file.py
+++ b/ros_buildfarm/config/doc_build_file.py
@@ -167,14 +167,21 @@ class DocBuildFile(BuildFile):
         # user host and docroot have default of uploading to the repo machine
         # next to the debs
         self.upload_user = data.get('upload_user', 'jenkins-agent')
-        self.upload_host = data.get('upload_host', 'repo')
+        self.upload_host = data.get('upload_host', None)
         self.upload_root = data.get('upload_root', '/var/repos/docs')
+
+        self.upload_repository_url = None
         if self.documentation_type == DOC_TYPE_DOCKER:
-            assert 'upload_repository_url' in data
-            self.upload_repository_url = data['upload_repository_url']
+            self.upload_repository_url = data.get('upload_repository_url', None)
             self.upload_repository_branch = data.get(
                 'upload_repository_branch', 'gh-pages'
             )
+
+            self.doc_repository_branch = data.get('doc_repository_branch', None)
+
+        # Ensure that we have one, and only one, place to upload to
+        assert (self.upload_host is not None) ^ (self.upload_repository_url is not None)
+
         assert 'upload_credential_id' in data
         self.upload_credential_id = data['upload_credential_id']
 

--- a/ros_buildfarm/config/doc_build_file.py
+++ b/ros_buildfarm/config/doc_build_file.py
@@ -74,10 +74,22 @@ class DocBuildFile(BuildFile):
             self.canonical_base_url = data['canonical_base_url']
             assert not self.canonical_base_url or is_rosdoc_type
 
-        self.doc_repositories = []
+        self.doc_repositories = {}
         if 'doc_repositories' in data:
-            self.doc_repositories = data['doc_repositories']
-            assert isinstance(self.doc_repositories, list)
+            doc_repos = data['doc_repositories']
+            if isinstance(doc_repos, list):
+                for url in doc_repos:
+                    self.doc_repositories[url] = ''
+            elif isinstance(doc_repos, dict):
+                for repo in doc_repos:
+                    assert 'url' in doc_repos[repo]
+                    url = doc_repos[repo]['url']
+                    if 'branch' in doc_repos[repo]:
+                        self.doc_repositories[url] = doc_repos[repo]['branch']
+                    else:
+                        self.doc_repositories[url] = ''
+            else:
+                assert isinstance(doc_repos, list) or isinstance(doc_repos, dict)
 
         # doc_repositories can only be used with make_target and docker_build
         # doc types
@@ -176,8 +188,6 @@ class DocBuildFile(BuildFile):
             self.upload_repository_branch = data.get(
                 'upload_repository_branch', 'gh-pages'
             )
-
-            self.doc_repository_branch = data.get('doc_repository_branch', None)
 
         # If neither upload location is specified, fall back to a default of
         # an upload_host of 'repo', which is valid for the publish-over-ssh

--- a/ros_buildfarm/doc_job.py
+++ b/ros_buildfarm/doc_job.py
@@ -427,6 +427,12 @@ def _get_doc_independent_job_config(
         'notify_emails': build_file.notify_emails,
 
         'timeout_minutes': build_file.jenkins_job_timeout,
+
+        'upload_user': build_file.upload_user,
+        'upload_host': build_file.upload_host,
+        'upload_root': build_file.upload_root,
+
+        'credential_id': build_file.upload_credential_id
     }
 
     if build_file.documentation_type == 'make_target':
@@ -434,17 +440,13 @@ def _get_doc_independent_job_config(
         job_data.update({
             'install_apt_packages': build_file.install_apt_packages,
             'install_pip_packages': build_file.install_pip_packages,
-            'upload_user': build_file.upload_user,
-            'upload_host': build_file.upload_host,
-            'upload_root': build_file.upload_root,
-            'credential_id': build_file.upload_credential_id
         })
     elif build_file.documentation_type == 'docker_build':
         template_name = 'doc/doc_independent_docker_job.xml.em'
         job_data.update({
+            'doc_repository_branch': build_file.doc_repository_branch,
             'upload_repository_url': build_file.upload_repository_url,
             'upload_repository_branch': build_file.upload_repository_branch,
-            'upload_credential_id': build_file.upload_credential_id,
         })
     else:
         raise JobValidationError(

--- a/ros_buildfarm/doc_job.py
+++ b/ros_buildfarm/doc_job.py
@@ -444,7 +444,6 @@ def _get_doc_independent_job_config(
     elif build_file.documentation_type == 'docker_build':
         template_name = 'doc/doc_independent_docker_job.xml.em'
         job_data.update({
-            'doc_repository_branch': build_file.doc_repository_branch,
             'upload_repository_url': build_file.upload_repository_url,
             'upload_repository_branch': build_file.upload_repository_branch,
         })

--- a/ros_buildfarm/doc_job.py
+++ b/ros_buildfarm/doc_job.py
@@ -432,7 +432,7 @@ def _get_doc_independent_job_config(
         'upload_host': build_file.upload_host,
         'upload_root': build_file.upload_root,
 
-        'credential_id': build_file.upload_credential_id
+        'upload_credential_id': build_file.upload_credential_id
     }
 
     if build_file.documentation_type == 'make_target':

--- a/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
@@ -89,15 +89,15 @@ import os
 doc_repository_name = os.path.splitext(os.path.basename(doc_repository_url))[0]
 
 if doc_repository_branch is None:
-  doc_repository_branch = ''
+  repo_branch_arg = ''
 else:
-  doc_repository_branch = '--no-single-branch -b ' + doc_repository_branch
+  repo_branch_arg = '--no-single-branch -b ' + doc_repository_branch
 }@
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
         'echo "# BEGIN SECTION: Clone %s"' % doc_repository_name,
-        'python3 -u $WORKSPACE/ros_buildfarm/scripts/wrapper/git.py clone --depth 1 %s %s $WORKSPACE/repositories/%s' % (doc_repository_url, doc_repository_branch, doc_repository_name),
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/wrapper/git.py clone --depth 1 %s %s $WORKSPACE/repositories/%s' % (doc_repository_url, repo_branch_arg, doc_repository_name),
         'git -C $WORKSPACE/repositories/%s log -n 1' % doc_repository_name,
         'echo "# END SECTION"',
     ]),
@@ -137,11 +137,11 @@ else:
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
-        'if [ -d "$WORKSPACE/repositories/%s/build/html" ]; then' % (doc_repository_name),
+        'if [ -d "$WORKSPACE/repositories/%s/build/html" ]; then' % doc_repository_name,
         '  echo "# BEGIN SECTION: rsync API documentation to server"',
         '  ssh %s@%s "mkdir -p %s"' %
           (upload_user, upload_host, os.path.join(upload_root, 'build', 'html')),
-        '  cd $WORKSPACE/repositories/%s/build' % (doc_repository_name),
+        '  cd $WORKSPACE/repositories/%s/build' % doc_repository_name,
         '  rsync -e ssh --stats -r --delete html %s@%s:%s' % \
           (upload_user, upload_host, os.path.join(upload_root, 'build/html')),
         '  echo "# END SECTION"',

--- a/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
@@ -83,15 +83,15 @@
     'builder_shell_key-files',
     script_generating_key_files=script_generating_key_files,
 ))@
-@[for doc_repository_url in doc_repositories]@
+@[for doc_repository_url,branch in doc_repositories.items()]@
 @{
 import os
 doc_repository_name = os.path.splitext(os.path.basename(doc_repository_url))[0]
 
-if doc_repository_branch is None:
+if not branch:
   repo_branch_arg = ''
 else:
-  repo_branch_arg = '--no-single-branch -b ' + doc_repository_branch
+  repo_branch_arg = '--no-single-branch -b ' + branch
 }@
 @(SNIPPET(
     'builder_shell',

--- a/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
@@ -29,7 +29,7 @@
   'scm_git',
    url=upload_repository_url,
    branch_name=upload_repository_branch,
-   git_ssh_credential_id=credential_id,
+   git_ssh_credential_id=upload_credential_id,
    relative_target_dir='upload_repository',
    refspec=None,
 ))@

--- a/ros_buildfarm/templates/doc/doc_independent_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_job.xml.em
@@ -163,7 +163,7 @@ repo_name = os.path.splitext(os.path.basename(repo_url))[0]
 ))@
 @(SNIPPET(
     'build-wrapper_ssh-agent',
-    credential_ids=[credential_id],
+    credential_ids=[upload_credential_id],
 ))@
   </buildWrappers>
 </project>

--- a/ros_buildfarm/templates/doc/doc_independent_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_job.xml.em
@@ -61,18 +61,22 @@
     'builder_shell',
     script='rm -fr repositories',
 ))@
-@[for repo_url in doc_repositories]@
+@[for repo_url,branch in doc_repositories.items()]@
 @{
 import os
 repo_name = os.path.splitext(os.path.basename(repo_url))[0]
+
+if not branch:
+  repo_branch_arg = ''
+else:
+  repo_branch_arg = '--no-single-branch -b ' + branch
 }@
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
         'echo "# BEGIN SECTION: Clone %s"' % repo_name,
-        'python3 -u $WORKSPACE/ros_buildfarm/scripts/wrapper/git.py clone --depth 1 %s $WORKSPACE/repositories/%s' % (repo_url, repo_name),
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/wrapper/git.py clone --depth 1 %s %s $WORKSPACE/repositories/%s' % (repo_url, repo_branch_arg, repo_name),
         'git -C $WORKSPACE/repositories/%s log -n 1' % repo_name,
-        'rm -fr $WORKSPACE/repositories/%s/.git' % repo_name,
         'echo "# END SECTION"',
     ]),
 ))@


### PR DESCRIPTION
In particular:

1.  Allow the user to specify the branch to checkout on the
source repository.
2.  Allow the doc_independent_docker_build to upload either
via the publish-over-git publisher, or via an rsync script.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This functionality is needed for uploading ros2_documentation to docs.ros.org.  I've tested this functionality up to the upload sequence; the test buildfarm I am working on doesn't actually have the correct credentials, so I can't do an end-to-end test.  I'll point out a few things of interest inline.

