### PR TITLE
Un-normalize some test dependency package names

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,9 @@ kwargs = {
         'PyYAML'],
     'tests_require': [
         'flake8 >= 3.7',
-        'flake8_class_newline',
+        'flake8-class-newline',
         'flake8_docstrings',
-        'flake8_import_order',
+        'flake8-import-order',
         'pep8',
         'pyflakes'],
     'author': 'Dirk Thomas',


### PR DESCRIPTION
It seems that these dependencies actually use hyphens and not underscores in the package name, but it typically "just works" because pip normalizes them.

flake8-class-newline: https://github.com/AlexanderVanEck/flake8-class-newline/blob/4b70bfd4fce4d6db702ed8b4a219a93635f505d1/setup.py#L27
flake8-import-order: https://github.com/PyCQA/flake8-import-order/blob/c36c22c061e5157ff6bbb138b4b4cf06cdeedb00/flake8_import_order/__about__.py#L9

Motivation for this change is that colcon doesn't currently support the "loose" name comparison that pip employs.