### PR TITLE
Update base container images for release-related jobs.

### DIFF
--- a/ros_buildfarm/templates/misc/rosdistro_cache_task.Dockerfile.em
+++ b/ros_buildfarm/templates/misc/rosdistro_cache_task.Dockerfile.em
@@ -1,6 +1,7 @@
 # generated from @template_name
 
-FROM ubuntu:xenial
+@{os_code_name = 'focal'}@
+FROM ubuntu:@os_code_name
 
 VOLUME ["/var/cache/apt/archives"]
 
@@ -18,7 +19,7 @@ RUN useradd -u @uid -l -m buildfarm
     distribution_repository_keys=distribution_repository_keys,
     distribution_repository_urls=distribution_repository_urls,
     os_name='ubuntu',
-    os_code_name='xenial',
+    os_code_name=os_code_name,
     add_source=False,
 ))@
 
@@ -33,7 +34,7 @@ RUN echo "@today_str"
 @(TEMPLATE(
     'snippet/install_python3.Dockerfile.em',
     os_name='ubuntu',
-    os_code_name='xenial',
+    os_code_name=os_code_name,
 ))@
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-rosdistro python3-yaml

--- a/ros_buildfarm/templates/release/release_check_sync_criteria_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_check_sync_criteria_task.Dockerfile.em
@@ -1,6 +1,7 @@
 # generated from @template_name
 
-FROM ubuntu:xenial
+@{os_code_name = 'focal'}@
+FROM ubuntu:@os_code_name
 
 VOLUME ["/var/cache/apt/archives"]
 
@@ -18,7 +19,7 @@ RUN useradd -u @uid -l -m buildfarm
     distribution_repository_keys=distribution_repository_keys,
     distribution_repository_urls=distribution_repository_urls,
     os_name='ubuntu',
-    os_code_name='xenial',
+    os_code_name=os_code_name,
     add_source=False,
 ))@
 
@@ -33,7 +34,7 @@ RUN echo "@today_str"
 @(TEMPLATE(
     'snippet/install_python3.Dockerfile.em',
     os_name='ubuntu',
-    os_code_name='xenial',
+    os_code_name=os_code_name,
 ))@
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-rosdistro-modules python3-yaml

--- a/ros_buildfarm/templates/release/release_check_sync_criteria_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_check_sync_criteria_task.Dockerfile.em
@@ -1,7 +1,7 @@
 # generated from @template_name
 
-@{os_code_name = 'focal'}@
-FROM ubuntu:@os_code_name
+@{task_os_code_name = 'focal'}@
+FROM ubuntu:@task_os_code_name
 
 VOLUME ["/var/cache/apt/archives"]
 
@@ -19,7 +19,7 @@ RUN useradd -u @uid -l -m buildfarm
     distribution_repository_keys=distribution_repository_keys,
     distribution_repository_urls=distribution_repository_urls,
     os_name='ubuntu',
-    os_code_name=os_code_name,
+    os_code_name=task_os_code_name,
     add_source=False,
 ))@
 
@@ -34,7 +34,7 @@ RUN echo "@today_str"
 @(TEMPLATE(
     'snippet/install_python3.Dockerfile.em',
     os_name='ubuntu',
-    os_code_name=os_code_name,
+    os_code_name=task_os_code_name,
 ))@
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-rosdistro-modules python3-yaml

--- a/ros_buildfarm/templates/release/release_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_create_reconfigure_task.Dockerfile.em
@@ -1,6 +1,7 @@
 # generated from @template_name
 
-FROM ubuntu:xenial
+@{os_code_name = 'focal'}@
+FROM ubuntu:@os_code_name
 
 VOLUME ["/var/cache/apt/archives"]
 
@@ -18,7 +19,7 @@ RUN useradd -u @uid -l -m buildfarm
     distribution_repository_keys=distribution_repository_keys,
     distribution_repository_urls=distribution_repository_urls,
     os_name='ubuntu',
-    os_code_name='xenial',
+    os_code_name=os_code_name,
     add_source=False,
 ))@
 
@@ -33,7 +34,7 @@ RUN echo "@today_str"
 @(TEMPLATE(
     'snippet/install_python3.Dockerfile.em',
     os_name='ubuntu',
-    os_code_name='xenial',
+    os_code_name=os_code_name,
 ))@
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-pip python3-rosdistro-modules python3-yaml

--- a/ros_buildfarm/templates/release/release_create_trigger_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_create_trigger_task.Dockerfile.em
@@ -1,6 +1,7 @@
 # generated from @template_name
 
-FROM ubuntu:xenial
+@{os_code_name = 'focal'}@
+FROM ubuntu:focal
 
 VOLUME ["/var/cache/apt/archives"]
 
@@ -18,7 +19,7 @@ RUN useradd -u @uid -l -m buildfarm
     distribution_repository_keys=distribution_repository_keys,
     distribution_repository_urls=distribution_repository_urls,
     os_name='ubuntu',
-    os_code_name='xenial',
+    os_code_name=os_code_name,
     add_source=False,
 ))@
 
@@ -33,7 +34,7 @@ RUN echo "@today_str"
 @(TEMPLATE(
     'snippet/install_python3.Dockerfile.em',
     os_name='ubuntu',
-    os_code_name='xenial',
+    os_code_name=os_code_name,
 ))@
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-empy python3-pip python3-rosdistro-modules python3-yaml

--- a/ros_buildfarm/templates/release/release_create_trigger_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_create_trigger_task.Dockerfile.em
@@ -1,7 +1,7 @@
 # generated from @template_name
 
 @{os_code_name = 'focal'}@
-FROM ubuntu:focal
+FROM ubuntu:@os_code_name
 
 VOLUME ["/var/cache/apt/archives"]
 


### PR DESCRIPTION
Partially addresses #878

Run jobs in focal containers rather than xenial containers and use a template variable so that future updates to the base image are made in a single location per job type.

Affected jobs

* _rosdistro-cache
* _release-check
* _rel-sync-packages-
* _rel-reconfigure-jobs
* _rel-trigger-broken-with-non-broken-upstream
* _rel-trigger-jobs
* _rel-trigger-missed-jobs

## rosdistro_cache_task

Used to run the rosdistro_build_cache script. There doesn't appear to be a material difference between cache files generated on Xenial or Focal.

## release_check_sync_criteria_task

An issue was caused by not realizing that os_code_name was already in use as a parameter for the script target so my creation of an in-template os_code_name variable shadowed that value and hard-coded it to `focal`. 7d5af5e renames the in-template variable to task_os_code_name to distinguish it and allow the target os_code_name to pass through correctly to the command line invocation.

## create_reconfigure_task

There does not appear to be a difference between jobs run on Xenial or Focal.

## create_trigger_task

There does not appear to be a difference between jobs run on Xenial or Focal.