### PR TITLE
Mirror testing/main RPM repositories from pulp on disk

### DIFF
--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -884,12 +884,19 @@ def get_sync_packages_to_main_job_name(rosdistro_name, package_format):
 
 
 def _get_sync_packages_to_main_job_config(rosdistro_name, build_file, package_format):
+    sync_targets = set()
+    for os_name, os_versions in build_file.targets.items():
+        for os_code_name, os_arches in os_versions.items():
+            for os_arch in os_arches.keys():
+                sync_targets.add((os_name, os_code_name, os_arch))
+
     template_name = 'release/%s/sync_packages_to_main_job.xml.em' % package_format
     job_data = {
         'ros_buildfarm_repository': get_repository(),
         'rosdistro_name': rosdistro_name,
 
         'deb_sync_to_main_job_name': get_sync_packages_to_main_job_name(rosdistro_name, 'deb'),
+        'sync_targets': sync_targets,
 
         'notify_emails': build_file.notify_emails,
         'credential_id': build_file.upload_credential_id,

--- a/ros_buildfarm/templates/release/rpm/sync_packages_to_main_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sync_packages_to_main_job.xml.em
@@ -56,6 +56,23 @@
         'echo "# END SECTION"',
     ]),
 ))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'echo "# BEGIN SECTION: mirror main repository content to disk"',
+    ] + [
+        'rsync --recursive --times --delete --itemize-changes rsync://127.0.0.1:1234/ros-main-%s-%s-SRPMS/ /var/repos/%s/main/%s/SRPMS/' % (os_name, os_code_name, os_name, os_code_name)
+        for os_name, os_code_name in set((os_name, os_code_name) for os_name, os_code_name, _ in sync_targets)
+    ] + [
+        'rsync --recursive --times --delete --exclude=debug --itemize-changes rsync://127.0.0.1:1234/ros-main-%s-%s-%s/ /var/repos/%s/main/%s/%s/' % (os_name, os_code_name, arch, os_name, os_code_name, arch)
+        for os_name, os_code_name, arch in sync_targets
+    ] + [
+        'rsync --recursive --times --delete --itemize-changes rsync://127.0.0.1:1234/ros-main-%s-%s-%s-debug/ /var/repos/%s/main/%s/%s/debug/' % (os_name, os_code_name, arch, os_name, os_code_name, arch)
+        for os_name, os_code_name, arch in sync_targets
+    ] + [
+        'echo "# END SECTION"',
+    ]),
+))@
   </builders>
   <publishers>
 @(SNIPPET(

--- a/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
@@ -112,6 +112,16 @@
         'echo "# END SECTION"',
     ]),
 ))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'echo "# BEGIN SECTION: mirror testing repository content to disk"',
+        'rsync --recursive --times --delete --itemize-changes rsync://127.0.0.1:1234/ros-testing-%s-%s-SRPMS/ /var/repos/%s/testing/%s/SRPMS/' % (os_name, os_code_name, os_name, os_code_name),
+        'rsync --recursive --times --delete --exclude=debug --itemize-changes rsync://127.0.0.1:1234/ros-testing-%s-%s-%s/ /var/repos/%s/testing/%s/%s/' % (os_name, os_code_name, arch, os_name, os_code_name, arch),
+        'rsync --recursive --times --delete --itemize-changes rsync://127.0.0.1:1234/ros-testing-%s-%s-%s-debug/ /var/repos/%s/testing/%s/%s/debug/' % (os_name, os_code_name, arch, os_name, os_code_name, arch),
+        'echo "# END SECTION"',
+    ]),
+))@
   </builders>
   <publishers>
 @(SNIPPET(


### PR DESCRIPTION
This means that we won't need to expose the pulp content endpoint publicly, and also makes the packages available to sync'd to a downstream repository using rsync.