### PR TITLE
Add non-Debian/Ubuntu repos to upload jobs

### DIFF
--- a/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
+++ b/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
@@ -36,7 +36,9 @@
   <builders>
     <hudson.tasks.Shell>
       <command>#!/bin/bash
-$HOME/upload_triggers/upload_repo.bash @repo
+@[for target in sync_targets]@
+$HOME/upload_triggers/upload_repo.bash @target
+@[end for]@
 </command>
     </hudson.tasks.Shell>
   </builders>


### PR DESCRIPTION
This change works under the assumption that Debian and Ubuntu will continue to share a repository directory (and upstream upload triggers), but subsequent platforms will have separate directories and triggers.