### PR TITLE
Pin charset-normalizer to a version that supports Python 3.5 on Xenial

### DIFF
--- a/ros_buildfarm/templates/ci/ci_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/ci_create_reconfigure_task.Dockerfile.em
@@ -37,7 +37,10 @@ RUN echo "@today_str"
 ))@
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-pip python3-rosdistro-modules python3-yaml
-RUN pip3 install jenkinsapi
+@(TEMPLATE(
+    'snippet/pip_install_jenkinsapi.Dockerfile.em',
+    os_code_name='xenial',
+))@
 
 USER buildfarm
 ENTRYPOINT ["sh", "-c"]

--- a/ros_buildfarm/templates/devel/devel_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_reconfigure_task.Dockerfile.em
@@ -37,7 +37,11 @@ RUN echo "@today_str"
 ))@
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-pip python3-rosdistro-modules python3-yaml
-RUN pip3 install jenkinsapi
+@(TEMPLATE(
+    'snippet/pip_install_jenkinsapi.Dockerfile.em',
+    os_code_name='xenial',
+))@
+
 
 USER buildfarm
 ENTRYPOINT ["sh", "-c"]

--- a/ros_buildfarm/templates/doc/doc_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_create_reconfigure_task.Dockerfile.em
@@ -38,7 +38,10 @@ RUN echo "@today_str"
 ))@
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-pip python3-rosdistro-modules python3-yaml
-RUN pip3 install jenkinsapi
+@(TEMPLATE(
+    'snippet/pip_install_jenkinsapi.Dockerfile.em',
+    os_code_name=os_code_name,
+))@
 
 USER buildfarm
 ENTRYPOINT ["sh", "-c"]

--- a/ros_buildfarm/templates/release/release_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_create_reconfigure_task.Dockerfile.em
@@ -37,7 +37,7 @@ RUN echo "@today_str"
 ))@
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-pip python3-rosdistro-modules python3-yaml
-RUN pip3 install jenkinsapi
+RUN pip3 install jenkinsapi charset-normalizer==2.0.4
 
 USER buildfarm
 ENTRYPOINT ["sh", "-c"]

--- a/ros_buildfarm/templates/release/release_create_trigger_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_create_trigger_task.Dockerfile.em
@@ -37,7 +37,10 @@ RUN echo "@today_str"
 ))@
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-empy python3-pip python3-rosdistro-modules python3-yaml
-RUN pip3 install jenkinsapi
+@(TEMPLATE(
+    'snippet/pip_install_jenkinsapi.Dockerfile.em',
+    os_code_name='xenial',
+))@
 
 USER buildfarm
 ENTRYPOINT ["sh", "-c"]

--- a/ros_buildfarm/templates/snippet/pip_install_jenkinsapi.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/pip_install_jenkinsapi.Dockerfile.em
@@ -1,0 +1,6 @@
+@[if os_code_name == 'xenial']@
+RUN pip3 install jekninsapi charset-normalizer==2.0.4
+@[else]@
+RUN pip3 install jekninsapi
+@[end if]@
+


### PR DESCRIPTION
As of last night, reconfigure and trigger jobs are failing with the following stacktrace:

```
00:01:20.298 Traceback (most recent call last):
00:01:20.298   File "/usr/local/lib/python3.5/dist-packages/charset_normalizer/api.py", line 5, in <module>
00:01:20.298     from os import PathLike
00:01:20.298 ImportError: cannot import name 'PathLike'
```

This is likely due to the fact that os.PathLike was added in Python 3.6. [charset-normalizer](https://pypi.org/project/charset-normalizer/) updated from 2.0.4 to 2.0.5 on September 14 according to the [release history](https://pypi.org/project/charset-normalizer/#history) and this release likely includes the use of PathLike.

#878 is in progress to move all of our maintenance jobs to Focal but I have not yet run and tested these jobs under Focal so this PR is a possible hotfix to restore builds while we continue the work to run the jobs on Focal.