### PR TITLE
Support more than one upstream RPM repo by default

### DIFF
--- a/ros_buildfarm/templates/release/rpm/import_upstream_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/import_upstream_job.xml.em
@@ -25,7 +25,7 @@
             'type': 'string',
             'name': 'REMOTE_SOURCE_EXPRESSION',
             'description': 'Expression to match pulp remote repositories',
-            'default_value': '^ros-upstream-[^-]*-([^-]*-[^-]*-[^-]*(-debug)?)$',
+            'default_value': '^ros-upstream-[^-]+-([^-]+-[^-]+-[^-]+(-debug)?)$',
         },
         {
             'type': 'string',

--- a/ros_buildfarm/templates/release/rpm/import_upstream_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/import_upstream_job.xml.em
@@ -25,7 +25,7 @@
             'type': 'string',
             'name': 'REMOTE_SOURCE_EXPRESSION',
             'description': 'Expression to match pulp remote repositories',
-            'default_value': '^ros-bootstrap-([^-]*-[^-]*-[^-]*(-debug)?)$',
+            'default_value': '^ros-upstream-[^-]*-([^-]*-[^-]*-[^-]*(-debug)?)$',
         },
         {
             'type': 'string',


### PR DESCRIPTION
This change expands the default pattern when looking for upstream RPM repositories to sync into building/testing/main.

Connects to ros-infrastructure/cookbook-ros-buildfarm#83