### PR TITLE
Also set DEB_BUILD_PROFILES when skipping tests

### DIFF
--- a/ros_buildfarm/binarydeb_job.py
+++ b/ros_buildfarm/binarydeb_job.py
@@ -126,7 +126,11 @@ def build_binarydeb(rosdistro_name, package_name, sourcepkg_dir, skip_tests=Fals
 
     env = dict(os.environ)
     if skip_tests:
+        # There are two settings which documentation suggests for disabling
+        # tests in debian builds:
+        # This setting should prevent invocation in dh_auto_test
         env['DEB_BUILD_OPTIONS'] = (env.get('DEB_BUILD_OPTIONS', '') + ' nocheck').lstrip()
+        # This setting should filter out Build-Depends marked with <!nocheck>
         env['DEB_BUILD_PROFILES'] = (env.get('DEB_BUILD_PROFILES', '') + ' nocheck').lstrip()
 
     source, version = dpkg_parsechangelog(


### PR DESCRIPTION
It appears that different parts of the debian build chain utilize DEB_BUILD_PROFILES vs DEB_BUILD_OPTIONS. From what I can tell, the safest thing to do is to set them both.

In particular, I needed to use `DEB_BUILD_PROFILES` to appease the dependency checking mechanism. `DEB_BUILD_OPTIONS` was necessary to suppress `dh_auto_test`.