### PR TITLE
Fix sync on py2, fix PR builds, add sync and trigger CI

### DIFF
--- a/.github/actions/sync_criteria_check/action.yaml
+++ b/.github/actions/sync_criteria_check/action.yaml
@@ -1,0 +1,55 @@
+---
+name: ros_buildfarm sync criteria check job
+description: Run a ROS buildfarm sync criteria check job
+inputs:
+  config_url:
+    description: URL of the buildfarm configuration index
+    required: true
+    default: https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml
+  config_name:
+    description: Name of the release configuration
+    required: true
+    default: default
+  ros_distro:
+    description: ROS distribution name
+    required: true
+  os_name:
+    description: Operating system name
+    required: true
+    default: ubuntu
+  os_code_name:
+    description: Operating system version name
+    required: true
+  arch:
+    description: Operating system architecture
+    required: true
+    default: amd64
+
+runs:
+  using: composite
+  steps:
+    - id: ros_buildfarm_job
+      shell: bash
+      run: |
+        echo ::group::Generate job
+        pushd $(mktemp -d)
+        mkdir -p docker_dir
+        curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc -o ros.asc
+        run_check_sync_criteria_job.py \
+          ${{inputs.config_url}} ${{inputs.ros_distro}} ${{inputs.config_name}} \
+          ${{inputs.os_name}} ${{inputs.os_code_name}} ${{inputs.arch}} \
+          --distribution-repository-urls http://repo.ros2.org/ubuntu/testing http://repositories.ros.org/ubuntu/testing \
+          --distribution-repository-key-files $PWD/ros.asc $PWD/ros.asc \
+          --cache-dir /tmp/package_repo_cache \
+          --dockerfile-dir $PWD/docker_dir
+        echo ::endgroup::
+
+        echo ::group::Build container
+        docker build --force-rm -t check_sync_condition $PWD/docker_dir
+        echo ::endgroup::
+
+        echo ::group::Run job
+        docker run --rm \
+          -v ${{github.workspace}}:/tmp/ros_buildfarm:ro \
+          check_sync_condition
+        echo ::endgroup

--- a/.github/actions/trigger/action.yaml
+++ b/.github/actions/trigger/action.yaml
@@ -1,0 +1,45 @@
+---
+name: ros_buildfarm trigger job
+description: Run a ROS buildfarm trigger job (without actually triggering)
+inputs:
+  config_url:
+    description: URL of the buildfarm configuration index
+    required: true
+    default: https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml
+  config_name:
+    description: Name of the release configuration
+    required: true
+    default: default
+  ros_distro:
+    description: ROS distribution name
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - id: ros_buildfarm_job
+      shell: bash
+      run: |
+        echo ::group::Generate job
+        pushd $(mktemp -d)
+        mkdir -p docker_dir trigger_jobs
+        curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc -o ros.asc
+        run_trigger_job.py \
+          ${{inputs.config_url}} ${{inputs.ros_distro}} ${{inputs.config_name}} \
+          --distribution-repository-urls http://repo.ros2.org/ubuntu/testing http://repositories.ros.org/ubuntu/testing \
+          --distribution-repository-key-files $PWD/ros.asc $PWD/ros.asc \
+          --groovy-script /tmp/trigger_jobs/trigger_jobs.groovy \
+          --cache-dir /tmp/package_repo_cache \
+          --dockerfile-dir $PWD/docker_dir
+        echo ::endgroup::
+
+        echo ::group::Build container
+        docker build --force-rm -t release_trigger_jobs $PWD/docker_dir
+        echo ::endgroup::
+
+        echo ::group::Run job
+        docker run --rm \
+          -v ${{github.workspace}}:/tmp/ros_buildfarm \
+          -v $PWD/trigger_jobs:/tmp/trigger_jobs \
+          release_trigger_jobs
+        echo ::endgroup

--- a/.github/actions/trigger/action.yaml
+++ b/.github/actions/trigger/action.yaml
@@ -39,7 +39,7 @@ runs:
 
         echo ::group::Run job
         docker run --rm \
-          -v ${{github.workspace}}:/tmp/ros_buildfarm \
+          -v ${{github.workspace}}:/tmp/ros_buildfarm:ro \
           -v $PWD/trigger_jobs:/tmp/trigger_jobs \
           release_trigger_jobs
         echo ::endgroup

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: ['*']
 
 jobs:
   pytest:
@@ -185,6 +184,39 @@ jobs:
         with:
           ros_distro: melodic
 
+  ros1_sync_criteria_check:
+    name: ROS 1 Sync Criteria Check
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python: ['2.7', '3.4', '3.5', '3.6']
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+      - name: Run job
+        uses: ./.github/actions/sync_criteria_check
+        with:
+          ros_distro: melodic
+          os_code_name: bionic
+
+  ros1_trigger:
+    name: ROS 1 Trigger
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python: ['2.7', '3.4', '3.5', '3.6']
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+      - name: Run job
+        uses: ./.github/actions/trigger
+        with:
+          ros_distro: melodic
+
   ros2_audit:
     name: ROS 2 Audit
     runs-on: ubuntu-20.04
@@ -301,3 +333,50 @@ jobs:
           os_code_name: 8
           arch: x86_64
           pkg_name: rcutils
+
+  ros2_sync_criteria_check:
+    name: ROS 2 Sync Criteria Check
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+      - name: Run job
+        uses: ./.github/actions/sync_criteria_check
+        with:
+          config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
+          ros_distro: rolling
+          os_code_name: focal
+
+  ros2_sync_criteria_check_rpm:
+    name: ROS 2 Sync Criteria Check (RPM)
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+      - name: Run job
+        uses: ./.github/actions/sync_criteria_check
+        with:
+          config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
+          config_name: rhel
+          ros_distro: rolling
+          os_name: rhel
+          os_code_name: 8
+          arch: x86_64
+
+  ros2_trigger:
+    name: ROS 2 Trigger
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+      - name: Run job
+        uses: ./.github/actions/trigger
+        with:
+          config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
+          ros_distro: rolling

--- a/scripts/release/run_check_sync_criteria_job.py
+++ b/scripts/release/run_check_sync_criteria_job.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 import argparse
 import copy
 import sys


### PR DESCRIPTION
* Python 2 support for run_check_sync_criteria_job.py was regressed in #726.
* The wildcard pattern in the PR branch filter doesn't appear to work correctly when opening a PR to a non-master branch.
* We've historically had no CI for trigger and sync jobs, but we're hitting some issues that are only happening in those job types (and reconfigure ones, but those are hard to test here).