### PR TITLE
Don't crawl non-ROS packages using rosdep in CI jobs

### DIFF
--- a/scripts/ci/generate_install_lists.py
+++ b/scripts/ci/generate_install_lists.py
@@ -74,11 +74,6 @@ def main(argv=sys.argv[1:]):
                 package_root = all_packages[package]
                 Path(package_root, 'COLCON_IGNORE').touch()
 
-        # generate a list of non-ROS package directories
-        non_ros_package_paths = set(
-            d for d in selected_packages.values()
-            if not os.path.isfile(os.path.join(d, 'package.xml')))
-
         print('There are %d packages which meet selection criteria' %
               len(selected_packages))
 
@@ -104,6 +99,9 @@ def main(argv=sys.argv[1:]):
 
         # get direct build dependencies
         package_root = args.package_root[-1]
+        non_ros_package_paths = set(
+            d for d in selected_packages.values()
+            if not os.path.isfile(os.path.join(d, 'package.xml')))
         print("Crawling for packages in '%s'" % package_root)
         pkgs = find_packages(package_root, exclude_paths=non_ros_package_paths)
 

--- a/scripts/ci/generate_install_lists.py
+++ b/scripts/ci/generate_install_lists.py
@@ -74,6 +74,11 @@ def main(argv=sys.argv[1:]):
                 package_root = all_packages[package]
                 Path(package_root, 'COLCON_IGNORE').touch()
 
+        # generate a list of non-ROS package directories
+        non_ros_package_paths = set(
+            d for d in selected_packages.values()
+            if not os.path.isfile(os.path.join(d, 'package.xml')))
+
         print('There are %d packages which meet selection criteria' %
               len(selected_packages))
 
@@ -100,7 +105,7 @@ def main(argv=sys.argv[1:]):
         # get direct build dependencies
         package_root = args.package_root[-1]
         print("Crawling for packages in '%s'" % package_root)
-        pkgs = find_packages(package_root)
+        pkgs = find_packages(package_root, exclude_paths=non_ros_package_paths)
 
         pkg_names = [pkg.name for pkg in pkgs.values()]
         print('Found the following ROS packages:')


### PR DESCRIPTION
When building CI jobs with colcon, not all of the packages in the workspace need to be ROS packages - we sometimes have non-ROS packages as well.

We're using rosdep to crawl the workspace in order to enumerate the dependencies we need to install. When rosdep encounters a package, it doesn't descend into the package any further. Because non-ROS packages are not discovered by rosdep, it freely descends into those packages looking for a manifest.

The problem occurs if that non-ROS package has any 'test' packages inside it. If it were a ROS package, the subdirectories would never have been traversed.

This change specifically excludes non-ROS package directories from rosdep's search.