### PR TITLE
add graphviz as a dependency necessary for sphinx in rosdoc_lite

### DIFF
--- a/scripts/doc/create_doc_task_generator.py
+++ b/scripts/doc/create_doc_task_generator.py
@@ -518,6 +518,7 @@ def main(argv=sys.argv[1:]):
             'rsync',
             # the following are required by rosdoc_lite
             'doxygen',
+            'graphviz',
             # since catkin is not a run dependency but provides the setup files
             get_os_package_name(args.rosdistro_name, 'catkin'),
             # rosdoc_lite does not work without genmsg being importable


### PR DESCRIPTION
Working to resolve: https://github.com/ros/geometry2/issues/498

I think the dependency used to come in for free from something indirectly.