### PR TITLE
Add rosdoc2 documentation job type

### DIFF
--- a/ros_buildfarm/config/doc_build_file.py
+++ b/ros_buildfarm/config/doc_build_file.py
@@ -14,12 +14,13 @@
 
 from .build_file import BuildFile
 
-DOC_TYPE_ROSDOC = 'rosdoc_lite'
-DOC_TYPE_MANIFEST = 'released_manifest'
-DOC_TYPE_MAKE = 'make_target'
 DOC_TYPE_DOCKER = 'docker_build'
+DOC_TYPE_MAKE = 'make_target'
+DOC_TYPE_MANIFEST = 'released_manifest'
+DOC_TYPE_ROSDOC = 'rosdoc_lite'
+DOC_TYPE_ROSDOC2 = 'rosdoc2'
 DOC_TYPES = [
-    DOC_TYPE_ROSDOC, DOC_TYPE_MANIFEST, DOC_TYPE_MAKE, DOC_TYPE_DOCKER
+    DOC_TYPE_DOCKER, DOC_TYPE_MAKE, DOC_TYPE_MANIFEST, DOC_TYPE_ROSDOC, DOC_TYPE_ROSDOC2
 ]
 
 
@@ -65,7 +66,7 @@ class DocBuildFile(BuildFile):
             assert len(self.targets) == 0
 
         # repository keys and urls can only be used with doc type rosdoc
-        is_rosdoc_type = self.documentation_type == DOC_TYPE_ROSDOC
+        is_rosdoc_type = self.documentation_type in (DOC_TYPE_ROSDOC, DOC_TYPE_ROSDOC2)
         assert not self.repository_keys or is_rosdoc_type
         assert not self.repository_urls or is_rosdoc_type
 

--- a/ros_buildfarm/doc_job.py
+++ b/ros_buildfarm/doc_job.py
@@ -260,7 +260,10 @@ def _get_doc_job_config(
         config, config_url, rosdistro_name, doc_build_name,
         build_file, os_name, os_code_name, arch, doc_repo_spec,
         repo_name, dist_cache=None, is_disabled=False):
-    template_name = 'doc/doc_job.xml.em'
+    if build_file.documentation_type == 'rosdoc2':
+        template_name = 'doc/rosdoc2_job.xml.em'
+    else:
+        template_name = 'doc/doc_job.xml.em'
 
     repository_args, script_generating_key_files = \
         get_repositories_and_script_generating_key_files(build_file=build_file)

--- a/ros_buildfarm/templates/__init__.py
+++ b/ros_buildfarm/templates/__init__.py
@@ -157,8 +157,6 @@ def _expand_template(template_name, **kwargs):
 
 
 def create_dockerfile(template_name, data, dockerfile_dir, verbose=True):
-    data['template_name'] = template_name
-    data['wrapper_scripts'] = get_wrapper_scripts()
     content = expand_template(template_name, data)
     dockerfile = os.path.join(dockerfile_dir, 'Dockerfile')
     print("Generating Dockerfile '%s':" % dockerfile)

--- a/ros_buildfarm/templates/doc/doc_script.sh.em
+++ b/ros_buildfarm/templates/doc/doc_script.sh.em
@@ -49,5 +49,5 @@ echo "travis_fold:end:doc-build-workspace"
 @[end if]@
 
 echo ""
-echo "Generated documentation: $WORKSPACE/generated_documentation/api_rosdoc"
+echo "Generated documentation: @doc_path"
 echo ""

--- a/ros_buildfarm/templates/doc/rosdoc2_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/rosdoc2_create_task.Dockerfile.em
@@ -1,0 +1,61 @@
+# generated from @template_name
+
+FROM ubuntu:@os_code_name
+
+VOLUME ["/var/cache/apt/archives"]
+
+ENV DEBIAN_FRONTEND noninteractive
+
+@(TEMPLATE(
+    'snippet/setup_locale.Dockerfile.em',
+    timezone=timezone,
+))@
+
+RUN useradd -u @uid -l -m buildfarm
+
+@(TEMPLATE(
+    'snippet/add_distribution_repositories.Dockerfile.em',
+    distribution_repository_keys=distribution_repository_keys,
+    distribution_repository_urls=distribution_repository_urls,
+    os_name='ubuntu',
+    os_code_name=os_code_name,
+    add_source=False,
+))@
+
+@(TEMPLATE(
+    'snippet/add_wrapper_scripts.Dockerfile.em',
+    wrapper_scripts=wrapper_scripts,
+))@
+
+# automatic invalidation once every day
+RUN echo "@today_str"
+
+@(TEMPLATE(
+    'snippet/install_python3.Dockerfile.em',
+    os_name=os_name,
+    os_code_name=os_code_name,
+))@
+
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-apt python3-catkin-pkg-modules python3-empy python3-rosdep python3-rosdistro-modules wget
+
+# always invalidate to actually have the latest apt and rosdep state
+RUN echo "@now_str"
+RUN python3 -u /tmp/wrapper_scripts/apt.py update
+
+USER buildfarm
+
+ENTRYPOINT ["sh", "-c"]
+@{
+cmds = [
+    'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \
+    ' /tmp/ros_buildfarm/scripts/doc/create_rosdoc2_task_generator.py' + \
+    ' --workspace-root /tmp/ws' + \
+    ' --os-name ' + os_name + \
+    ' --os-code-name ' + os_code_name + \
+    ' --arch ' + arch + \
+    ' --distribution-repository-urls ' + ' '.join(distribution_repository_urls) + \
+    ' --distribution-repository-key-files ' + ' ' .join(['/tmp/keys/%d.key' % i for i in range(len(distribution_repository_keys))]) + \
+    ' --dockerfile-dir /tmp/docker_doc',
+]
+}@
+CMD ["@(' && '.join([c.replace('"', '\\"') for c in cmds]))"]

--- a/ros_buildfarm/templates/doc/rosdoc2_job.xml.em
+++ b/ros_buildfarm/templates/doc/rosdoc2_job.xml.em
@@ -1,0 +1,243 @@
+@{import os}@
+<project>
+  <actions/>
+  <description>Generated at @ESCAPE(now_str) from template '@ESCAPE(template_name)'@
+@[if disabled]
+but disabled since the package is blacklisted (or not whitelisted) in the configuration file@
+@[end if]@
+@ </description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+@(SNIPPET(
+    'property_log-rotator',
+    days_to_keep=365,
+    num_to_keep=100,
+))@
+@[if github_url]@
+@(SNIPPET(
+    'property_github-project',
+    project_url=github_url,
+))@
+@[end if]@
+@[if job_priority is not None]@
+@(SNIPPET(
+    'property_job-priority',
+    priority=job_priority,
+))@
+@[end if]@
+@(SNIPPET(
+    'property_rebuild-settings',
+))@
+@(SNIPPET(
+    'property_requeue-job',
+))@
+@(SNIPPET(
+    'property_parameters-definition',
+    parameters=[
+        {
+            'type': 'boolean',
+            'name': 'force',
+            'description': 'Run documentation generation even if neither the source repository nor any of the tools have changes',
+        },
+        {
+            'type': 'boolean',
+            'name': 'skip_cleanup',
+            'description': 'Skip cleanup of build artifacts',
+        },
+    ],
+))@
+@(SNIPPET(
+    'property_job-weight',
+))@
+  </properties>
+@(SNIPPET(
+    'scm',
+    repo_spec=doc_repo_spec,
+    path='ws/src/%s' % doc_repo_spec.name,
+    git_ssh_credential_id=git_ssh_credential_id,
+))@
+  <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
+  <assignedNode>@(node_label)</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>@('true' if disabled else 'false')</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+@(SNIPPET(
+    'trigger_poll',
+    spec='H 3 H/3 * *',
+))@
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+@(SNIPPET(
+    'builder_system-groovy_check-free-disk-space',
+))@
+@(SNIPPET(
+    'builder_shell_docker-info',
+))@
+@(SNIPPET(
+    'builder_check-docker',
+    os_name=os_name,
+    os_code_name=os_code_name,
+    arch=arch,
+))@
+@(SNIPPET(
+    'builder_shell_clone-ros-buildfarm',
+    ros_buildfarm_repository=ros_buildfarm_repository,
+    wrapper_scripts=wrapper_scripts,
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'echo "# BEGIN SECTION: Clone rosdoc2"',
+        'rm -fr rosdoc2',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/wrapper/git.py clone --depth 1 https://github.com/ros-infrastructure/rosdoc2.git rosdoc2',
+        'git -C rosdoc2 log -n 1',
+        'echo "# END SECTION"',
+    ]),
+))@
+@(SNIPPET(
+    'builder_shell_key-files',
+    script_generating_key_files=script_generating_key_files,
+))@
+@{
+if doc_repo_spec.type == 'hg':
+    hgcache_mount_arg = ' -v $HOME/hgcache:$HOME/hgcache '
+else:
+    hgcache_mount_arg = ''
+}@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'rm -fr $WORKSPACE/docker_generating_docker',
+        'mkdir -p $WORKSPACE/docker_generating_docker',
+        '',
+        '# monitor all subprocesses and enforce termination',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/subprocess_reaper.py $$ --cid-file $WORKSPACE/docker_generating_docker/docker.cid > $WORKSPACE/docker_generating_docker/subprocess_reaper.log 2>&1 &',
+        '# sleep to give python time to startup',
+        'sleep 1',
+        '',
+        '# generate Dockerfile, build and run it',
+        '# generating the Dockerfiles for the actual doc task',
+        'echo "# BEGIN SECTION: Generate Dockerfile - doc task"',
+        'export TZ="%s"' % timezone,
+        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
+        'if [ "$force" = "true" ]; then FORCE_FLAG="--force"; fi',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/doc/run_rosdoc2_job.py' +
+        ' ' + os_name +
+        ' ' + os_code_name +
+        ' ' + arch +
+        ' ' + ' '.join(repository_args) +
+        ' --dockerfile-dir $WORKSPACE/docker_generating_docker',
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: Build Dockerfile - generating doc task"',
+        'cd $WORKSPACE/docker_generating_docker',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
+        'docker build --force-rm -t rosdoc2_task_generation.%s_%s .' % (rosdistro_name, doc_repo_spec.name.lower()),
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: Run Dockerfile - generating doc task"',
+        'rm -fr $WORKSPACE/docker_doc',
+        'mkdir -p $WORKSPACE/docker_doc',
+        'docker run' +
+        ' --rm ' +
+        ' --cidfile=$WORKSPACE/docker_generating_docker/docker.cid' +
+        ' -e=HOME=/home/buildfarm' +
+        ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
+        ' -v $WORKSPACE/rosdoc2:/tmp/rosdoc2:ro' +
+        ' -v $WORKSPACE/ws:/tmp/ws' +
+        ' -v $WORKSPACE/docker_doc:/tmp/docker_doc' +
+        hgcache_mount_arg +
+        ' rosdoc2_task_generation.%s_%s' % (rosdistro_name, doc_repo_spec.name.lower()),
+        'echo "# END SECTION"',
+    ]),
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'if [ ! -f "$WORKSPACE/docker_doc/Dockerfile" ]; then',
+        '  exit 0',
+        'fi',
+        '',
+        '# monitor all subprocesses and enforce termination',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/subprocess_reaper.py $$ --cid-file $WORKSPACE/docker_doc/docker.cid > $WORKSPACE/docker_doc/subprocess_reaper.log 2>&1 &',
+        '# sleep to give python time to startup',
+        'sleep 1',
+        '',
+        'echo "# BEGIN SECTION: Build Dockerfile - doc"',
+        '# build and run build_and_install Dockerfile',
+        'cd $WORKSPACE/docker_doc',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
+        'docker build --force-rm -t rosdoc2.%s_%s .' % (rosdistro_name, doc_repo_spec.name.lower()),
+        'echo "# END SECTION"',
+        '',
+        'echo "# BEGIN SECTION: Run Dockerfile - doc"',
+        'docker run' +
+        ' --rm ' +
+        ' --cidfile=$WORKSPACE/docker_doc/docker.cid' +
+        ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
+        ' -v $WORKSPACE/rosdoc2:/tmp/rosdoc2:ro' +
+        ' -v $WORKSPACE/ws:/tmp/ws' +
+        ' rosdoc2.%s_%s' % (rosdistro_name, doc_repo_spec.name.lower()),
+        'echo "# END SECTION"',
+    ]),
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'if [ "$skip_cleanup" = "false" ]; then',
+        'echo "# BEGIN SECTION: Clean up to save disk space on agents"',
+        'rm -fr rosdoc2',
+        'echo "# END SECTION"',
+        'fi',
+    ]),
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
+        'if [ -d "$WORKSPACE/ws/docs_output" ]; then',
+        '  echo "# BEGIN SECTION: rsync API documentation to server"',
+        '  cd $WORKSPACE/ws/docs_output',
+        '  for pkg_name in $(find . -maxdepth 1 -mindepth 1 -type d); do',
+        '    rsync -e ssh --stats -r --delete $pkg_name %s@%s:%s' % \
+          (upload_user, upload_host, os.path.join(upload_root, rosdistro_name, 'api')),
+        '  done',
+        '  echo "# END SECTION"',
+        'fi',
+    ]),
+))@
+@(SNIPPET(
+    'builder_system-groovy_extract-warnings',
+))@
+  </builders>
+  <publishers>
+@[if notify_maintainers]@
+@(SNIPPET(
+    'publisher_groovy-postbuild_maintainer-notification',
+))@
+@[end if]@
+@(SNIPPET(
+    'publisher_mailer',
+    recipients=notify_emails,
+    dynamic_recipients=maintainer_emails,
+    send_to_individuals=notify_committers,
+))@
+  </publishers>
+  <buildWrappers>
+@[if timeout_minutes is not None]@
+@(SNIPPET(
+    'build-wrapper_build-timeout',
+    timeout_minutes=timeout_minutes,
+))@
+@[end if]@
+@(SNIPPET(
+    'build-wrapper_timestamper',
+))@
+@(SNIPPET(
+    'build-wrapper_ssh-agent',
+    credential_ids=[credential_id],
+))@
+  </buildWrappers>
+</project>

--- a/ros_buildfarm/templates/doc/rosdoc2_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/rosdoc2_task.Dockerfile.em
@@ -1,0 +1,54 @@
+# generated from @template_name
+
+@(TEMPLATE(
+    'snippet/from_base_image.Dockerfile.em',
+    os_name=os_name,
+    os_code_name=os_code_name,
+    arch=arch,
+))@
+
+VOLUME ["/var/cache/apt/archives"]
+
+ENV DEBIAN_FRONTEND noninteractive
+
+@(TEMPLATE(
+    'snippet/setup_locale.Dockerfile.em',
+    timezone=timezone,
+))@
+
+RUN useradd -u @uid -l -m buildfarm
+
+@(TEMPLATE(
+    'snippet/add_distribution_repositories.Dockerfile.em',
+    distribution_repository_keys=distribution_repository_keys,
+    distribution_repository_urls=distribution_repository_urls,
+    os_name=os_name,
+    os_code_name=os_code_name,
+    add_source=False,
+))@
+
+@(TEMPLATE(
+    'snippet/add_wrapper_scripts.Dockerfile.em',
+    wrapper_scripts=wrapper_scripts,
+))@
+
+# automatic invalidation once every day
+RUN echo "@today_str"
+
+@(TEMPLATE(
+    'snippet/install_python3.Dockerfile.em',
+    os_name=os_name,
+    os_code_name=os_code_name,
+))@
+
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y -o Debug::pkgProblemResolver=yes build-essential python3-catkin-pkg-modules doxygen graphviz openssh-client python3 python3-yaml python3-pip rsync
+
+USER buildfarm
+ENTRYPOINT ["sh", "-c"]
+@{
+cmd = 'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \
+    ' /tmp/ros_buildfarm/scripts/doc/build_rosdoc2.py' + \
+    ' --workspace-root /tmp/ws' + \
+    ' --rosdoc2-dir /tmp/rosdoc2'
+}@
+CMD ["@cmd"]

--- a/scripts/doc/build_rosdoc2.py
+++ b/scripts/doc/build_rosdoc2.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+# Copyright 2015-2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import subprocess
+import sys
+
+from catkin_pkg.packages import find_packages
+from ros_buildfarm.common import Scope
+from ros_buildfarm.workspace import clean_workspace
+from ros_buildfarm.workspace import ensure_workspace_exists
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Invoke 'rosdoc2' on each package of a workspace")
+    parser.add_argument(
+        '--workspace-root',
+        required=True,
+        help='The root path of the workspace to document')
+    parser.add_argument(
+        '--rosdoc2-dir',
+        required=True,
+        help='The root path of the rosdoc2 repository')
+    parser.add_argument(
+        'pkg_tuples',
+        nargs='*',
+        help='A list of package tuples in topological order, each containing '
+             'the name, and the relative path separated by a colon')
+    args = parser.parse_args(argv)
+
+    ensure_workspace_exists(args.workspace_root)
+    clean_workspace(args.workspace_root)
+
+    with Scope('SUBSECTION', 'Installing rosdoc2'):
+        pip_rc = subprocess.call(['python3',
+                                  '-m',
+                                  'pip',
+                                  'install',
+                                  '--no-warn-script-location',
+                                  '.'],
+                                 cwd=args.rosdoc2_dir)
+        if pip_rc:
+            return pip_rc
+
+    with Scope('SUBSECTION', 'rosdoc2'):
+        env = {
+            **os.environ,
+        }
+        if 'PATH' not in env:
+            env['PATH'] = ''
+        else:
+            env['PATH'] += ':'
+        env['PATH'] += '/home/buildfarm/.local/bin'
+
+        source_space = os.path.join(args.workspace_root, 'src')
+        print("Crawling for packages in workspace '%s'" % (source_space))
+        pkgs = find_packages(source_space)
+
+        pkg_names = [pkg.name for pkg in pkgs.values()]
+        print('Found the following packages:')
+        for pkg_name in sorted(pkg_names):
+            print('  -', pkg_name)
+
+        for pkg_path, pkg in pkgs.items():
+            abs_pkg_path = os.path.join(source_space, pkg_path)
+            cmd = ['rosdoc2', 'build', '--package-path', abs_pkg_path]
+            subprocess.call(cmd, cwd=args.workspace_root, env=env)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/doc/create_rosdoc2_task_generator.py
+++ b/scripts/doc/create_rosdoc2_task_generator.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+# Copyright 2015-2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+
+from ros_buildfarm.argument import \
+    add_argument_distribution_repository_key_files
+from ros_buildfarm.argument import add_argument_distribution_repository_urls
+from ros_buildfarm.argument import add_argument_dockerfile_dir
+from ros_buildfarm.common import get_distribution_repository_keys
+from ros_buildfarm.common import get_user_id
+from ros_buildfarm.templates import create_dockerfile
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Generate a 'Dockerfile' for the doc job")
+    parser.add_argument(
+        '--workspace-root',
+        required=True,
+        help='The root path of the workspace')
+    parser.add_argument(
+        '--os-name',
+        required=True,
+        help="The OS name (e.g. 'ubuntu')")
+    parser.add_argument(
+        '--os-code-name',
+        required=True,
+        help="The OS code name (e.g. 'xenial')")
+    parser.add_argument(
+        '--arch',
+        required=True,
+        help="The architecture (e.g. 'amd64')")
+    add_argument_distribution_repository_urls(parser)
+    add_argument_distribution_repository_key_files(parser)
+    add_argument_dockerfile_dir(parser)
+    args = parser.parse_args(argv)
+
+    print('Running generation of documentation')
+    # generate Dockerfile
+    data = {
+        'os_name': args.os_name,
+        'os_code_name': args.os_code_name,
+        'arch': args.arch,
+
+        'distribution_repository_urls': args.distribution_repository_urls,
+        'distribution_repository_keys': get_distribution_repository_keys(
+            args.distribution_repository_urls,
+            args.distribution_repository_key_files),
+
+        'uid': get_user_id(),
+    }
+    create_dockerfile('doc/rosdoc2_task.Dockerfile.em', data, args.dockerfile_dir)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/doc/generate_doc_script.py
+++ b/scripts/doc/generate_doc_script.py
@@ -28,6 +28,8 @@ from ros_buildfarm.argument import add_argument_os_name
 from ros_buildfarm.argument import add_argument_repository_name
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.common import get_doc_job_name
+from ros_buildfarm.config import get_doc_build_files
+from ros_buildfarm.config import get_index
 from ros_buildfarm.doc_job import configure_doc_job
 from ros_buildfarm.templates import expand_template
 
@@ -88,6 +90,12 @@ def main(argv=sys.argv[1:]):
         args.rosdistro_name, args.doc_build_name, args.repository_name,
         args.os_name, args.os_code_name, args .arch)
 
+    config = get_index(args.config_url)
+    doc_build_file = get_doc_build_files(config, args.rosdistro_name)
+    doc_path = '$WORKSPACE/generated_documentation/api_rosdoc'
+    if doc_build_file[next(iter(doc_build_file))].documentation_type == 'rosdoc2':
+        doc_path = '$WORKSPACE/ws/docs_output'
+
     # set force flag
     force_flag = '$force'
     for i, script in enumerate(scripts):
@@ -118,7 +126,8 @@ def main(argv=sys.argv[1:]):
         'doc/doc_script.sh.em', {
             'doc_job_name': doc_job_name,
             'scms': hook.scms,
-            'scripts': scripts},
+            'scripts': scripts,
+            'doc_path': doc_path},
         options={BANGPATH_OPT: False})
     value = value.replace('python3', sys.executable)
     print(value)

--- a/scripts/doc/run_rosdoc2_job.py
+++ b/scripts/doc/run_rosdoc2_job.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import copy
+import sys
+
+from ros_buildfarm.argument import add_argument_arch
+from ros_buildfarm.argument import \
+    add_argument_distribution_repository_key_files
+from ros_buildfarm.argument import add_argument_distribution_repository_urls
+from ros_buildfarm.argument import add_argument_dockerfile_dir
+from ros_buildfarm.argument import add_argument_os_code_name
+from ros_buildfarm.argument import add_argument_os_name
+from ros_buildfarm.common import get_distribution_repository_keys
+from ros_buildfarm.common import get_user_id
+from ros_buildfarm.templates import create_dockerfile
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Run the 'rosdoc2' job")
+    add_argument_os_name(parser)
+    add_argument_os_code_name(parser)
+    add_argument_arch(parser)
+    add_argument_distribution_repository_urls(parser)
+    add_argument_distribution_repository_key_files(parser)
+    add_argument_dockerfile_dir(parser)
+    args = parser.parse_args(argv)
+
+    data = copy.deepcopy(args.__dict__)
+    data.update({
+        'distribution_repository_urls': args.distribution_repository_urls,
+        'distribution_repository_keys': get_distribution_repository_keys(
+            args.distribution_repository_urls,
+            args.distribution_repository_key_files),
+        'uid': get_user_id(),
+    })
+    create_dockerfile(
+        'doc/rosdoc2_create_task.Dockerfile.em', data, args.dockerfile_dir)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR allows us to start using https://github.com/ros-infrastructure/rosdoc2 to generate per-package API documentation for packages on the buildfarm.  In order to make this truly work, we'll need a ros_buildfarm_config file like https://github.com/ros-staging/ros_buildfarm_config/blob/848d5107f7e4f3925b2ad08786784387b53a9cf2/rolling/doc-build.yaml on the main buildfarm.

As it stands, these jobs have a few limitations (some of which come from this code, some of which come from rosdoc2):
    
1.  This will really only work for C++ packages.  To make it work for Python requires an update to the rosdoc2 code.
2.  It will only generate documentation against sources.  To make it look at build or install artifacts as well, we'll need to update both rosdoc2 and this code.
3.  It will not do any cross-referencing outside of the current repository.  To make this work requires generating, storing, and retrieving a cross-reference database.

Nonetheless, I think this is a good first step and will allow us to at least build basic API documentation for packages.

You can see an example list of jobs that would be created by this PR at https://build.test.ros2.org/view/Rdoc/ .

To truly host the documentation we'll also need to properly setup the Apache configuration at https://docs.ros.org , but that is somewhat orthogonal to this.

Note that the first 2 commits in this series are bugfixes, so can be applied with or without the third one.

Part of https://github.com/ros2/ros2/issues/1009