### PR TITLE
Drop portlet IDs from dashboard views

### DIFF
--- a/ros_buildfarm/templates/dashboard_view_all_jobs.xml.em
+++ b/ros_buildfarm/templates/dashboard_view_all_jobs.xml.em
@@ -34,13 +34,11 @@
   <rightPortlets/>
   <topPortlets>
     <hudson.plugins.view.dashboard.stats.StatBuilds>
-      <id>dashboard_portlet_5357</id>
       <name>Build statistics</name>
     </hudson.plugins.view.dashboard.stats.StatBuilds>
   </topPortlets>
   <bottomPortlets>
     <hudson.plugins.view.dashboard.core.HudsonStdJobsPortlet>
-      <id>dashboard_portlet_14122</id>
       <name>Jenkins jobs list</name>
     </hudson.plugins.view.dashboard.core.HudsonStdJobsPortlet>
   </bottomPortlets>

--- a/ros_buildfarm/templates/dashboard_view_devel_jobs.xml.em
+++ b/ros_buildfarm/templates/dashboard_view_devel_jobs.xml.em
@@ -48,13 +48,11 @@
   <rightPortletWidth>50%</rightPortletWidth>
   <leftPortlets>
     <hudson.plugins.view.dashboard.stats.StatBuilds>
-      <id>dashboard_portlet_5357</id>
       <name>Build statistics</name>
     </hudson.plugins.view.dashboard.stats.StatBuilds>
   </leftPortlets>
   <rightPortlets>
     <hudson.plugins.view.dashboard.test.TestTrendChart>
-      <id>dashboard_portlet_6555</id>
       <name>Test Trend Chart</name>
       <graphWidth>500</graphWidth>
       <graphHeight>220</graphHeight>
@@ -66,7 +64,6 @@
   <topPortlets/>
   <bottomPortlets>
     <hudson.plugins.view.dashboard.core.HudsonStdJobsPortlet>
-      <id>dashboard_portlet_14122</id>
       <name>Jenkins jobs list</name>
     </hudson.plugins.view.dashboard.core.HudsonStdJobsPortlet>
   </bottomPortlets>


### PR DESCRIPTION
As of dashboard-view-plugin 2.11, this ID is no longer part of the plugin configuration.

See [JENKINS-10457](https://issues.jenkins.io/browse/JENKINS-10457) for details, which was resolved by this change: https://github.com/jenkinsci/dashboard-view-plugin/commit/d463bd00c65437783ddc71cef0c778897db6deac

From what I can tell, we've been using 2.12 since the 20.04 migration: https://github.com/ros-infrastructure/cookbook-ros-buildfarm/blob/5b961fe8f156198f7d7b03dd0134827561c82202/attributes/plugins.rb#L24