### PR TITLE
Revert "Work around a regression in the RPM mock tool"

### DIFF
--- a/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
@@ -35,9 +35,6 @@ RUN echo "@(today_str)"
 
 RUN @(package_manager) update -y
 
-# Work around rpm-software-management/mock#753
-RUN sed -i "s/rpm.addMacro(macro.lstrip('%'), expression)/rpm.addMacro(macro.lstrip('%'), str(expression))/g" /usr/lib/python*/site-packages/mockbuild/scm.py
-
 @[for i, key in enumerate(distribution_repository_keys)]@
 RUN echo -e "@('\\n'.join(key.splitlines()))" > /etc/pki/mock/RPM-GPG-KEY-ros-buildfarm-@(i)
 @[end for]@

--- a/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
@@ -35,9 +35,6 @@ RUN echo "@(today_str)"
 
 RUN @(package_manager) update -y
 
-# Work around rpm-software-management/mock#753
-RUN sed -i "s/rpm.addMacro(macro.lstrip('%'), expression)/rpm.addMacro(macro.lstrip('%'), str(expression))/g" /usr/lib/python*/site-packages/mockbuild/scm.py
-
 @[for i, key in enumerate(distribution_repository_keys)]@
 RUN echo -e "@('\\n'.join(key.splitlines()))" > /etc/pki/mock/RPM-GPG-KEY-ros-buildfarm-@(i)
 @[end for]@


### PR DESCRIPTION
This regression was resolved in mock 2.12-1, which is already available in EPEL 8.

This reverts #894.