### PR TITLE
Drop superfluous mentions of 'CentOS'

### DIFF
--- a/ros_buildfarm/sourcerpm_job.py
+++ b/ros_buildfarm/sourcerpm_job.py
@@ -20,7 +20,7 @@ from ros_buildfarm.common import get_os_package_name
 
 def _get_source_tag(
         rosdistro_name, pkg_name, pkg_version, os_name, os_code_name):
-    assert os_name in ['centos', 'fedora', 'rhel']
+    assert os_name in ['fedora', 'rhel']
     return 'rpm/%s-%s_%s' % (
         get_os_package_name(rosdistro_name, pkg_name),
         pkg_version, os_code_name)

--- a/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
@@ -2,16 +2,16 @@
 package_manager = 'dnf'
 python3_pkgversion = '3'
 
-if os_name in ['centos', 'rhel'] and os_code_name.isnumeric() and int(os_code_name) < 8:
+if os_name in ['rhel'] and os_code_name.isnumeric() and int(os_code_name) < 8:
     package_manager = 'yum'
     python3_pkgversion = '36'
 }@
 # generated from @template_name
 
-@[if os_name in ['centos', 'rhel']]@
+@[if os_name in ['rhel']]@
 FROM centos:@(os_code_name)
 
-# Enable EPEL on CentOS/RHEL
+# Enable EPEL on RHEL
 RUN @(package_manager) install -y epel-release
 @[else]@
 FROM @(os_name):@(os_code_name)

--- a/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
@@ -2,7 +2,7 @@
 package_manager = 'dnf'
 python3_pkgversion = '3'
 
-if os_name in ['rhel'] and os_code_name.isnumeric() and int(os_code_name) < 8:
+if os_name == 'rhel' and os_code_name.isnumeric() and int(os_code_name) < 8:
     package_manager = 'yum'
     python3_pkgversion = '36'
 }@

--- a/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
+++ b/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
@@ -32,7 +32,7 @@ config_opts['macros']['%__cmake3_in_source_build'] = '1'
 # Required for running mock in Docker
 config_opts['use_nspawn'] = False
 
-@[if os_name in ['centos', 'rhel'] and os_code_name == '7']@
+@[if os_name in ['rhel'] and os_code_name == '7']@
 # Inject g++ 8 into RHEL 7 builds
 config_opts['chroot_setup_cmd'] += ' devtoolset-8-gcc-c++ devtoolset-8-make-nonblocking'
 config_opts['macros']['%_buildshell'] = '/usr/bin/scl enable devtoolset-8 -- /bin/sh'

--- a/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
+++ b/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
@@ -32,7 +32,7 @@ config_opts['macros']['%__cmake3_in_source_build'] = '1'
 # Required for running mock in Docker
 config_opts['use_nspawn'] = False
 
-@[if os_name in ['rhel'] and os_code_name == '7']@
+@[if os_name == 'rhel' and os_code_name == '7']@
 # Inject g++ 8 into RHEL 7 builds
 config_opts['chroot_setup_cmd'] += ' devtoolset-8-gcc-c++ devtoolset-8-make-nonblocking'
 config_opts['macros']['%_buildshell'] = '/usr/bin/scl enable devtoolset-8 -- /bin/sh'

--- a/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
@@ -2,16 +2,16 @@
 package_manager = 'dnf'
 python3_pkgversion = '3'
 
-if os_name in ['centos', 'rhel'] and os_code_name.isnumeric() and int(os_code_name) < 8:
+if os_name in ['rhel'] and os_code_name.isnumeric() and int(os_code_name) < 8:
     package_manager = 'yum'
     python3_pkgversion = '36'
 }@
 # generated from @template_name
 
-@[if os_name in ['centos', 'rhel']]@
+@[if os_name in ['rhel']]@
 FROM centos:@(os_code_name)
 
-# Enable EPEL on CentOS/RHEL
+# Enable EPEL on RHEL
 RUN @(package_manager) install -y epel-release
 @[else]@
 FROM @(os_name):@(os_code_name)

--- a/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
@@ -2,7 +2,7 @@
 package_manager = 'dnf'
 python3_pkgversion = '3'
 
-if os_name in ['rhel'] and os_code_name.isnumeric() and int(os_code_name) < 8:
+if os_name == 'rhel' and os_code_name.isnumeric() and int(os_code_name) < 8:
     package_manager = 'yum'
     python3_pkgversion = '36'
 }@


### PR DESCRIPTION
We're really targeting RHEL here, so no need to discriminate which clone. The only remaining mentions in this repo stem from our use of the CentOS docker images specifically for building RHEL packages.