### PR TITLE
The command `$test_result_EXECUTABLE test-result --help` always fails

### DIFF
--- a/ros_buildfarm/templates/devel/devel_script_test_results.sh.em
+++ b/ros_buildfarm/templates/devel/devel_script_test_results.sh.em
@@ -13,7 +13,7 @@ if ! type "$test_result_EXECUTABLE" > /dev/null; then
   echo "'$test_result_EXECUTABLE' not found on the PATH. Please make sure the tool is installed and the environment is setup (if applicable) to output the test result summary."
   test_result_RC=0
 @[if build_tool == 'colcon']@
-elif ! $($test_result_EXECUTABLE test-result --help > /dev/null 2> /dev/null); then
+elif ! $($test_result_EXECUTABLE test-result --help --test-result-base $WORKSPACE/@workspace_path/test_results > /dev/null 2> /dev/null); then
   echo "'$test_result_EXECUTABLE test-result' not available. Please make sure the necessary extension is installed to output the test result summary."
   test_result_RC=0
 @[end if]@


### PR DESCRIPTION
The script checks for the existence of `$test_result_EXECUTABLE` by executing `$test_result_EXECUTABLE test-result --help`.
This command is always failing because it requires to specify the `test-result-base` argument if a `build` folder is not present.