### PR TITLE
Add a clang-tidy warning publisher.

### DIFF
--- a/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
@@ -14,6 +14,13 @@
           <reportEncoding></reportEncoding>
           <skipSymbolicLinks>false</skipSymbolicLinks>
         </io.jenkins.plugins.analysis.warnings.Gcc4>
+        <io.jenkins.plugins.analysis.warnings.ClangTidy>
+          <id></id>
+          <name></name>
+          <pattern>@[if build_tool == 'colcon']ws/log/test_*/*/stdout_stderr.log@[end if]</pattern>
+          <reportEncoding></reportEncoding>
+          <skipSymbolicLinks>false</skipSymbolicLinks>
+        </io.jenkins.plugins.analysis.warnings.ClangTidy>
       </analysisTools>
       <sourceCodeEncoding></sourceCodeEncoding>
       <sourceDirectory></sourceDirectory>

--- a/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/publisher_warnings.xml.em
@@ -17,7 +17,7 @@
         <io.jenkins.plugins.analysis.warnings.ClangTidy>
           <id></id>
           <name></name>
-          <pattern>@[if build_tool == 'colcon']ws/log/test_*/*/stdout_stderr.log@[end if]</pattern>
+          <pattern></pattern>
           <reportEncoding></reportEncoding>
           <skipSymbolicLinks>false</skipSymbolicLinks>
         </io.jenkins.plugins.analysis.warnings.ClangTidy>


### PR DESCRIPTION
This is most desired for CI jobs but I don't see a reason to restrict deployment to just those jobs. We can always revisit that if this warning parser picks up false positives in other jobs.

![clang-tidy-jenkins-warning-display](https://user-images.githubusercontent.com/358882/128231519-5dc42484-0847-444e-970c-905d12217744.png)

![clang-tidy-jenkins-warning-list](https://user-images.githubusercontent.com/358882/128231530-56aed33c-82a4-4af0-8d34-c4c5c496a709.png)
