### PR TITLE
Use prereq repos in sync job container

### DIFF
--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -822,7 +822,7 @@ def _get_sync_packages_to_testing_job_config(
     template_name = 'release/%s/sync_packages_to_testing_job.xml.em' % package_format
 
     repository_args, script_generating_key_files = \
-        get_repositories_and_script_generating_key_files(build_file=build_file)
+        get_repositories_and_script_generating_key_files(config=config)
 
     job_data = {
         'ros_buildfarm_repository': get_repository(),

--- a/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
@@ -42,15 +42,8 @@
     'builder_shell_docker-info',
 ))@
 @(SNIPPET(
-    'builder_shell',
-    script='\n'.join([
-        '# generate key files',
-        'echo "# BEGIN SECTION: Write PGP repository keys"',
-        'mkdir -p $WORKSPACE/keys',
-        'rm -fr $WORKSPACE/keys/*',
-        'echo "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v1\n\n\nmQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc\nVFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro\nu5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4\nK/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG\naIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+\nTwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz\npwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p\nV5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT\nhM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/\n/SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV\nokdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB\ntCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQoA\nPhYhBMHPbjHmut6IaLFytPQu1vurF8ZUBQJc7yaWAhsDBQkDwmcABQsJCAcCBhUK\nCQgLAgQWAgMBAh4BAheAAAoJEPQu1vurF8ZUkhIP/RbZY1ErvCEUy8iLJm9aSpLQ\nnDZl5xILOxyZlzpg+Ml5bb0EkQDr92foCgcvLeANKARNCaGLyNIWkuyDovPV0xZJ\nrEy0kgBrDNb3++NmdI/+GA92pkedMXXioQvqdsxUagXAIB/sNGByJEhs37F05AnF\nvZbjUhceq3xTlvAMcrBWrgB4NwBivZY6IgLvl/CRQpVYwANShIQdbvHvZSxRonWh\nNXr6v/Wcf8rsp7g2VqJ2N2AcWT84aa9BLQ3Oe/SgrNx4QEhA1y7rc3oaqPVu5ZXO\nK+4O14JrpbEZ3Xs9YEjrcOuEDEpYktA8qqUDTdFyZrxb9S6BquUKrA6jZgT913kj\nJ4e7YAZobC4rH0w4u0PrqDgYOkXA9Mo7L601/7ZaDJob80UcK+Z12ZSw73IgBix6\nDiJVfXuWkk5PM2zsFn6UOQXUNlZlDAOj5NC01V0fJ8P0v6GO9YOSSQx0j5UtkUbR\nfp/4W7uCPFvwAatWEHJhlM3sQNiMNStJFegr56xQu1a/cbJH7GdbseMhG/f0BaKQ\nqXCI3ffB5y5AOLc9Hw7PYiTFQsuY1ePRhE+J9mejgWRZxkjAH/FlAubqXkDgterC\nh+sLkzGf+my2IbsMCuc+3aeNMJ5Ej/vlXefCH/MpPWAHCqpQhe2DET/jRSaM53US\nAHNx8kw4MPUkxExgI7Sd\n=4Ofr\n-----END PGP PUBLIC KEY BLOCK-----" > $WORKSPACE/keys/0.key',
-        'echo "# END SECTION"',
-    ]),
+    'builder_shell_key-files',
+    script_generating_key_files=script_generating_key_files,
 ))@
 @(SNIPPET(
     'builder_shell',
@@ -75,8 +68,7 @@
         ' ' + os_name +
         ' ' + os_code_name +
         ' ' + arch +
-        ' --distribution-repository-urls http://repositories.ros.org/ubuntu/main' +
-        ' --distribution-repository-key-files $WORKSPACE/keys/0.key' +
+        ' ' + ' '.join(repository_args) +
         ' --cache-dir /tmp/package_repo_cache' +
         ' --dockerfile-dir $WORKSPACE/docker_check_sync_criteria',
         'echo "# END SECTION"',


### PR DESCRIPTION
During the build for the container which is used to determine if the sync criteria is met for a sync-to-testing job, that container is currently provisioned with the repository it is checking. This change instead provisions the container with the repositories listed as "prerequisite" repositories in the build configuration index, and not those associated with each build file.

This list of repositories actually has nothing to do with the syncing repository, and are only used to build up the container that performs the check. They eventually end up here: https://github.com/ros-infrastructure/ros_buildfarm/blob/1235956bbb2d8ff607200dd41743cf49c2d857c6/ros_buildfarm/templates/release/release_check_sync_criteria_task.Dockerfile.em#L16-L23

These repositories are required because the evaluation of the sync criteria requires some infrastructure packages that are currently supplied by our bootstrap repository.

This most important for supporting any buildfarm release build file which doesn't store packages in the same base repository as the Ubuntu Xenial debs are stored, which is currently only the case for RPMs. Previously, this was not a problem due to a hack that was inadvertently committed and merged.

Example change for RPM sync jobs:
<details>

```
Updating job 'Grel_sync-packages-to-testing_rhel_8_x86_64' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -88,2 +88 @@
    -Version: GnuPG v1
    -
    +Version: GnuPGv1
    @@ -102,16 +101,48 @@
    -tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQoA
    -PhYhBMHPbjHmut6IaLFytPQu1vurF8ZUBQJc7yaWAhsDBQkDwmcABQsJCAcCBhUK
    -CQgLAgQWAgMBAh4BAheAAAoJEPQu1vurF8ZUkhIP/RbZY1ErvCEUy8iLJm9aSpLQ
    -nDZl5xILOxyZlzpg+Ml5bb0EkQDr92foCgcvLeANKARNCaGLyNIWkuyDovPV0xZJ
    -rEy0kgBrDNb3++NmdI/+GA92pkedMXXioQvqdsxUagXAIB/sNGByJEhs37F05AnF
    -vZbjUhceq3xTlvAMcrBWrgB4NwBivZY6IgLvl/CRQpVYwANShIQdbvHvZSxRonWh
    -NXr6v/Wcf8rsp7g2VqJ2N2AcWT84aa9BLQ3Oe/SgrNx4QEhA1y7rc3oaqPVu5ZXO
    -K+4O14JrpbEZ3Xs9YEjrcOuEDEpYktA8qqUDTdFyZrxb9S6BquUKrA6jZgT913kj
    -J4e7YAZobC4rH0w4u0PrqDgYOkXA9Mo7L601/7ZaDJob80UcK+Z12ZSw73IgBix6
    -DiJVfXuWkk5PM2zsFn6UOQXUNlZlDAOj5NC01V0fJ8P0v6GO9YOSSQx0j5UtkUbR
    -fp/4W7uCPFvwAatWEHJhlM3sQNiMNStJFegr56xQu1a/cbJH7GdbseMhG/f0BaKQ
    -qXCI3ffB5y5AOLc9Hw7PYiTFQsuY1ePRhE+J9mejgWRZxkjAH/FlAubqXkDgterC
    -h+sLkzGf+my2IbsMCuc+3aeNMJ5Ej/vlXefCH/MpPWAHCqpQhe2DET/jRSaM53US
    -AHNx8kw4MPUkxExgI7Sd
    -=4Ofr
    ------END PGP PUBLIC KEY BLOCK-----" &gt; $WORKSPACE/keys/0.key
    +tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQgA
    +PgIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgBYhBMHPbjHmut6IaLFytPQu1vur
    +F8ZUBQJgsdhRBQkLTMW7AAoJEPQu1vurF8ZUTMwP/3f7EkOPIFjUdRmpNJ2db4iB
    +RQu5b2SJRG+KIdbvQBzKUBMV6/RUhEDPjhXZI3zDevzBewvAMKkqs2Q1cWo9WV7Z
    +PyTkvSyey/Tjn+PozcdvzkvrEjDMftIk8E1WzLGq7vnPLZ1q/b6Vq4H373Z+EDWa
    +DaDwW72CbCBLWAVtqff80CwlI2x8fYHKr3VBUnwcXNHR4+nRABfAWnaU4k+oTshC
    +Qucsd8vitNfsSXrKuKyz91IRHRPnJjx8UvGU4tRGfrHkw1505EZvgP02vXeRyWBR
    +fKiL1vGy4tCSRDdZO3ms2J2m08VPv65HsHaWYMnO+rNJmMZj9d9JdL/9GRf5F6U0
    +quoIFL39BhUEvBynuqlrqistnyOhw8W/IQy/ymNzBMcMz6rcMjMwhkgm/LNXoSD1
    +1OrJu4ktQwRhwvGVarnB8ihwjsTxZFylaLmFSfaA+OAlOqCLS1OkIVMzjW+Ul6A6
    +qjiCEUOsnlf4CGlhzNMZOx3low6ixzEqKOcfECpeIj80a2fBDmWkcAAjlHu6VBhA
    +TUDG9e2xKLzV2Z/DLYsb3+n9QW7KO0yZKfiuUo6AYboAioQKn5jh3iRvjGh2Ujpo
    +22G+oae3PcCc7G+z12j6xIY709FQuA49dA2YpzMda0/OX4LP56STEveDRrO+CnV6
    +WE+F5FaIKwb72PL4rLi4
    +=i0tj
    +-----END PGP PUBLIC KEY BLOCK-----
    +" &gt; $WORKSPACE/keys/0.key
    +echo "-----BEGIN PGP PUBLIC KEY BLOCK-----
    +Version: GnuPG v1.4.11 (GNU/Linux)
    +
    +mQGiBEsy5KkRBADJbDSISoamRM5AA20bfAeBuhhaI+VaiCVcxw90sq9AI5lIc42F
    +WzM2acm8yplqWiehAqOLKd+iIrqNGZ+VavZEPTx7o06UZUMRoPBiTFaCwrQ5avKz
    +lt7ij8PRMVWNrJ7A2lDYXfFQVV1o3Xo06qVnv0KLLUmiur0LBu4H/oTH3wCgt+/I
    +D3LUKaMJsc77KwFBTjHB0EsD/26Z2Ud12f3urSNyN6VMWnP3rz6xsmtY4Qsmkbnr
    +JuduxCQBZv6bX1Cr2ulXkv0fFOr+s5OyUv7zyCPbxiJFh3Br7fJGb0b5/M208KPe
    +giITY9hMh/aUbKjXCPoOXPxSL6SWOWV8taR6903EFyLBN0qno/kXIBKnVqBZobgn
    +jIEPA/0fTnxtZtE7EpirGQMF2caJfv7/LCgXmRs9xAhgbE0/caoa1tnc79uaHmLZ
    +FtbGFoAO31YNYM/IUHtmabbGdvZ4oYUwDhjBevVvC7aI+XhuNGK5mU8qCLLSEUOl
    +CUr6BJq/0iFmjwjmwk9idZEYhqSNy2OoYJbq45rbHfbdKLEVrbQeUk9TIEJ1aWxk
    +ZXIgPHJvc2J1aWxkQHJvcy5vcmc+iGAEExECACAFAksy5KkCGwMGCwkIBwMCBBUC
    +CAMEFgIDAQIeAQIXgAAKCRBVI7rusB+hFmk7AJ0XsLp05KA8l3YzAumZfjSN04MZ
    +jQCfQHfp4aQUXdOCUtetVo0QZUX3IuO5Ag0ESzLkrhAIAOCuSC83VXYWf8gOMSzd
    +xwpsH/uLV9Wze2LGnajsJLjEOhcsz2BHfxqNXhYaE9aQaodPCpbUAkPq8tLbpXy0
    +SWRCx0F5RcplXx5vIWbP6TlfPbRpK70w7IWd6vsNrjwEHjlhOLcNcj42sp5pgx4b
    +dceK06k5Ml2hYovPnD9o2TYgjOqg5FHZ2g1J0103n/66bN/hZnpLaZJYQiPWCyq6
    +K0565i1k2Y7hgWB/OXqwaqCehqmLTvpyQGzE1UJvKLuYU+T+4hBnSPbT3KIi5fCz
    +lIwvxijOMcfbkLhzYQXcU0Rd1VItcd5nmPL4z97jBxzuhkgxXpGR4WGKhvsA2Z9Y
    +UtsAAwYH/3Bf44bTpD9bVADUdab3e7zm8iHfh9K/a83mIgDB7mHV6WuemQVTf/1d
    +eu4mI5WtpbOCoucybGfjGIIAcSxwIx6VfC7HSp4J51bOpHhbdDffUEk6QVsZjwoF
    +yn3W9W3ZVeTI+ch/Qoo5a98SnmdjN8eXI/qCuiXOHc6rXDXc2R0iox/1EAS8xGVd
    +cYZe7IWBO2CjCknyhLrWxZHoy+i1GCZ9KvPF/Ef2dmLhCydT73ZlumsY8N5vm76Q
    +ul1G7f8LNbnMgXQafRkPffrAXSVhGY3Z2IiBwFNgxcKTq479l7yedYRGeU1A+SYI
    +YmRFWHXt3rTkMlQSpxCsB0fAYfrwEqqISQQYEQIACQUCSzLkrgIbDAAKCRBVI7ru
    +sB+hFpryAJ4puo6cMZxa6wITHFAM/k84+aRijwCeItuWpUngP25xDuDGMsKarcNi
    +qYE=
    +=Vgio
    +-----END PGP PUBLIC KEY BLOCK-----
    +" &gt; $WORKSPACE/keys/1.key
    @@ -135 +166 @@
    @@ -135 +166 @@
    -python3 -u $WORKSPACE/ros_buildfarm/scripts/release/run_check_sync_criteria_job.py https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml galactic rhel rhel 8 x86_64 --distribution-repository-urls http://repositories.ros.org/ubuntu/main --distribution-repository-key-files $WORKSPACE/keys/0.key --cache-dir /tmp/package_repo_cache --dockerfile-dir $WORKSPACE/docker_check_sync_criteria
    +python3 -u $WORKSPACE/ros_buildfarm/scripts/release/run_check_sync_criteria_job.py https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml galactic rhel rhel 8 x86_64 --distribution-repository-urls http://repo.ros2.org/ubuntu/building http://repositories.ros.org/ubuntu/main --distribution-repository-key-files $WORKSPACE/keys/0.key $WORKSPACE/keys/1.key --cache-dir /tmp/package_repo_cache --dockerfile-dir $WORKSPACE/docker_check_sync_criteria
    >>>
```

</details>

Example change for Ubuntu/Debian sync jobs:

<details>

```
Updating job 'Grel_sync-packages-to-testing_focal_amd64' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -88 +88 @@
    -Version: GnuPG v1
    +Version: GnuPGv1
    @@ -166 +166 @@
    -python3 -u $WORKSPACE/ros_buildfarm/scripts/release/run_check_sync_criteria_job.py https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml galactic default ubuntu focal amd64 --distribution-repository-urls http://repo.ros2.org/ubuntu/building http://repositories.ros.org/ubuntu/testing --distribution-repository-key-files $WORKSPACE/keys/0.key $WORKSPACE/keys/1.key --cache-dir /tmp/package_repo_cache --dockerfile-dir $WORKSPACE/docker_check_sync_criteria
    +python3 -u $WORKSPACE/ros_buildfarm/scripts/release/run_check_sync_criteria_job.py https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml galactic default ubuntu focal amd64 --distribution-repository-urls http://repo.ros2.org/ubuntu/building http://repositories.ros.org/ubuntu/main --distribution-repository-key-files $WORKSPACE/keys/0.key $WORKSPACE/keys/1.key --cache-dir /tmp/package_repo_cache --dockerfile-dir $WORKSPACE/docker_check_sync_criteria
    >>>
```

</details>