### PR TITLE
Add CI action for reconfiguring release jobs

### DIFF
--- a/.github/actions/release_reconfigure/action.yaml
+++ b/.github/actions/release_reconfigure/action.yaml
@@ -1,0 +1,52 @@
+---
+name: ros_buildfarm release reconfigure
+description: Run a ROS buildfarm reconfigure job for release jobs
+inputs:
+  config_url:
+    description: URL of the buildfarm configuration index
+    required: true
+    default: https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml
+  config_name:
+    description: Name of the release configuration
+    required: true
+    default: default
+  ros_distro:
+    description: ROS distribution name
+    required: true
+  pkg_names:
+    description: Names of the package to reconfigure jobs for
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - id: ros_buildfarm_job
+      shell: bash
+      run: |
+        echo ::group::Generate job
+        package_names_arg=""
+        if [[ "${{inputs.package_names}}" != "" ]]; then
+          package_names_arg="--package-names ${{inputs.package_names}}"
+        fi
+
+        pushd $(mktemp -d)
+        mkdir -p docker_dir
+        curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc -o ros.asc
+        run_release_reconfigure_job.py \
+          ${{inputs.config_url}} ${{inputs.ros_distro}} ${{inputs.config_name}} \
+          --distribution-repository-urls http://repo.ros2.org/ubuntu/testing http://repositories.ros.org/ubuntu/testing \
+          --distribution-repository-key-files $PWD/ros.asc $PWD/ros.asc \
+          --dockerfile-dir $PWD/docker_dir \
+          --groovy-script /reconfigure_jobs.groovy \
+          ${package_names_arg}
+        echo ::endgroup::
+
+        echo ::group::Build container
+        docker build --force-rm -t release_reconfigure_jobs $PWD/docker_dir
+        echo ::endgroup::
+
+        echo ::group::Run job
+        docker run --rm \
+          -v ${{github.workspace}}:/tmp/ros_buildfarm:ro \
+          release_reconfigure_jobs
+        echo ::endgroup

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,6 +164,27 @@ jobs:
           os_code_name: bionic
           pkg_name: rostime
 
+  ros1_release_reconfigure:
+    name: ROS 1 Release Reconfigure
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python: ['2.7', '3.4', '3.5', '3.6']
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{matrix.python}}
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+      - name: Run job
+        uses: ./.github/actions/release_reconfigure
+        with:
+          ros_distro: melodic
+          pkg_names: rostime
+
   ros1_status_pages:
     name: ROS 1 Status Pages
     runs-on: ubuntu-18.04
@@ -314,6 +335,21 @@ jobs:
           ros_distro: rolling
           os_code_name: focal
           pkg_name: rcutils
+
+  ros2_release:
+    name: ROS 2 Release Reconfigure
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+      - name: Run job
+        uses: ./.github/actions/release_reconfigure
+        with:
+          config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
+          ros_distro: rolling
+          pkg_names: rcutils
 
   ros2_release_rpm:
     name: ROS 2 Release (RPM)


### PR DESCRIPTION
I'm concerned that the issues we've been facing in Jenkins regarding timeouts talking to the API endpoint will make this action really flaky. I'm opening this PR anyway so that it can be reviewed and we can hopefully collect some data.