### PR TITLE
Update xunit plugin version in template.

### DIFF
--- a/ros_buildfarm/templates/snippet/publisher_xunit.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_xunit.xml.em
@@ -3,7 +3,7 @@
 if 'types' not in vars() and 'pattern' in vars():
     types = [('GoogleTestType', pattern)]
 }@
-    <xunit plugin="xunit@@2.3.9">
+    <xunit plugin="xunit@@2.4.0">
       <types>
 @[for type_tag_and_pattern in types]@
 @{


### PR DESCRIPTION
Together with https://github.com/ros-infrastructure/cookbook-ros-buildfarm/pull/89 this should close #871.

This is the only plugin updated in that PR which is referenced in our templates according to a grep through for `${PLUGIN}@@`.