### PR TITLE
Update plugin versions in all templates.

### DIFF
--- a/ros_buildfarm/templates/dashboard_view_all_jobs.xml.em
+++ b/ros_buildfarm/templates/dashboard_view_all_jobs.xml.em
@@ -1,4 +1,4 @@
-<hudson.plugins.view.dashboard.Dashboard plugin="dashboard-view@@2.12">
+<hudson.plugins.view.dashboard.Dashboard plugin="dashboard-view@@2.15">
   <name>@view_name</name>
   <description>Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'</description>
   <filterExecutors>false</filterExecutors>
@@ -15,7 +15,7 @@
     <hudson.views.LastSuccessColumn/>
     <hudson.views.LastFailureColumn/>
     <hudson.views.LastDurationColumn/>
-    <jenkins.plugins.extracolumns.BuildDescriptionColumn plugin="extra-columns@@1.20">
+    <jenkins.plugins.extracolumns.BuildDescriptionColumn plugin="extra-columns@@1.23">
       <columnWidth>80</columnWidth>
       <forceWidth>true</forceWidth>
     </jenkins.plugins.extracolumns.BuildDescriptionColumn>

--- a/ros_buildfarm/templates/dashboard_view_devel_jobs.xml.em
+++ b/ros_buildfarm/templates/dashboard_view_devel_jobs.xml.em
@@ -1,4 +1,4 @@
-<hudson.plugins.view.dashboard.Dashboard plugin="dashboard-view@@2.12">
+<hudson.plugins.view.dashboard.Dashboard plugin="dashboard-view@@2.15">
   <name>@view_name</name>
   <description>Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'</description>
   <filterExecutors>false</filterExecutors>
@@ -15,15 +15,15 @@
     <hudson.views.LastSuccessColumn/>
     <hudson.views.LastFailureColumn/>
     <hudson.views.LastDurationColumn/>
-    <jenkins.plugins.extracolumns.BuildDescriptionColumn plugin="extra-columns@@1.20">
+    <jenkins.plugins.extracolumns.BuildDescriptionColumn plugin="extra-columns@@1.23">
       <columnWidth>80</columnWidth>
       <forceWidth>true</forceWidth>
     </jenkins.plugins.extracolumns.BuildDescriptionColumn>
     <hudson.views.BuildButtonColumn/>
-    <jenkins.plugins.extracolumns.TestResultColumn plugin="extra-columns@@1.20">
+    <jenkins.plugins.extracolumns.TestResultColumn plugin="extra-columns@@1.23">
       <testResultFormat>1</testResultFormat>
     </jenkins.plugins.extracolumns.TestResultColumn>
-    <io.jenkins.plugins.analysis.core.columns.IssuesTotalColumn plugin="warnings-ng@@8.1.0">
+    <io.jenkins.plugins.analysis.core.columns.IssuesTotalColumn plugin="warnings-ng@@9.0.1">
       <selectTools>false</selectTools>
       <tools>
         <io.jenkins.plugins.analysis.core.model.ToolSelection>
@@ -32,7 +32,7 @@
       </tools>
       <name># Issues</name>
       <labelProviderFactory>
-        <jenkins plugin="plugin-util-api@@1.2.2"/>
+        <jenkins plugin="plugin-util-api@@2.1.0"/>
       </labelProviderFactory>
       <type>TOTAL</type>
     </io.jenkins.plugins.analysis.core.columns.IssuesTotalColumn>

--- a/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
+++ b/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
@@ -40,6 +40,7 @@
 $HOME/upload_triggers/upload_repo.bash @target
 @[end for]@
 </command>
+      <configuredLocalRules/>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
+++ b/ros_buildfarm/templates/release/trigger_upload_repo_job.xml.em
@@ -3,7 +3,7 @@
   <description/>
   <keepDependencies>false</keepDependencies>
   <properties>
-    <jenkins.advancedqueue.priority.strategy.PriorityJobProperty plugin="PrioritySorter@@3.6.0">
+    <jenkins.advancedqueue.priority.strategy.PriorityJobProperty plugin="PrioritySorter@@4.0.0">
       <useJobPriority>false</useJobPriority>
       <priority>-1</priority>
     </jenkins.advancedqueue.priority.strategy.PriorityJobProperty>

--- a/ros_buildfarm/templates/snippet/build-wrapper_build-timeout.xml.em
+++ b/ros_buildfarm/templates/snippet/build-wrapper_build-timeout.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@@1.19">
+    <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@@1.20">
       <strategy class="hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy">
         <timeoutMinutes>@int(timeout_minutes)</timeoutMinutes>
       </strategy>

--- a/ros_buildfarm/templates/snippet/builder_parameterized-trigger.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_parameterized-trigger.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.parameterizedtrigger.TriggerBuilder plugin="parameterized-trigger@@2.35.2">
+    <hudson.plugins.parameterizedtrigger.TriggerBuilder plugin="parameterized-trigger@@2.40">
       <configs>
         <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
 @[if parameters]@

--- a/ros_buildfarm/templates/snippet/builder_publish-over-ssh.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_publish-over-ssh.xml.em
@@ -1,9 +1,9 @@
-    <jenkins.plugins.publish__over__ssh.BapSshBuilderPlugin plugin="publish-over-ssh@@1.20.1">
+    <jenkins.plugins.publish__over__ssh.BapSshBuilderPlugin plugin="publish-over-ssh@@1.22">
       <delegate>
         <consolePrefix>SSH: </consolePrefix>
         <delegate plugin="publish-over@@0.22">
           <publishers>
-            <jenkins.plugins.publish__over__ssh.BapSshPublisher plugin="publish-over-ssh@@1.20.1">
+            <jenkins.plugins.publish__over__ssh.BapSshPublisher plugin="publish-over-ssh@@1.22">
               <configName>@config_name</configName>
               <verbose>false</verbose>
               <transfers>

--- a/ros_buildfarm/templates/snippet/builder_shell.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_shell.xml.em
@@ -1,3 +1,4 @@
     <hudson.tasks.Shell>
       <command>@ESCAPE(script)</command>
+      <configuredLocalRules/>
     </hudson.tasks.Shell>

--- a/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy.xml.em
@@ -1,7 +1,7 @@
     <hudson.plugins.groovy.SystemGroovy plugin="groovy@@2.2">
 @[if command]@
       <source class="hudson.plugins.groovy.StringSystemScriptSource">
-        <script plugin="script-security@@1.74">
+        <script plugin="script-security@@1.76">
           <script>@ESCAPE(command)</script>
           <sandbox>false</sandbox>
         </script>

--- a/ros_buildfarm/templates/snippet/copy_artifacts.xml.em
+++ b/ros_buildfarm/templates/snippet/copy_artifacts.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.copyartifact.CopyArtifact plugin="copyartifact@@1.41">
+    <hudson.plugins.copyartifact.CopyArtifact plugin="copyartifact@@1.45.2">
       <project>@(project)</project>
       <filter>@(','.join(artifacts))</filter>
       <target>@(target_directory)</target>

--- a/ros_buildfarm/templates/snippet/property_job-priority.xml.em
+++ b/ros_buildfarm/templates/snippet/property_job-priority.xml.em
@@ -1,4 +1,4 @@
-    <jenkins.advancedqueue.priority.strategy.PriorityJobProperty plugin="PrioritySorter@@3.6.0">
+    <jenkins.advancedqueue.priority.strategy.PriorityJobProperty plugin="PrioritySorter@@4.0.0">
       <useJobPriority>@('true' if priority != -1 else 'false')</useJobPriority>
       <priority>@int(priority)</priority>
     </jenkins.advancedqueue.priority.strategy.PriorityJobProperty>

--- a/ros_buildfarm/templates/snippet/publisher_extended-email.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_extended-email.xml.em
@@ -1,5 +1,5 @@
 @[if recipients]@
-    <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@@2.68">
+    <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@@2.78">
       <recipientList>@ESCAPE(' '.join(sorted(recipients)))</recipientList>
       <configuredTriggers>
         <hudson.plugins.emailext.plugins.trigger.FailureTrigger>

--- a/ros_buildfarm/templates/snippet/publisher_groovy-postbuild.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_groovy-postbuild.xml.em
@@ -1,5 +1,5 @@
     <org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder plugin="groovy-postbuild@@2.4.3">
-      <script plugin="script-security@@1.74">
+      <script plugin="script-security@@1.76">
         <script>@ESCAPE(script)</script>
         <sandbox>false</sandbox>
       </script>

--- a/ros_buildfarm/templates/snippet/publisher_publish-over-git.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_publish-over-git.xml.em
@@ -1,4 +1,4 @@
-    <hudson.plugins.git.GitPublisher plugin="git@@4.3.0">
+    <hudson.plugins.git.GitPublisher plugin="git@@4.7.1">
       <configVersion>2</configVersion>
       <pushMerge>false</pushMerge>
       <pushOnlyIfSuccess>true</pushOnlyIfSuccess>

--- a/ros_buildfarm/templates/snippet/publisher_publish-over-ssh.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_publish-over-ssh.xml.em
@@ -1,8 +1,8 @@
-    <jenkins.plugins.publish__over__ssh.BapSshPublisherPlugin plugin="publish-over-ssh@@1.20.1">
+    <jenkins.plugins.publish__over__ssh.BapSshPublisherPlugin plugin="publish-over-ssh@@1.22">
       <consolePrefix>SSH: </consolePrefix>
       <delegate plugin="publish-over@@0.22">
         <publishers>
-          <jenkins.plugins.publish__over__ssh.BapSshPublisher plugin="publish-over-ssh@@1.20.1">
+          <jenkins.plugins.publish__over__ssh.BapSshPublisher plugin="publish-over-ssh@@1.22">
             <configName>@config_name</configName>
             <verbose>false</verbose>
             <transfers>

--- a/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
@@ -1,4 +1,4 @@
-    <io.jenkins.plugins.analysis.core.steps.IssuesRecorder plugin="warnings-ng@@8.1.0">
+    <io.jenkins.plugins.analysis.core.steps.IssuesRecorder plugin="warnings-ng@@9.0.1">
       <analysisTools>
         <io.jenkins.plugins.analysis.warnings.Cmake>
           <id></id>
@@ -23,7 +23,7 @@
       <failOnError>false</failOnError>
       <healthy>0</healthy>
       <unhealthy>0</unhealthy>
-      <minimumSeverity plugin="analysis-model-api@@8.0.1">
+      <minimumSeverity plugin="analysis-model-api@@10.0.0">
         <name>LOW</name>
       </minimumSeverity>
       <filters>

--- a/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
@@ -19,7 +19,6 @@
       <sourceDirectory></sourceDirectory>
       <ignoreQualityGate>false</ignoreQualityGate>
       <ignoreFailedBuilds>true</ignoreFailedBuilds>
-      <referenceJobName>-</referenceJobName>
       <failOnError>false</failOnError>
       <healthy>0</healthy>
       <unhealthy>0</unhealthy>
@@ -34,7 +33,8 @@
       <isEnabledForFailure>false</isEnabledForFailure>
       <isAggregatingResults>false</isAggregatingResults>
       <isBlameDisabled>false</isBlameDisabled>
-      <isForensicsDisabled>false</isForensicsDisabled>
+      <skipPublishingChecks>false</skipPublishingChecks>
+      <publishAllIssues>true</publishAllIssues>
 @[if unstable_threshold != '']@
       <qualityGates>
         <io.jenkins.plugins.analysis.core.util.QualityGate>
@@ -47,4 +47,5 @@
       <qualityGates/>
 @[end if]@
       <trendChartType>AGGREGATION_TOOLS</trendChartType>
+      <scm/>
     </io.jenkins.plugins.analysis.core.steps.IssuesRecorder>

--- a/ros_buildfarm/templates/snippet/publisher_xunit.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_xunit.xml.em
@@ -3,7 +3,7 @@
 if 'types' not in vars() and 'pattern' in vars():
     types = [('GoogleTestType', pattern)]
 }@
-    <xunit plugin="xunit@@2.4.0">
+    <xunit plugin="xunit@@3.0.2">
       <types>
 @[for type_tag_and_pattern in types]@
 @{

--- a/ros_buildfarm/templates/snippet/publisher_xunit.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_xunit.xml.em
@@ -13,6 +13,7 @@ assert type_tag in ('CTestType', 'GoogleTestType', 'JUnitType'), 'Unsupported te
 }@
         <@(type_tag)>
           <pattern>@ESCAPE(pattern)</pattern>
+          <excludesPattern/>
           <skipNoTestFiles>true</skipNoTestFiles>
           <failIfNotNew>true</failIfNotNew>
           <deleteOutputFiles>true</deleteOutputFiles>
@@ -23,19 +24,15 @@ assert type_tag in ('CTestType', 'GoogleTestType', 'JUnitType'), 'Unsupported te
       <thresholds>
         <org.jenkinsci.plugins.xunit.threshold.FailedThreshold>
           <unstableThreshold>0</unstableThreshold>
-          <unstableNewThreshold/>
-          <failureThreshold/>
-          <failureNewThreshold/>
         </org.jenkinsci.plugins.xunit.threshold.FailedThreshold>
-        <org.jenkinsci.plugins.xunit.threshold.SkippedThreshold>
-          <unstableThreshold/>
-          <unstableNewThreshold/>
-          <failureThreshold/>
-          <failureNewThreshold/>
-        </org.jenkinsci.plugins.xunit.threshold.SkippedThreshold>
+        <org.jenkinsci.plugins.xunit.threshold.SkippedThreshold/>
       </thresholds>
       <thresholdMode>1</thresholdMode>
       <extraConfiguration>
         <testTimeMargin>3000</testTimeMargin>
+        <sleepTime>0</sleepTime>
+        <reduceLog>false</reduceLog>
+        <followSymlink>true</followSymlink>
       </extraConfiguration>
+      <testDataPublishers class="empty-set"/>
     </xunit>

--- a/ros_buildfarm/templates/snippet/scm_git.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_git.xml.em
@@ -17,7 +17,7 @@
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
-    <submoduleCfg class="list"/>
+    <submoduleCfg class="empty-list"/>
     <extensions>
 @[if relative_target_dir]@
       <hudson.plugins.git.extensions.impl.RelativeTargetDirectory>

--- a/ros_buildfarm/templates/snippet/scm_git.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_git.xml.em
@@ -1,4 +1,4 @@
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@@4.3.0">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@@4.7.1">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>

--- a/ros_buildfarm/templates/snippet/scm_hg.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_hg.xml.em
@@ -1,4 +1,4 @@
-  <scm class="hudson.plugins.mercurial.MercurialSCM" plugin="mercurial@@2.4">
+  <scm class="hudson.plugins.mercurial.MercurialSCM" plugin="mercurial@@2.14">
     <installation>Default</installation>
     <source>@ESCAPE(source)</source>
     <modules/>

--- a/ros_buildfarm/templates/snippet/scm_svn.xml.em
+++ b/ros_buildfarm/templates/snippet/scm_svn.xml.em
@@ -1,4 +1,4 @@
-<scm class="hudson.scm.SubversionSCM" plugin="subversion@@2.13.1">
+<scm class="hudson.scm.SubversionSCM" plugin="subversion@@2.14.0">
   <locations>
     <hudson.scm.SubversionSCM_-ModuleLocation>
       <remote>@ESCAPE(remote)</remote>

--- a/ros_buildfarm/templates/snippet/trigger_github-pull-request-builder.xml.em
+++ b/ros_buildfarm/templates/snippet/trigger_github-pull-request-builder.xml.em
@@ -1,4 +1,4 @@
-    <org.jenkinsci.plugins.ghprb.GhprbTrigger plugin="ghprb@@1.42.0">
+    <org.jenkinsci.plugins.ghprb.GhprbTrigger plugin="ghprb@@1.42.1">
       <spec/>
       <latestVersion>3</latestVersion>
       <configVersion>3</configVersion>


### PR DESCRIPTION
This is a big plugin update to correspond to ros-infrastructure/cookbook-ros-buildfarm#93

The first commit contains pure plugin version bumps. The second contains configuration changes resulting from the updated plugin versions. So far I have only reviewed the devel jobs. I have a list of job types to check for changes here:

* [x] devel/pr jobs
* [ ] ci jobs
* [ ] sourcerpm and binaryrpm jobs
* [ ] sourcedeb and binarydeb jobs
* [ ] management jobs
	* [ ] trigger jobs
	* [ ] reconfigure jobs
	* [ ] sync jobs
	* [ ] status page jobs
	* [ ] rosdistro cache jobs
	* [ ] import package jobs
	* [ ] import upstream jobs
	* [ ] failing jobs jobs
	* [ ] dashboard job
	* [ ] check agents job

Changes to plugin configuration

* hudson.tasks.Shell added the ability to filter or reset environment
variables from specific steps and the default configuration saves a
self-closing configuredLocalRules tag which contains that information.

* warnings-ng no longer uses a referenceJobName field and now has a more
complex/robust method for selecting a reference build using the Git
Forensics plugin
jenkinsci/warnings-ng-plugin@master/doc/Documentation.md#configure-the-selection-of-the-reference-build-baseline

* warnings-ng has additional configuration for publishing checks to
GitHub. It is unclear if the successful use of this feature requires
usng the GitHub Branch Source plugin which we have not explored but the
if publishing checks works, we'll do it.
`publishAllIssues` is an additional configuration for publishing checks for
all issues not just issues which are `new` as of the current build.
For now I've left this as true until we have more information about the
reliability of the reference build info with our current setup.

* xunit report types can now take an exclude pattern as well as the
include pattern. At one point we split up some test type patterns to
deconflict between multiple test types but I'm not sure that a simple
exclude would allow us to re-combine any of them I will have to check
the history.

* xunit inner threshold tags are no longer required.  There are also
several new extra configuration fields for a sleep timer between reports (to avoid
report CPU time starving out the Jenkins ping thread) a stdout/stderr
log reduction option to save memory during report generation, and an
option whether or not to follow symlinks when reviewing reports. I have
opted to leave all of these at their defaults for now. There is
additionally a final `testDataPublishers` tag with the attribute
"empty-set" I cannot info on what this does but it appears to be a new
feature not an evolution of something we were already doing.