### PR TITLE
Make python3 interpreter replacement in scripts stricter

### DIFF
--- a/scripts/ci/generate_ci_script.py
+++ b/scripts/ci/generate_ci_script.py
@@ -16,6 +16,7 @@
 
 import argparse
 import os
+import re
 import sys
 
 from em import BANGPATH_OPT
@@ -161,7 +162,7 @@ def main(argv=sys.argv[1:]):
             'build_tool': args.build_tool or build_file.build_tool,
             'parameters': hook.parameters},
         options={BANGPATH_OPT: False})
-    value = value.replace('python3 ', sys.executable + ' ')
+    value = re.sub(r'(^| )python3 ', r'\1' + sys.executable + ' ', value, flags=re.M)
     print(value)
 
 

--- a/scripts/devel/generate_devel_script.py
+++ b/scripts/devel/generate_devel_script.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+import re
 import sys
 
 from em import BANGPATH_OPT
@@ -142,7 +143,7 @@ def main(argv=sys.argv[1:]):
             'scripts': hook.scripts,
             'build_tool': args.build_tool or build_file.build_tool},
         options={BANGPATH_OPT: False})
-    value = value.replace('python3', sys.executable)
+    value = re.sub(r'(^| )python3 ', r'\1' + sys.executable + ' ', value, flags=re.M)
     print(value)
 
 

--- a/scripts/doc/generate_doc_script.py
+++ b/scripts/doc/generate_doc_script.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+import re
 import sys
 
 from em import BANGPATH_OPT
@@ -129,7 +130,7 @@ def main(argv=sys.argv[1:]):
             'scripts': scripts,
             'doc_path': doc_path},
         options={BANGPATH_OPT: False})
-    value = value.replace('python3', sys.executable)
+    value = re.sub(r'(^| )python3 ', r'\1' + sys.executable + ' ', value, flags=re.M)
     print(value)
 
 

--- a/scripts/release/generate_release_script.py
+++ b/scripts/release/generate_release_script.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+import re
 import sys
 
 from em import BANGPATH_OPT
@@ -145,7 +146,7 @@ def main(argv=sys.argv[1:]):
             'binary_scripts': binary_scripts,
             'package_format': package_format},
         options={BANGPATH_OPT: False})
-    value = value.replace('python3', sys.executable)
+    value = re.sub(r'(^| )python3 ', r'\1' + sys.executable + ' ', value, flags=re.M)
     print(value)
 
 


### PR DESCRIPTION
There's a string replace in the generated bash scripts for various script jobs. It's there to ensure that the same python interpreter which was used to generate the script is used in the script's python invocations.

The current blind replacement is a little too aggressive and will replace any occurrence of 'python3 ' anywhere in the script, including URLs and package names. This change makes that replacement happen only at the beginning of a line or when there is whitespace before the invocation.