### PR TITLE
Update the groovy-extract-warnings script.

### DIFF
--- a/ros_buildfarm/templates/snippet/builder_system-groovy_extract-warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy_extract-warnings.xml.em
@@ -33,6 +33,10 @@ try {
       println "- " + warning
       println ""
     }
+    if (build.getResult().equals(null)) {
+      // Handle the case where no previous step set a result
+      build.setResult(Result.SUCCESS)
+    }
     if (build.getResult().isBetterThan(Result.UNSTABLE)) {
       println "Marking build as unstable"
       build.setResult(Result.UNSTABLE)


### PR DESCRIPTION
It may be the case that no previous step set a build
status.  If that is the case, calling getResult().isBetterThan()
will throw an exception since 'null' has no method isBetterThan().

The fix as implemented here is to check if a status has already
been set.  If it hasn't, set the status to 'SUCCESS', so that the
following line can check against this state.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

An alternative solution here would be to change the conditional line to:

```
if (build.getResult().equals(null) or build.getResult().isBetterThan(Result.UNSTABLE)) {
```