### PR TITLE
Set trigger_timer from build file if unset.

### DIFF
--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -108,8 +108,7 @@ def _configure_ci_jobs(
                 jenkins=jenkins, views=views,
                 is_disabled=is_disabled,
                 groovy_script=groovy_script,
-                dry_run=dry_run,
-                trigger_timer=build_file.jenkins_job_schedule)
+                dry_run=dry_run)
             ci_job_names.append(job_name)
             if groovy_script is not None:
                 print("Configuration for job '%s'" % job_name)
@@ -159,8 +158,12 @@ def configure_ci_job(
     if build_targets is not None:
         build_file.targets = build_targets
 
-    if trigger_timer is None:
-        trigger_timer = build_file.jenkins_job_schedule
+    if trigger_timer is not None:
+        print(
+          'WARNING: trigger_timer keyword has been deprecated. '
+          'jenkins_job_schedule property of `build_file` is used instead.',
+          file=sys.stderr)
+    trigger_timer = build_file.jenkins_job_schedule
 
     if index is None:
         index = get_index(config.rosdistro_index_url)

--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -159,6 +159,9 @@ def configure_ci_job(
     if build_targets is not None:
         build_file.targets = build_targets
 
+    if trigger_timer is None:
+        trigger_timer = build_file.jenkins_job_schedule
+
     if index is None:
         index = get_index(config.rosdistro_index_url)
     if dist_file is None:


### PR DESCRIPTION
I noticed that when using generate_ci_job.py rather than generate_ci_jobs.py to manually deploy some test jobs that in the former case the scheduled job configuration was not being set.

I'm not sure whether this is an optimal way to resolve this particular issue but I figured that a half-hearted patch was a better starting point than an issue with no code attached.