### PR TITLE
Work around a regression in the RPM mock tool

### DIFF
--- a/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
@@ -35,6 +35,9 @@ RUN echo "@(today_str)"
 
 RUN @(package_manager) update -y
 
+# Work around rpm-software-management/mock#753
+RUN sed -i "s/rpm.addMacro(macro.lstrip('%'), expression)/rpm.addMacro(macro.lstrip('%'), str(expression))/g" /usr/lib/python*/site-packages/mockbuild/scm.py
+
 @[for i, key in enumerate(distribution_repository_keys)]@
 RUN echo -e "@('\\n'.join(key.splitlines()))" > /etc/pki/mock/RPM-GPG-KEY-ros-buildfarm-@(i)
 @[end for]@

--- a/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
@@ -35,6 +35,9 @@ RUN echo "@(today_str)"
 
 RUN @(package_manager) update -y
 
+# Work around rpm-software-management/mock#753
+RUN sed -i "s/rpm.addMacro(macro.lstrip('%'), expression)/rpm.addMacro(macro.lstrip('%'), str(expression))/g" /usr/lib/python*/site-packages/mockbuild/scm.py
+
 @[for i, key in enumerate(distribution_repository_keys)]@
 RUN echo -e "@('\\n'.join(key.splitlines()))" > /etc/pki/mock/RPM-GPG-KEY-ros-buildfarm-@(i)
 @[end for]@


### PR DESCRIPTION
Upstream issue: rpm-software-management/mock#753

This is a temporary hack to unblock jobs until the issue is fixed upstream.

Before: [![Build Status](https://build.ros2.org/buildStatus/icon?job=Gsrc_el8__ament_index_cpp__rhel_8__source&build=22)](https://build.ros2.org/job/Gsrc_el8__ament_index_cpp__rhel_8__source/22/)
After: [![Build Status](https://build.ros2.org/buildStatus/icon?job=Gsrc_el8__ament_index_cpp__rhel_8__source&build=23)](https://build.ros2.org/job/Gsrc_el8__ament_index_cpp__rhel_8__source/23/)