### PR TITLE
Clean up repositories directory after successful doc job

### DIFF
--- a/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
@@ -127,13 +127,11 @@ doc_repository_name = os.path.splitext(os.path.basename(doc_repository_url))[0]
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
-        'if [ "$skip_cleanup" = "false" ]; then',
         'echo "# BEGIN SECTION: Clean up to save disk space on agents"',
         '# ensure to have write permission before trying to delete the folder',
         'chmod -R u+w $WORKSPACE/repositories',
-        'rm -fr repositories',
+        'rm -fr $WORKSPACE/repositories',
         'echo "# END SECTION"',
-        'fi',
     ]),
 ))@
   </builders>

--- a/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
@@ -124,6 +124,19 @@ doc_repository_name = os.path.splitext(os.path.basename(doc_repository_url))[0]
     ]),
 ))@
 @[end for]@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'if [ "$skip_cleanup" = "false" ]; then',
+        'echo "# BEGIN SECTION: Clean up to save disk space on agents"',
+        '# ensure to have write permission before trying to delete the folder',
+        'chmod -R u+w $WORKSPACE/repositories',
+        'rm -fr repositories',
+        'echo "# END SECTION"',
+        'fi',
+    ]),
+))@
+
   </builders>
   <publishers>
 @(SNIPPET(

--- a/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
@@ -136,7 +136,6 @@ doc_repository_name = os.path.splitext(os.path.basename(doc_repository_url))[0]
         'fi',
     ]),
 ))@
-
   </builders>
   <publishers>
 @(SNIPPET(

--- a/ros_buildfarm/templates/doc/doc_independent_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_job.xml.em
@@ -145,13 +145,11 @@ repo_name = os.path.splitext(os.path.basename(repo_url))[0]
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
-        'if [ "$skip_cleanup" = "false" ]; then',
         'echo "# BEGIN SECTION: Clean up to save disk space on agents"',
         '# ensure to have write permission before trying to delete the folder',
         'chmod -R u+w $WORKSPACE/repositories',
-        'rm -fr repositories',
+        'rm -fr $WORKSPACE/repositories',
         'echo "# END SECTION"',
-        'fi',
     ]),
 ))@
   </builders>

--- a/ros_buildfarm/templates/doc/doc_independent_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_job.xml.em
@@ -142,6 +142,18 @@ repo_name = os.path.splitext(os.path.basename(repo_url))[0]
         'fi',
     ]),
 ))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'if [ "$skip_cleanup" = "false" ]; then',
+        'echo "# BEGIN SECTION: Clean up to save disk space on agents"',
+        '# ensure to have write permission before trying to delete the folder',
+        'chmod -R u+w $WORKSPACE/repositories',
+        'rm -fr repositories',
+        'echo "# END SECTION"',
+        'fi',
+    ]),
+))@
   </builders>
   <publishers>
 @(SNIPPET(


### PR DESCRIPTION
The rosindex doc_independent_docker job is leaving a 30 GiB directory on disk after a successful build. One of the first things a new build does is delete that directory, so it isn't being used as a cache of any kind (though maybe it could).

The oversize worker on build.ros.org is dropping below the free disk space threshold, and this job is a decent sized part of that.