### PR TITLE
Run c_rehash to work around openssl rehash issue on focal/armhf.

### DIFF
--- a/ros_buildfarm/templates/release/deb/binarypkg_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/deb/binarypkg_create_task.Dockerfile.em
@@ -63,6 +63,9 @@ RUN echo "@today_str"
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y devscripts dpkg-dev python3-apt python3-catkin-pkg-modules python3-empy python3-rosdistro-modules python3-yaml
 
+# Workaround for focal armhf certificate rehash issue
+RUN . /etc/os-release && test "$VERSION_ID" = "20.04" && test "$(uname -m)" = "armv7l" && c_rehash || true
+
 # always invalidate to actually have the latest apt repo state
 RUN echo "@now_str"
 RUN python3 -u /tmp/wrapper_scripts/apt.py update

--- a/ros_buildfarm/templates/release/deb/binarypkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/deb/binarypkg_task.Dockerfile.em
@@ -57,6 +57,9 @@ RUN echo "@today_str"
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-yaml
 
+# Workaround for focal armhf certificate rehash issue
+RUN . /etc/os-release && test "$VERSION_ID" = "20.04" && test "$(uname -m)" = "armv7l" && c_rehash || true
+
 @(TEMPLATE(
     'snippet/install_dh-python.Dockerfile.em',
     os_name=os_name,


### PR DESCRIPTION
As discussed in
https://discourse.ros.org/t/ssl-failure-in-buildfarm-jobs-ros1/18304/3
there is an issue with Ubuntu 20.04 armhf when being run on an amd64
20.04 host via qemu which is interfering with openssl-rehash.

Until the cause is identified we're invoking c_rehash explicitly as the
last step before cache invalidation when the build environment is 20.04
on armhf.

On a local test using the script generated with `generate_release_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml noetic ufhf geometry_msgs ubuntu focal armhf > /tmp/geom.sh`

I was able to get past the SSL issue shown on the buildfarm and confirmed with a local run before modification. But I then got a weird compiler issue when actually building the deb which didn't *seem* related but that I also didn't bother to triage deeply. So far as I can tell this is enough to get these packages operational.

@cottsay when examining the template files I saw that the binarydeb task file as opposed to the generate file didn't have the rehash workaround so I threw on an additional commit adding it. But it made no difference for me locally.