### PR TITLE
Add configurations for omitting package testing

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -234,6 +234,16 @@ The following options are valid in version ``2`` (beside the generic options):
 * ``upload_credential_id``: the ID of the credential to upload the built
   packages to the repository host.
 
+* ``package_dependecy_behavior``: a dictionary with the following optional
+  keys:
+
+  * ``include_test_dependencies``: a boolean flag indicating whether test and
+    exec dependencies should be included in the package dependencies for each
+    binary job (default: ``true``).
+
+  * ``run_package_tests``: a boolean flag indicating whether binary package
+    builds should also build and run tests (default: ``true``).
+
 
 Specific options in source build files
 ---------------------------------------

--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -482,6 +482,12 @@ def add_argument_return_zero(parser):
              ' recommended for use.')
 
 
+def add_argument_skip_tests(parser):
+    parser.add_argument(
+        '--skip-tests', action='store_true',
+        help='Skip execution of tests as part of the package build process.')
+
+
 def check_len_action(minargs, maxargs):
     class CheckLength(argparse.Action):
 

--- a/ros_buildfarm/binarydeb_job.py
+++ b/ros_buildfarm/binarydeb_job.py
@@ -117,7 +117,7 @@ def append_build_timestamp(rosdistro_name, package_name, sourcepkg_dir):
     subprocess.check_call(cmd, cwd=source_dir)
 
 
-def build_binarydeb(rosdistro_name, package_name, sourcepkg_dir, skip_tests=True):
+def build_binarydeb(rosdistro_name, package_name, sourcepkg_dir, skip_tests=False):
     # ensure that one source subfolder exists
     debian_package_name = get_os_package_name(rosdistro_name, package_name)
     subfolders = _get_package_subfolders(sourcepkg_dir, debian_package_name)

--- a/ros_buildfarm/binarydeb_job.py
+++ b/ros_buildfarm/binarydeb_job.py
@@ -117,12 +117,16 @@ def append_build_timestamp(rosdistro_name, package_name, sourcepkg_dir):
     subprocess.check_call(cmd, cwd=source_dir)
 
 
-def build_binarydeb(rosdistro_name, package_name, sourcepkg_dir):
+def build_binarydeb(rosdistro_name, package_name, sourcepkg_dir, skip_tests=True):
     # ensure that one source subfolder exists
     debian_package_name = get_os_package_name(rosdistro_name, package_name)
     subfolders = _get_package_subfolders(sourcepkg_dir, debian_package_name)
     assert len(subfolders) == 1, subfolders
     source_dir = subfolders[0]
+
+    env = dict(os.environ)
+    if skip_tests:
+        env['DEB_BUILD_OPTIONS'] = (env.get('DEB_BUILD_OPTIONS', '') + ' nocheck').lstrip()
 
     source, version = dpkg_parsechangelog(
         source_dir, ['Source', 'Version'])
@@ -130,12 +134,12 @@ def build_binarydeb(rosdistro_name, package_name, sourcepkg_dir):
     print("Package '%s' version: %s" % (debian_package_name, version))
 
     cmd = ['apt-src', 'import', source, '--here', '--version', version]
-    subprocess.check_call(cmd, cwd=source_dir)
+    subprocess.check_call(cmd, cwd=source_dir, env=env)
 
     cmd = ['apt-src', 'build', source]
     print("Invoking '%s' in '%s'" % (' '.join(cmd), source_dir))
     try:
-        subprocess.check_call(cmd, cwd=source_dir)
+        subprocess.check_call(cmd, cwd=source_dir, env=env)
     except subprocess.CalledProcessError:
         traceback.print_exc()
         sys.exit("""

--- a/ros_buildfarm/binaryrpm_job.py
+++ b/ros_buildfarm/binaryrpm_job.py
@@ -52,7 +52,8 @@ def get_sourcerpm(
 
 
 def build_binaryrpm(
-        rosdistro_name, package_name, sourcepkg_dir, binarypkg_dir, append_timestamp=False):
+        rosdistro_name, package_name, sourcepkg_dir, binarypkg_dir, append_timestamp=False,
+        skip_tests=False):
     rpm_package_name = get_os_package_name(rosdistro_name, package_name)
     source_packages = glob.glob(os.path.join(sourcepkg_dir, rpm_package_name + '-*.src.rpm'))
     assert len(source_packages) == 1
@@ -69,6 +70,9 @@ def build_binaryrpm(
 
     if append_timestamp:
         cmd += ['--define', 'dist_suffix .%(date -u +%%Y%%m%%d.%%H%%M%%S)']
+
+    if skip_tests:
+        cmd += ['--without', 'tests']
 
     print("Invoking '%s'" % ' '.join(cmd))
     subprocess.check_call(cmd)

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -629,9 +629,9 @@ def get_direct_dependencies(pkg_name, cached_pkgs, pkg_names, include_test_deps=
                 pkg.buildtool_export_depends + pkg.build_export_depends)
     if include_test_deps:
         pkg_deps += pkg.exec_depends + pkg.test_depends
-    # test dependencies are treated as build dependencies by bloom
-    # so we need them here to ensure that all dependencies are available
-    # before starting a build
+    # test dependencies are treated similar to build dependencies by bloom
+    # so if configured to include test dependencies, we need them here to
+    # ensure that all dependencies are available before starting a build
     depends = set([
         d.name for d in pkg_deps
         if d.name in pkg_names and

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -621,21 +621,19 @@ def get_xunit_publisher_types_and_patterns(
     return types
 
 
-def get_direct_dependencies(pkg_name, cached_pkgs, pkg_names):
+def get_direct_dependencies(pkg_name, cached_pkgs, pkg_names, include_test_deps=True):
     if pkg_name not in cached_pkgs:
         return None
     pkg = cached_pkgs[pkg_name]
+    pkg_deps = (pkg.buildtool_depends + pkg.build_depends +
+                pkg.buildtool_export_depends + pkg.build_export_depends)
+    if include_test_deps:
+        pkg_deps += pkg.exec_depends + pkg.test_depends
     # test dependencies are treated as build dependencies by bloom
     # so we need them here to ensure that all dependencies are available
     # before starting a build
     depends = set([
-        d.name for d in (
-            pkg.buildtool_depends +
-            pkg.build_depends +
-            pkg.buildtool_export_depends +
-            pkg.build_export_depends +
-            pkg.exec_depends +
-            pkg.test_depends)
+        d.name for d in pkg_deps
         if d.name in pkg_names and
         d.evaluated_condition is not False])
     return depends

--- a/ros_buildfarm/config/release_build_file.py
+++ b/ros_buildfarm/config/release_build_file.py
@@ -110,7 +110,8 @@ class ReleaseBuildFile(BuildFile):
 
         self.include_test_dependencies = True
         self.run_package_tests = True
-        if 'package_dependency_behavior' in data:
+        if data.get('package_dependency_behavior'):
+            assert isinstance(data['package_dependency_behavior'], dict)
             if 'include_test_dependencies' in data['package_dependency_behavior']:
                 self.include_test_dependencies = \
                     bool(data['package_dependency_behavior']['include_test_dependencies'])

--- a/ros_buildfarm/config/release_build_file.py
+++ b/ros_buildfarm/config/release_build_file.py
@@ -108,6 +108,16 @@ class ReleaseBuildFile(BuildFile):
         if 'upload_destination_credential_id' in data:
             self.upload_destination_credential_id = data['upload_destination_credential_id']
 
+        self.include_test_dependencies = True
+        self.run_package_tests = True
+        if 'package_dependency_behavior' in data:
+            if 'include_test_dependencies' in data['package_dependency_behavior']:
+                self.include_test_dependencies = \
+                    bool(data['package_dependency_behavior']['include_test_dependencies'])
+            if 'run_package_tests' in data['package_dependency_behavior']:
+                self.run_package_tests = \
+                    bool(data['package_dependency_behavior']['run_package_tests'])
+
     def filter_packages(self, package_names):
         res = set(package_names)
         if self.package_whitelist:

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -723,6 +723,7 @@ def _get_binarydeb_job_config(
         'notify_emails': build_file.notify_emails,
         'maintainer_emails': maintainer_emails,
         'notify_maintainers': build_file.notify_maintainers,
+        'skip_tests': not build_file.run_package_tests,
 
         'timeout_minutes': build_file.jenkins_binary_job_timeout,
 

--- a/ros_buildfarm/templates/release/deb/binarypkg_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/deb/binarypkg_create_task.Dockerfile.em
@@ -104,6 +104,7 @@ cmds.append(
     ' --distribution-repository-key-files ' + ' ' .join(['/tmp/keys/%d.key' % i for i in range(len(distribution_repository_keys))]) +
     ' --binarypkg-dir ' + binarypkg_dir +
     ' --env-vars ' + ' '.join(build_environment_variables) +
-    ' --dockerfile-dir ' + dockerfile_dir)
+    ' --dockerfile-dir ' + dockerfile_dir +
+    (' --skip-tests' if skip_tests else ''))
 }@
 CMD ["@(' && '.join(cmds))"]

--- a/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
@@ -111,7 +111,8 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' --binarypkg-dir /tmp/binarydeb' +
         ' --dockerfile-dir $WORKSPACE/docker_generating_docker' +
         ' --env-vars ' + ' '.join(build_environment_variables) +
-        (' --append-timestamp' if append_timestamp else ''),
+        (' --append-timestamp' if append_timestamp else '') +
+        (' --skip-tests' if skip_tests else ''),
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Build Dockerfile - binarydeb task"',

--- a/ros_buildfarm/templates/release/deb/binarypkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/deb/binarypkg_task.Dockerfile.em
@@ -98,6 +98,7 @@ cmd = \
     ' /tmp/ros_buildfarm/scripts/release/build_binarydeb.py' + \
     ' ' + rosdistro_name + \
     ' ' + package_name + \
-    ' --sourcepkg-dir ' + binarypkg_dir
+    ' --sourcepkg-dir ' + binarypkg_dir + \
+    (' --skip-tests' if skip_tests else '')
 }@
 CMD ["@cmd"]

--- a/ros_buildfarm/templates/release/rpm/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_job.xml.em
@@ -114,7 +114,8 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' --dockerfile-dir $WORKSPACE/docker_binaryrpm' +
         ' --binarypkg-dir /tmp/binarypkg' +
         ' --env-vars ' + ' '.join(build_environment_variables) +
-        (' --append-timestamp' if append_timestamp else ''),
+        (' --append-timestamp' if append_timestamp else '') +
+        (' --skip-tests' if skip_tests else ''),
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Build Dockerfile - build binaryrpm"',

--- a/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
@@ -58,7 +58,8 @@ cmds = [
     ' ' + package_name +
     ' --sourcepkg-dir ' + sourcepkg_dir +
     ' --binarypkg-dir ' + binarypkg_dir +
-    (' --append-timestamp' if append_timestamp else ''),
+    (' --append-timestamp' if append_timestamp else '') +
+    (' --skip-tests' if skip_tests else ''),
 ]
 }@
 CMD ["@(' && '.join(cmds))"]

--- a/scripts/release/build_binarydeb.py
+++ b/scripts/release/build_binarydeb.py
@@ -19,6 +19,7 @@ import sys
 
 from ros_buildfarm.argument import add_argument_package_name
 from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.argument import add_argument_skip_tests
 from ros_buildfarm.argument import add_argument_sourcepkg_dir
 from ros_buildfarm.binarydeb_job import build_binarydeb
 from ros_buildfarm.common import Scope
@@ -31,10 +32,12 @@ def main(argv=sys.argv[1:]):
         add_argument_rosdistro_name(parser)
         add_argument_package_name(parser)
         add_argument_sourcepkg_dir(parser)
+        add_argument_skip_tests(parser)
         args = parser.parse_args(argv)
 
         return build_binarydeb(
-            args.rosdistro_name, args.package_name, args.sourcepkg_dir)
+            args.rosdistro_name, args.package_name, args.sourcepkg_dir,
+            skip_tests=args.skip_tests)
 
 
 if __name__ == '__main__':

--- a/scripts/release/create_binarydeb_task_generator.py
+++ b/scripts/release/create_binarydeb_task_generator.py
@@ -33,6 +33,7 @@ from ros_buildfarm.argument import add_argument_os_name
 from ros_buildfarm.argument import add_argument_package_name
 from ros_buildfarm.argument import add_argument_rosdistro_index_url
 from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.argument import add_argument_skip_tests
 from ros_buildfarm.common import get_binary_package_versions
 from ros_buildfarm.common import get_distribution_repository_keys
 from ros_buildfarm.common import get_os_package_name
@@ -56,6 +57,7 @@ def main(argv=sys.argv[1:]):
     add_argument_binarypkg_dir(parser)
     add_argument_dockerfile_dir(parser)
     add_argument_env_vars(parser)
+    add_argument_skip_tests(parser)
     args = parser.parse_args(argv)
 
     debian_package_name = get_os_package_name(
@@ -101,6 +103,7 @@ def main(argv=sys.argv[1:]):
 
         'dependencies': debian_pkg_names,
         'dependency_versions': debian_pkg_versions,
+        'skip_tests': args.skip_tests,
         'install_lists': [],
 
         'rosdistro_name': args.rosdistro_name,

--- a/scripts/release/rpm/build_binarypkg.py
+++ b/scripts/release/rpm/build_binarypkg.py
@@ -21,6 +21,7 @@ from ros_buildfarm.argument import add_argument_append_timestamp
 from ros_buildfarm.argument import add_argument_binarypkg_dir
 from ros_buildfarm.argument import add_argument_package_name
 from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.argument import add_argument_skip_tests
 from ros_buildfarm.argument import add_argument_sourcepkg_dir
 from ros_buildfarm.binaryrpm_job import build_binaryrpm
 from ros_buildfarm.common import Scope
@@ -35,11 +36,12 @@ def main(argv=sys.argv[1:]):
         add_argument_sourcepkg_dir(parser)
         add_argument_binarypkg_dir(parser)
         add_argument_append_timestamp(parser)
+        add_argument_skip_tests(parser)
         args = parser.parse_args(argv)
 
         return build_binaryrpm(
             args.rosdistro_name, args.package_name, args.sourcepkg_dir, args.binarypkg_dir,
-            args.append_timestamp)
+            args.append_timestamp, skip_tests=args.skip_tests)
 
 
 if __name__ == '__main__':

--- a/scripts/release/rpm/run_binarypkg_job.py
+++ b/scripts/release/rpm/run_binarypkg_job.py
@@ -33,6 +33,7 @@ from ros_buildfarm.argument import add_argument_package_name
 from ros_buildfarm.argument import add_argument_rosdistro_index_url
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.argument import add_argument_skip_download_sourcepkg
+from ros_buildfarm.argument import add_argument_skip_tests
 from ros_buildfarm.argument import add_argument_target_repository
 from ros_buildfarm.common import get_distribution_repository_keys
 from ros_buildfarm.common import get_user_id
@@ -57,6 +58,7 @@ def main(argv=sys.argv[1:]):
     add_argument_append_timestamp(parser)
     add_argument_env_vars(parser)
     add_argument_binarypkg_dir(parser)
+    add_argument_skip_tests(parser)
     args = parser.parse_args(argv)
 
     data = copy.deepcopy(args.__dict__)
@@ -70,6 +72,7 @@ def main(argv=sys.argv[1:]):
         'target_repository': os.path.join(args.target_repository, args.os_code_name, 'SRPMS'),
 
         'skip_download_sourcepkg': args.skip_download_sourcepkg,
+        'skip_tests': args.skip_tests,
 
         'sourcepkg_dir': os.path.join(args.binarypkg_dir, 'source'),
     })

--- a/scripts/release/run_binarydeb_job.py
+++ b/scripts/release/run_binarydeb_job.py
@@ -32,6 +32,7 @@ from ros_buildfarm.argument import add_argument_package_name
 from ros_buildfarm.argument import add_argument_rosdistro_index_url
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.argument import add_argument_skip_download_sourcepkg
+from ros_buildfarm.argument import add_argument_skip_tests
 from ros_buildfarm.argument import add_argument_target_repository
 from ros_buildfarm.common import get_distribution_repository_keys
 from ros_buildfarm.common import get_user_id
@@ -55,6 +56,7 @@ def main(argv=sys.argv[1:]):
     add_argument_skip_download_sourcepkg(parser)
     add_argument_append_timestamp(parser)
     add_argument_env_vars(parser)
+    add_argument_skip_tests(parser)
     args = parser.parse_args(argv)
 
     data = copy.deepcopy(args.__dict__)
@@ -68,6 +70,7 @@ def main(argv=sys.argv[1:]):
         'target_repository': args.target_repository,
 
         'skip_download_sourcepkg': args.skip_download_sourcepkg,
+        'skip_tests': args.skip_tests,
 
         'binarypkg_dir': '/tmp/binarydeb',
         'build_environment_variables': ['%s=%s' % key_value for key_value in args.env_vars.items()],


### PR DESCRIPTION
The goal here is to provide a mechanism to disable test invocation in the binary package builds (deb/RPM) but maintain the existing best-effort behavior.