### PR TITLE
Run export_repositories at the same directory as import.

### DIFF
--- a/scripts/ci/create_workspace.py
+++ b/scripts/ci/create_workspace.py
@@ -85,7 +85,7 @@ def main(argv=sys.argv[1:]):
 
     with Scope('SUBSECTION', 'vcs export --exact'):
         # if a repo has been rebased against the default branch vcs can't detect the remote
-        export_repositories(args.workspace_root, check=not args.test_branch)
+        export_repositories(source_space, check=not args.test_branch)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I noticed reviewing CI jobs that the vcs export and vcs import aren't
run at the same directory level making a direct comparison difficult.

In CI jobs on ci.ros2.org the export is run at the same directory level.
Reviewing the commit logs for this script I believe the discrepancy is
an oversight as nothing in the logs indicates they differ intentionally.