### PR TITLE
Fix syntax errors caused by mixing template and python syntax.

### DIFF
--- a/ros_buildfarm/templates/ci/ci_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/ci_create_reconfigure_task.Dockerfile.em
@@ -19,7 +19,7 @@ RUN useradd -u @uid -l -m buildfarm
     distribution_repository_keys=distribution_repository_keys,
     distribution_repository_urls=distribution_repository_urls,
     os_name='ubuntu',
-    os_code_name=@os_code_name,
+    os_code_name=os_code_name,
     add_source=False,
 ))@
 
@@ -34,7 +34,7 @@ RUN echo "@today_str"
 @(TEMPLATE(
     'snippet/install_python3.Dockerfile.em',
     os_name='ubuntu',
-    os_code_name=@os_code_name,
+    os_code_name=os_code_name,
 ))@
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-catkin-pkg-modules python3-empy python3-pip python3-rosdistro-modules python3-yaml

--- a/ros_buildfarm/templates/devel/devel_create_reconfigure_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_create_reconfigure_task.Dockerfile.em
@@ -19,7 +19,7 @@ RUN useradd -u @uid -l -m buildfarm
     distribution_repository_keys=distribution_repository_keys,
     distribution_repository_urls=distribution_repository_urls,
     os_name='ubuntu',
-    os_code_name=@os_code_name,
+    os_code_name=os_code_name,
     add_source=False,
 ))@
 


### PR DESCRIPTION
Introduced in #906. Syntax errors due to using the @-variable syntax in empy function blocks.