### PR TITLE
Add a validation script for buildfarm configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,17 +21,6 @@ jobs:
         run: |
           python -m pytest -s test
 
-  config_validation:
-    name: Configuration Validation
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out project
-        uses: actions/checkout@v2
-      - name: Install dependencies
-        uses: ./.github/actions/setup
-      - name: Validate Configration
-        run: validate_config_index.py https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
-
   ros1_audit:
     name: ROS 1 Audit
     runs-on: ubuntu-18.04
@@ -52,6 +41,17 @@ jobs:
         with:
           ros_distro: melodic
           os_code_name: bionic
+
+  ros1_config:
+    name: ROS 1 Config Validation
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+      - name: Validate configration
+        run: validate_config_index.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml
 
   ros1_devel:
     name: ROS 1 Devel
@@ -276,6 +276,17 @@ jobs:
           os_code_name: focal
           underlay_dirs: ${{steps.underlay1.outputs.install_dir}} ${{steps.underlay2.outputs.install_dir}}
           package_selection_args: --packages-skip-up-to ament_flake8 ament_pep257 --packages-up-to ament_cmake_ros
+
+  ros1_config:
+    name: ROS 2 Config Validation
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+      - name: Validate configration
+        run: validate_config_index.py https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
 
   ros2_devel:
     name: ROS 2 Devel

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,17 @@ jobs:
         run: |
           python -m pytest -s test
 
+  config_validation:
+    name: Configuration Validation
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+      - name: Validate Configration
+        run: validate_config_index.py https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
+
   ros1_audit:
     name: ROS 1 Audit
     runs-on: ubuntu-18.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -277,7 +277,7 @@ jobs:
           underlay_dirs: ${{steps.underlay1.outputs.install_dir}} ${{steps.underlay2.outputs.install_dir}}
           package_selection_args: --packages-skip-up-to ament_flake8 ament_pep257 --packages-up-to ament_cmake_ros
 
-  ros1_config:
+  ros2_config:
     name: ROS 2 Config Validation
     runs-on: ubuntu-20.04
     steps:

--- a/scripts/misc/validate_config_index.py
+++ b/scripts/misc/validate_config_index.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+
+from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.config import (
+    get_ci_build_files,
+    get_doc_build_files,
+    get_global_doc_build_files,
+    get_index,
+    get_release_build_files,
+    get_source_build_files,
+)
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Parse and validate a buildfarm configuration")
+    add_argument_config_url(parser)
+    args = parser.parse_args(argv)
+
+    print('Loading index...')
+    index = get_index(args.config_url)
+
+    for dist_name in index.distributions.keys():
+        print('Processing distrubiton: ' + dist_name)
+        configs = get_ci_build_files(index, dist_name)
+        print('- Processed %d ci configs' % (len(configs),))
+        configs = get_doc_build_files(index, dist_name)
+        print('- Processed %d doc configs' % (len(configs),))
+        configs = get_release_build_files(index, dist_name)
+        print('- Processed %d release configs' % (len(configs),))
+        configs = get_source_build_files(index, dist_name)
+        print('- Processed %d source configs' % (len(configs),))
+
+    configs = get_global_doc_build_files(index)
+    print('Processed %d global doc configs' % (len(configs),))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This script can be used to load all of the configurations associated with a buildfarm configuration index, which should raise an exception if any of the build files have a syntax problem or do not pass the assertions made in the associated build file class.

I intend to use this script to validate the `ros_buildfarm_config` repositories in a GitHub Action to protect us from taking down the buildfarm with a bad change.