### PR TITLE
Separate objects when passing cache and new packages to pulp sync

### DIFF
--- a/scripts/release/rpm/sync_repo.py
+++ b/scripts/release/rpm/sync_repo.py
@@ -102,9 +102,10 @@ def main(argv=sys.argv[1:]):
             print('Syncing %d packages from %s to %s...%s' % (
                 len(packages_to_sync), dist_source, dist_dest,
                 ' (dry run)' if args.dry_run else ''))
+            package_cache = dict(packages_to_sync)
             new_pkgs, pkgs_removed = pulp_client.import_and_invalidate(
                 dist_dest, packages_to_sync, args.invalidate_expression,
-                args.invalidate, package_cache=packages_to_sync, dry_run=args.dry_run)
+                args.invalidate, package_cache=package_cache, dry_run=args.dry_run)
             print('- Added %d packages%s' % (
                 len(new_pkgs), ' (dry run)' if args.dry_run else ''))
             for pkg in sorted(new_pkgs, key=lambda pkg: pkg.name):


### PR DESCRIPTION
Previously, the `package_cache` was duplicated in `import_and_invalidate` before being modified. A recent change modified the code to use a passed object as-is. Because the same instance was also passed for `packages_to_add`, modifications to the cache resulted in changes to the list of packages to add.

The result was that no packages were ever removed from the target repo, effectively making the invalidation pattern inert.

Regression caused by #921