### PR TITLE
Switch from CentOS 8 to AlmaLinux for RHEL jobs

### DIFF
--- a/ros_buildfarm/templates/release/rpm/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_job.xml.em
@@ -74,7 +74,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 ))@
 @(SNIPPET(
     'builder_check-docker',
-    os_name={'rhel': 'centos'}.get(os_name, os_name),
+    os_name={'rhel': 'almalinux'}.get(os_name, os_name),
     os_code_name=os_code_name,
     arch=arch,
 ))@

--- a/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
@@ -9,7 +9,7 @@ if os_name == 'rhel' and os_code_name.isnumeric() and int(os_code_name) < 8:
 # generated from @template_name
 
 @[if os_name in ['rhel']]@
-FROM centos:@(os_code_name)
+FROM almalinux:@(os_code_name)
 
 # Enable EPEL on RHEL
 RUN @(package_manager) install -y epel-release

--- a/ros_buildfarm/templates/release/rpm/sourcepkg_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sourcepkg_job.xml.em
@@ -61,7 +61,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 ))@
 @(SNIPPET(
     'builder_check-docker',
-    os_name={'rhel': 'centos'}.get(os_name, os_name),
+    os_name={'rhel': 'almalinux'}.get(os_name, os_name),
     os_code_name=os_code_name,
     arch=arch,
 ))@

--- a/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
@@ -9,7 +9,7 @@ if os_name == 'rhel' and os_code_name.isnumeric() and int(os_code_name) < 8:
 # generated from @template_name
 
 @[if os_name in ['rhel']]@
-FROM centos:@(os_code_name)
+FROM almalinux:@(os_code_name)
 
 # Enable EPEL on RHEL
 RUN @(package_manager) install -y epel-release


### PR DESCRIPTION
CentOS 8 will reach EOL at the end of the year. AlmaLinux 8 should be a drop-in replacement as far as we are concerned.