### PR TITLE
Fix an inverted boolean in sync_criteria_check CI

### DIFF
--- a/.github/actions/sync_criteria_check/action.yaml
+++ b/.github/actions/sync_criteria_check/action.yaml
@@ -37,7 +37,7 @@ runs:
       run: |
         echo ::group::Generate job
         return_zero_arg=""
-        if ! ${{inputs.return_zero}}; then
+        if ${{inputs.return_zero}}; then
           return_zero_arg="--return-zero"
         fi
 


### PR DESCRIPTION
Looks like the suggested fix accidentally inverted the logic: https://github.com/ros-infrastructure/ros_buildfarm/pull/911#discussion_r724560933