### PR TITLE
Clean up check_sync_criteria CI

### DIFF
--- a/.github/actions/audit/action.yaml
+++ b/.github/actions/audit/action.yaml
@@ -30,7 +30,3 @@ runs:
         echo ::group::Audit rosdistro
         audit_rosdistro.py ${{inputs.config_url}} ${{inputs.ros_distro}} --return-zero
         echo ::endgroup::
-
-        echo ::group::Check sync criteria
-        check_sync_criteria.py ${{inputs.config_url}} ${{inputs.ros_distro}} default ${{inputs.os_name}} ${{inputs.os_code_name}} ${{inputs.arch}}
-        echo ::endgroup::

--- a/.github/actions/sync_criteria_check/action.yaml
+++ b/.github/actions/sync_criteria_check/action.yaml
@@ -24,6 +24,10 @@ inputs:
     description: Operating system architecture
     required: true
     default: amd64
+  return_zero:
+    description: Always return zero on success, even if criteria are not met
+    required: true
+    default: true
 
 runs:
   using: composite
@@ -32,6 +36,11 @@ runs:
       shell: bash
       run: |
         echo ::group::Generate job
+        return_zero_arg=""
+        if [[ "${{inputs.return_zero}}" != "false" ]]; then
+          return_zero_arg="--return-zero"
+        fi
+
         pushd $(mktemp -d)
         mkdir -p docker_dir
         curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc -o ros.asc
@@ -41,7 +50,8 @@ runs:
           --distribution-repository-urls http://repo.ros2.org/ubuntu/testing http://repositories.ros.org/ubuntu/testing \
           --distribution-repository-key-files $PWD/ros.asc $PWD/ros.asc \
           --cache-dir /tmp/package_repo_cache \
-          --dockerfile-dir $PWD/docker_dir
+          --dockerfile-dir $PWD/docker_dir \
+          ${return_zero_arg}
         echo ::endgroup::
 
         echo ::group::Build container

--- a/ros_buildfarm/templates/release/release_check_sync_criteria_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_check_sync_criteria_task.Dockerfile.em
@@ -51,6 +51,7 @@ cmd = \
     ' ' + os_name + \
     ' ' + os_code_name + \
     ' ' + arch + \
-    ' --cache-dir ' + cache_dir
+    ' --cache-dir ' + cache_dir + \
+    (' --return-zero' if return_zero else '')
 }@
 CMD ["@cmd"]

--- a/scripts/release/run_check_sync_criteria_job.py
+++ b/scripts/release/run_check_sync_criteria_job.py
@@ -30,6 +30,7 @@ from ros_buildfarm.argument import add_argument_distribution_repository_urls
 from ros_buildfarm.argument import add_argument_dockerfile_dir
 from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
+from ros_buildfarm.argument import add_argument_return_zero
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.common import get_distribution_repository_keys
 from ros_buildfarm.common import get_user_id
@@ -52,6 +53,7 @@ def main(argv=sys.argv[1:]):
     add_argument_distribution_repository_key_files(parser)
     add_argument_cache_dir(parser)
     add_argument_dockerfile_dir(parser)
+    add_argument_return_zero(parser)
     args = parser.parse_args(argv)
 
     if args.os_name is None:


### PR DESCRIPTION
1. Drop the explicit invocation from the audit action in favor of the invocation inside the container happening in the sync_criteria_check action.
2. Plumb the '--return-zero' argument through run_check_sync_criteria_job to the check_sync_criteria invocation.
3. Default CI to returning zero even if sync criteria are not met.