### PR TITLE
Work-around for https://github.com/colcon/colcon-test-result/issues/36

### DIFF
--- a/ros_buildfarm/templates/devel/devel_script_test_results.sh.em
+++ b/ros_buildfarm/templates/devel/devel_script_test_results.sh.em
@@ -13,7 +13,7 @@ if ! type "$test_result_EXECUTABLE" > /dev/null; then
   echo "'$test_result_EXECUTABLE' not found on the PATH. Please make sure the tool is installed and the environment is setup (if applicable) to output the test result summary."
   test_result_RC=0
 @[if build_tool == 'colcon']@
-elif ! $($test_result_EXECUTABLE test-result --help > /dev/null 2> /dev/null); then
+elif ! $($test_result_EXECUTABLE test-result --test-result-base $WORKSPACE/@workspace_path/test_results --help > /dev/null 2> /dev/null); then
   echo "'$test_result_EXECUTABLE test-result' not available. Please make sure the necessary extension is installed to output the test result summary."
   test_result_RC=0
 @[end if]@


### PR DESCRIPTION
As reported in https://github.com/ros-industrial/industrial_ci/issues/666, prerelease (and devel) tests skip the test-result printing for colcon as a build tool.

colcon test-result --help actually fails (exit code 2) with

```
usage: colcon test-result [-h] [--test-result-base TEST_RESULT_BASE] [--all]
                          [--result-files-only] [--verbose] [--delete]
                          [--delete-yes]
colcon test-result: error: argument --test-result-base: Path 'build' does not exist
```

I haven' tested this fix yet..