### PR TITLE
Work around a packaging bug in RHEL 8.4

### DIFF
--- a/ros_buildfarm/sourcerpm_job.py
+++ b/ros_buildfarm/sourcerpm_job.py
@@ -55,6 +55,22 @@ def build_sourcerpm(
         '--depth', '1', '--no-single-branch',
         release_repository_url, os_pkg_name]
 
+    # HACK FOR RHBZ#1960791
+    # RHEL 8.4 shipped a cmake package which omitted the 'cmake3' virtual
+    # package. This hack replaces dependencies on 'cmake3' with 'cmake>3',
+    # which will work on RHEL 8, but not RHEL 7.
+    if os_name == 'rhel' and os_code_name == '8':
+        fixup_cmd = [
+            'sed', '-i',
+            r's/^\\\(\\\(Build\\\)\\?Requires:\ \*\\\)cmake3$/\\1cmake\>3/g',
+            '%s/rpm/%s.spec' % (os_pkg_name, os_pkg_name)]
+        clone_cmd = [
+            'sh', '-c', "'" + ' && '.join([
+                ' '.join(clone_cmd),
+                ' '.join(fixup_cmd),
+            ]) + "'"]
+    # END HACK
+
     cmd = [
         'mock',
         '--scm-option', 'git_get=%s' % ' '.join(clone_cmd),

--- a/ros_buildfarm/sourcerpm_job.py
+++ b/ros_buildfarm/sourcerpm_job.py
@@ -55,14 +55,14 @@ def build_sourcerpm(
         '--depth', '1', '--no-single-branch',
         release_repository_url, os_pkg_name]
 
-    # HACK FOR RHBZ#1960791
+    # HACK FOR https://bugzilla.redhat.com/1960791
     # RHEL 8.4 shipped a cmake package which omitted the 'cmake3' virtual
-    # package. This hack replaces dependencies on 'cmake3' with 'cmake>3',
+    # package. This hack replaces dependencies on 'cmake3' with 'cmake >= 3',
     # which will work on RHEL 8, but not RHEL 7.
     if os_name == 'rhel' and os_code_name == '8':
         fixup_cmd = [
-            'sed', '-i',
-            r's/^\\\(\\\(Build\\\)\\?Requires:\ \*\\\)cmake3$/\\1cmake\>3/g',
+            'sed', '-i', '-E',
+            r's/^\(\(Build\)\?Requires:\ \*\)cmake3$/\\1cmake\ \>=\ 3/',
             '%s/rpm/%s.spec' % (os_pkg_name, os_pkg_name)]
         clone_cmd = [
             'sh', '-c', "'" + ' && '.join([


### PR DESCRIPTION
There is a fix pending for this issue, but it is currently breaking pretty much all builds on the farm, and a hack to the source RPM build processes is the most expedient way to work around the bug.

This change can be reverted once the CentOS 8 buildroot has an updated cmake package which provides the cmake3 virtual package. A rebuild of the source packages will not be required at that time.

Currently tracking this ticket for the issue: https://bugzilla.redhat.com/show_bug.cgi?id=1960791