### PR TITLE
Update container image base for doc-related container templates.

### DIFF
--- a/ros_buildfarm/templates/doc/doc_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_create_reconfigure_task.Dockerfile.em
@@ -1,6 +1,6 @@
 # generated from @template_name
 
-FROM ubuntu:xenial
+FROM ubuntu:focal
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/doc/doc_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_create_reconfigure_task.Dockerfile.em
@@ -1,6 +1,7 @@
 # generated from @template_name
 
-FROM ubuntu:focal
+@{os_code_name = 'focal'}
+FROM ubuntu:@os_code_name
 
 VOLUME ["/var/cache/apt/archives"]
 
@@ -18,7 +19,7 @@ RUN useradd -u @uid -l -m buildfarm
     distribution_repository_keys=distribution_repository_keys,
     distribution_repository_urls=distribution_repository_urls,
     os_name='ubuntu',
-    os_code_name='xenial',
+    os_code_name=os_code_name,
     add_source=False,
 ))@
 
@@ -33,7 +34,7 @@ RUN echo "@today_str"
 @(TEMPLATE(
     'snippet/install_python3.Dockerfile.em',
     os_name='ubuntu',
-    os_code_name='xenial',
+    os_code_name=os_code_name,
 ))@
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-pip python3-rosdistro-modules python3-yaml

--- a/ros_buildfarm/templates/doc/doc_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_create_reconfigure_task.Dockerfile.em
@@ -1,6 +1,6 @@
 # generated from @template_name
 
-@{os_code_name = 'focal'}
+@{os_code_name = 'focal'}@
 FROM ubuntu:@os_code_name
 
 VOLUME ["/var/cache/apt/archives"]

--- a/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
@@ -60,7 +60,7 @@
 @(SNIPPET(
     'builder_check-docker',
     os_name='ubuntu',
-    os_code_name='xenial',
+    os_code_name='focal',
     arch='amd64',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
@@ -57,10 +57,11 @@
 @(SNIPPET(
     'builder_shell_docker-info',
 ))@
+@{os_code_name = 'focal'}
 @(SNIPPET(
     'builder_check-docker',
     os_name='ubuntu',
-    os_code_name='focal',
+    os_code_name=os_code_name,
     arch='amd64',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
@@ -57,7 +57,7 @@
 @(SNIPPET(
     'builder_shell_docker-info',
 ))@
-@{os_code_name = 'focal'}
+@{os_code_name = 'focal'}@
 @(SNIPPET(
     'builder_check-docker',
     os_name='ubuntu',

--- a/ros_buildfarm/templates/doc/doc_independent_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_job.xml.em
@@ -49,7 +49,7 @@
 @(SNIPPET(
     'builder_check-docker',
     os_name='ubuntu',
-    os_code_name='xenial',
+    os_code_name='focal',
     arch='amd64',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/doc/doc_independent_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_job.xml.em
@@ -46,7 +46,7 @@
 @(SNIPPET(
     'builder_shell_docker-info',
 ))@
-@{os_code_name = 'focal'}
+@{os_code_name = 'focal'}@
 @(SNIPPET(
     'builder_check-docker',
     os_name='ubuntu',

--- a/ros_buildfarm/templates/doc/doc_independent_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_job.xml.em
@@ -46,10 +46,11 @@
 @(SNIPPET(
     'builder_shell_docker-info',
 ))@
+@{os_code_name = 'focal'}
 @(SNIPPET(
     'builder_check-docker',
     os_name='ubuntu',
-    os_code_name='focal',
+    os_code_name=os_code_name,
     arch='amd64',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/doc/doc_independent_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_independent_task.Dockerfile.em
@@ -19,7 +19,7 @@ RUN useradd -u @uid -l -m buildfarm
     distribution_repository_keys=distribution_repository_keys,
     distribution_repository_urls=distribution_repository_urls,
     os_name='ubuntu',
-    os_code_name=@os_code_name,
+    os_code_name=os_code_name,
     add_source=False,
 ))@
 
@@ -34,7 +34,7 @@ RUN echo "@today_str"
 @(TEMPLATE(
     'snippet/install_python3.Dockerfile.em',
     os_name='ubuntu',
-    os_code_name=@os_code_name,
+    os_code_name=os_code_name,
 ))@
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y make python3-pip

--- a/ros_buildfarm/templates/doc/doc_independent_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_independent_task.Dockerfile.em
@@ -1,6 +1,6 @@
 # generated from @template_name
 
-FROM ubuntu:xenial
+FROM ubuntu:focal
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/doc/doc_independent_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_independent_task.Dockerfile.em
@@ -1,6 +1,6 @@
 # generated from @template_name
 
-@{os_code_name = 'focal'}
+@{os_code_name = 'focal'}@
 FROM ubuntu:@os_code_name
 
 VOLUME ["/var/cache/apt/archives"]

--- a/ros_buildfarm/templates/doc/doc_independent_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_independent_task.Dockerfile.em
@@ -1,6 +1,7 @@
 # generated from @template_name
 
-FROM ubuntu:focal
+@{os_code_name = 'focal'}
+FROM ubuntu:@os_code_name
 
 VOLUME ["/var/cache/apt/archives"]
 
@@ -18,7 +19,7 @@ RUN useradd -u @uid -l -m buildfarm
     distribution_repository_keys=distribution_repository_keys,
     distribution_repository_urls=distribution_repository_urls,
     os_name='ubuntu',
-    os_code_name='xenial',
+    os_code_name=@os_code_name,
     add_source=False,
 ))@
 
@@ -33,7 +34,7 @@ RUN echo "@today_str"
 @(TEMPLATE(
     'snippet/install_python3.Dockerfile.em',
     os_name='ubuntu',
-    os_code_name='xenial',
+    os_code_name=@os_code_name,
 ))@
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y make python3-pip

--- a/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
@@ -49,7 +49,7 @@
 @(SNIPPET(
     'builder_check-docker',
     os_name='ubuntu',
-    os_code_name='xenial',
+    os_code_name='focal',
     arch='amd64',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
@@ -46,7 +46,7 @@
 @(SNIPPET(
     'builder_shell_docker-info',
 ))@
-@{os_code_name = 'focal'}
+@{os_code_name = 'focal'}@
 @(SNIPPET(
     'builder_check-docker',
     os_name='ubuntu',

--- a/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
@@ -46,10 +46,11 @@
 @(SNIPPET(
     'builder_shell_docker-info',
 ))@
+@{os_code_name = 'focal'}
 @(SNIPPET(
     'builder_check-docker',
     os_name='ubuntu',
-    os_code_name='focal',
+    os_code_name=os_code_name,
     arch='amd64',
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/doc/doc_metadata_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_metadata_task.Dockerfile.em
@@ -18,7 +18,7 @@ RUN useradd -u @uid -l -m buildfarm
     distribution_repository_keys=distribution_repository_keys,
     distribution_repository_urls=distribution_repository_urls,
     os_name='ubuntu',
-    os_code_name='xenial',
+    os_code_name='focal',
     add_source=False,
 ))@
 
@@ -33,7 +33,7 @@ RUN echo "@today_str"
 @(TEMPLATE(
     'snippet/install_python3.Dockerfile.em',
     os_name='ubuntu',
-    os_code_name='xenial',
+    os_code_name='focal',
 ))@
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-catkin-pkg-modules python3-rosdistro-modules python3-yaml

--- a/ros_buildfarm/templates/doc/doc_metadata_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_metadata_task.Dockerfile.em
@@ -1,6 +1,6 @@
 # generated from @template_name
 
-FROM ubuntu:xenial
+FROM ubuntu:focal
 
 VOLUME ["/var/cache/apt/archives"]
 

--- a/ros_buildfarm/templates/doc/doc_metadata_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_metadata_task.Dockerfile.em
@@ -1,6 +1,7 @@
 # generated from @template_name
 
-FROM ubuntu:focal
+@{os_code_name = 'focal'}
+FROM ubuntu:@os_code_name
 
 VOLUME ["/var/cache/apt/archives"]
 
@@ -18,7 +19,7 @@ RUN useradd -u @uid -l -m buildfarm
     distribution_repository_keys=distribution_repository_keys,
     distribution_repository_urls=distribution_repository_urls,
     os_name='ubuntu',
-    os_code_name='focal',
+    os_code_name=os_code_name,
     add_source=False,
 ))@
 
@@ -33,7 +34,7 @@ RUN echo "@today_str"
 @(TEMPLATE(
     'snippet/install_python3.Dockerfile.em',
     os_name='ubuntu',
-    os_code_name='focal',
+    os_code_name=os_code_name,
 ))@
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-catkin-pkg-modules python3-rosdistro-modules python3-yaml

--- a/ros_buildfarm/templates/doc/doc_metadata_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_metadata_task.Dockerfile.em
@@ -1,6 +1,6 @@
 # generated from @template_name
 
-@{os_code_name = 'focal'}
+@{os_code_name = 'focal'}@
 FROM ubuntu:@os_code_name
 
 VOLUME ["/var/cache/apt/archives"]


### PR DESCRIPTION
Partially addressing #878


doc_create_reconfigure_task
---------------------------

This container is used to bootstrap the creation of doc reconfigure
jobs. Changes here aren't likely to be high impact since ros_buildfarm
is tested on Focal's python3 version by CI and our local workstations.

doc_independent_task
--------------------

Container for running doc independent jobs. There's a high likelihood
for churn here but the task is currently failing due to changes in pip
dependencies.

doc_metadata_task
-----------------

It does not appear that we have any current doc_metadata jobs on the
build farm. Nor does this job appear tested so this change will not
break anything immediately but it may break if doc_metadata jobs are
reintroduced.