### PR TITLE
Test ROS 2 release jobs in CI 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -266,3 +266,38 @@ jobs:
           os_code_name: focal
           overlay_pkg: rcutils
           underlay_repos: ament_cmake_ros
+
+  ros2_release:
+    name: ROS 2 Release
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+      - name: Run job
+        uses: ./.github/actions/release
+        with:
+          config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
+          ros_distro: rolling
+          os_code_name: focal
+          pkg_name: rcutils
+
+  ros2_release_rpm:
+    name: ROS 2 Release (RPM)
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+      - name: Run job
+        uses: ./.github/actions/release
+        with:
+          config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
+          config_name: rhel
+          ros_distro: rolling
+          os_name: rhel
+          os_code_name: 8
+          arch: x86_64
+          pkg_name: rcutils

--- a/ros_buildfarm/templates/release/release_script.sh.em
+++ b/ros_buildfarm/templates/release/release_script.sh.em
@@ -47,13 +47,13 @@ cd $WORKSPACE
 
 echo ""
 echo "Get artifacts from source job"
-if [ -d "$BASEPATH/source/sourcedeb" ]; then
-    mkdir -p $WORKSPACE/binarydeb
-    (set -x; cp $BASEPATH/source/sourcedeb/*.debian.tar.[gx]z $BASEPATH/source/sourcedeb/*.dsc $BASEPATH/source/sourcedeb/*.orig.tar.gz $WORKSPACE/binarydeb/)
-else
-    mkdir -p $WORKSPACE/binarypkg/source/
-    (set -x; cp $BASEPATH/source/sourcepkg/*.src.rpm $WORKSPACE/binarypkg/source/)
-fi
+@[if package_format == 'deb']@
+mkdir -p $WORKSPACE/binarydeb
+(set -x; cp $BASEPATH/source/sourcedeb/*.debian.tar.[gx]z $BASEPATH/source/sourcedeb/*.dsc $BASEPATH/source/sourcedeb/*.orig.tar.gz $WORKSPACE/binarydeb/)
+@[else]@
+mkdir -p $WORKSPACE/binarypkg/source
+(set -x; cp $BASEPATH/source/sourcepkg/* $WORKSPACE/binarypkg/source/)
+@[end if]@
 
 @(TEMPLATE(
     'devel/devel_script_build.sh.em',

--- a/ros_buildfarm/templates/release/release_script.sh.em
+++ b/ros_buildfarm/templates/release/release_script.sh.em
@@ -50,9 +50,11 @@ echo "Get artifacts from source job"
 @[if package_format == 'deb']@
 mkdir -p $WORKSPACE/binarydeb
 (set -x; cp $BASEPATH/source/sourcedeb/*.debian.tar.[gx]z $BASEPATH/source/sourcedeb/*.dsc $BASEPATH/source/sourcedeb/*.orig.tar.gz $WORKSPACE/binarydeb/)
-@[else]@
+@[elif package_format == 'rpm']@
 mkdir -p $WORKSPACE/binarypkg/source
-(set -x; cp $BASEPATH/source/sourcepkg/* $WORKSPACE/binarypkg/source/)
+(set -x; cp $BASEPATH/source/sourcepkg/*.src.rpm $WORKSPACE/binarypkg/source/)
+@[else]@
+@{assert False, "Unsupported packaging format '%s'" % package_format}@
 @[end if]@
 
 @(TEMPLATE(

--- a/ros_buildfarm/templates/release/release_script.sh.em
+++ b/ros_buildfarm/templates/release/release_script.sh.em
@@ -51,8 +51,8 @@ if [ -d "$BASEPATH/source/sourcedeb" ]; then
     mkdir -p $WORKSPACE/binarydeb
     (set -x; cp $BASEPATH/source/sourcedeb/*.debian.tar.[gx]z $BASEPATH/source/sourcedeb/*.dsc $BASEPATH/source/sourcedeb/*.orig.tar.gz $WORKSPACE/binarydeb/)
 else
-    mkdir -p $WORKSPACE/binarypkg
-    (set -x; cp $BASEPATH/source/sourcepkg/*.src.rpm $WORKSPACE/binarypkg/)
+    mkdir -p $WORKSPACE/binarypkg/source/
+    (set -x; cp $BASEPATH/source/sourcepkg/*.src.rpm $WORKSPACE/binarypkg/source/)
 fi
 
 @(TEMPLATE(

--- a/ros_buildfarm/templates/release/release_script.sh.em
+++ b/ros_buildfarm/templates/release/release_script.sh.em
@@ -47,8 +47,13 @@ cd $WORKSPACE
 
 echo ""
 echo "Get artifacts from source job"
-mkdir -p $WORKSPACE/binarydeb
-(set -x; cp $BASEPATH/source/sourcedeb/*.debian.tar.[gx]z $BASEPATH/source/sourcedeb/*.dsc $BASEPATH/source/sourcedeb/*.orig.tar.gz $WORKSPACE/binarydeb/)
+if [ -d "$BASEPATH/source/sourcedeb" ]; then
+    mkdir -p $WORKSPACE/binarydeb
+    (set -x; cp $BASEPATH/source/sourcedeb/*.debian.tar.[gx]z $BASEPATH/source/sourcedeb/*.dsc $BASEPATH/source/sourcedeb/*.orig.tar.gz $WORKSPACE/binarydeb/)
+else
+    mkdir -p $WORKSPACE/binarypkg
+    (set -x; cp $BASEPATH/source/sourcepkg/*.src.rpm $WORKSPACE/binarypkg/)
+fi
 
 @(TEMPLATE(
     'devel/devel_script_build.sh.em',

--- a/scripts/release/generate_release_script.py
+++ b/scripts/release/generate_release_script.py
@@ -57,7 +57,7 @@ def main(argv=sys.argv[1:]):
 
         def beforeFile(self, *args, **kwargs):
             template_path = kwargs['file'].name
-            if template_path.endswith('/release/deb/binarypkg_job.xml.em'):
+            if template_path.endswith('/binarypkg_job.xml.em'):
                 self.scripts.append('--')
 
         def beforeInclude(self, *args, **kwargs):
@@ -74,6 +74,8 @@ def main(argv=sys.argv[1:]):
                         'fi',
                     ]
                     script = '\n'.join(lines)
+                elif 'Upload binary' in script or 'Upload source' in script:
+                    return
                 self.scripts.append(script)
 
     hook = IncludeHook()

--- a/scripts/release/generate_release_script.py
+++ b/scripts/release/generate_release_script.py
@@ -122,6 +122,26 @@ def main(argv=sys.argv[1:]):
             binary_scripts[i] = script
             break
 
+    # inject additional argument to skip fetching source package from repo
+    script_name = '/run_binarypkg_job.py '
+    additional_argument = '--skip-download-sourcepkg '
+    for i, script in enumerate(binary_scripts):
+        offset = script.find(script_name)
+        if offset != -1:
+            offset += len(script_name)
+            script = script[:offset] + additional_argument + script[offset:]
+            binary_scripts[i] = script
+            break
+
+    # remove rm command for sourcepkg location
+    rm_command = 'rm -fr $WORKSPACE/binarypkg'
+    for i, script in enumerate(binary_scripts):
+        offset = script.find(rm_command)
+        if offset != -1:
+            script = script[:offset] + script[offset + len(rm_command):]
+            binary_scripts[i] = script
+            break
+
     if args.skip_install:
         # remove install step
         script_name = '/create_binarydeb_install_task_generator.py '

--- a/scripts/release/generate_release_script.py
+++ b/scripts/release/generate_release_script.py
@@ -79,6 +79,8 @@ def main(argv=sys.argv[1:]):
                     ]
                     script = '\n'.join(lines)
                 elif 'Upload binary' in script or 'Upload source' in script:
+                    # Skip scripts which are responsible for uploading resources
+                    # to Pulp.
                     return
                 self.scripts.append(script)
 

--- a/scripts/release/generate_release_script.py
+++ b/scripts/release/generate_release_script.py
@@ -28,6 +28,7 @@ from ros_buildfarm.argument import add_argument_package_name
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.common import get_binarydeb_job_name
 from ros_buildfarm.common import get_sourcedeb_job_name
+from ros_buildfarm.common import package_format_mapping
 from ros_buildfarm.release_job import configure_release_job
 from ros_buildfarm.templates import expand_template
 
@@ -48,6 +49,9 @@ def main(argv=sys.argv[1:]):
         help='Skip trying to install binarydeb')
     args = parser.parse_args(argv)
 
+    package_format = package_format_mapping[args.os_name]
+    deb_or_pkg = 'deb' if package_format == 'deb' else 'pkg'
+
     # collect all template snippets of specific types
     class IncludeHook(Hook):
 
@@ -57,7 +61,7 @@ def main(argv=sys.argv[1:]):
 
         def beforeFile(self, *args, **kwargs):
             template_path = kwargs['file'].name
-            if template_path.endswith('/binarypkg_job.xml.em'):
+            if template_path.endswith('/release/%s/binarypkg_job.xml.em' % package_format):
                 self.scripts.append('--')
 
         def beforeInclude(self, *args, **kwargs):
@@ -103,7 +107,7 @@ def main(argv=sys.argv[1:]):
     binary_scripts = hook.scripts[separator_index + 1:]
 
     # inject additional argument to skip fetching sourcedeb from repo
-    script_name = '/run_binarydeb_job.py '
+    script_name = '/run_binary%s_job.py ' % deb_or_pkg
     additional_argument = '--skip-download-sourcepkg '
     for i, script in enumerate(binary_scripts):
         offset = script.find(script_name)
@@ -114,27 +118,7 @@ def main(argv=sys.argv[1:]):
             break
 
     # remove rm command for sourcedeb location
-    rm_command = 'rm -fr $WORKSPACE/binarydeb'
-    for i, script in enumerate(binary_scripts):
-        offset = script.find(rm_command)
-        if offset != -1:
-            script = script[:offset] + script[offset + len(rm_command):]
-            binary_scripts[i] = script
-            break
-
-    # inject additional argument to skip fetching source package from repo
-    script_name = '/run_binarypkg_job.py '
-    additional_argument = '--skip-download-sourcepkg '
-    for i, script in enumerate(binary_scripts):
-        offset = script.find(script_name)
-        if offset != -1:
-            offset += len(script_name)
-            script = script[:offset] + additional_argument + script[offset:]
-            binary_scripts[i] = script
-            break
-
-    # remove rm command for sourcepkg location
-    rm_command = 'rm -fr $WORKSPACE/binarypkg'
+    rm_command = 'rm -fr $WORKSPACE/binary%s' % deb_or_pkg
     for i, script in enumerate(binary_scripts):
         offset = script.find(rm_command)
         if offset != -1:
@@ -156,7 +140,8 @@ def main(argv=sys.argv[1:]):
             'source_job_name': source_job_name,
             'binary_job_name': binary_job_name,
             'source_scripts': source_scripts,
-            'binary_scripts': binary_scripts},
+            'binary_scripts': binary_scripts,
+            'package_format': package_format},
         options={BANGPATH_OPT: False})
     value = value.replace('python3', sys.executable)
     print(value)


### PR DESCRIPTION
Part of this change is getting the RPM jobs to work with the release script. The other is simply a matter of listing the jobs in the workflow.