### PR TITLE
Parse deb dependency exclusions and support nocheck

### DIFF
--- a/scripts/release/create_binarydeb_task_generator.py
+++ b/scripts/release/create_binarydeb_task_generator.py
@@ -170,13 +170,12 @@ def parse_build_depends(dep_str):
         dep_profs = dep_str[dep_sep + 1:-1]
         dep_str = dep_str[:dep_sep].rstrip()
         profiles.update(dep_profs.split())
-    # 2. Architectures (zero or more)
+    # 2. Architectures (zero or one)
     arches = set()
-    while dep_str.endswith(']'):
+    if dep_str.endswith(']'):
         dep_sep = dep_str.find('[')
-        dep_arches = dep_str[dep_sep + 1:-1]
+        arches.update(dep_str[dep_sep + 1:-1].split())
         dep_str = dep_str[:dep_sep].rstrip()
-        arches.update(dep_arches.split())
     # 3. Version (zero or one)
     version = None
     if dep_str.endswith(')'):


### PR DESCRIPTION
Previous behavior is to ignore a version-based exclusion and break if any arch or profile exclusions are present. This change parses all of those exclusions and specifically adds proper support for the 'nocheck' build profile.

Given some documentation, it should be easy to add architecture exclusion support as well.

The implementation here builds on the existing approach, which works backward from the end of the string looking for exclusion markers. A regular expression for each class would probably also work here.