### PR TITLE
Add support for publishing CI archives to the repo host

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -583,3 +583,8 @@ The following options are valid in version ``1`` (beside the generic options):
 
 * ``underlay_from_ci_jobs``: names of other CI jobs which should be used
   as an underlay to this job.
+
+* ``upload_directory``: a subdirectory name to upload the resulting archive
+  to, if desired.
+  By default, the resulting archives are only available to other jobs within
+  Jenkins.

--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -303,6 +303,8 @@ def _get_ci_job_config(
         'benchmark_schema': build_file.benchmark_schema,
 
         'shared_ccache': build_file.shared_ccache,
+
+        'upload_directory': build_file.upload_directory,
     }
     job_config = expand_template(template_name, job_data)
     return job_config

--- a/ros_buildfarm/config/ci_build_file.py
+++ b/ros_buildfarm/config/ci_build_file.py
@@ -139,3 +139,7 @@ class CIBuildFile(BuildFile):
             self._assert_valid_benchmark_schema()
             assert self.benchmark_patterns, \
                 "The 'benchmark_patterns' value is required when using 'benchmark_schema'"
+
+        self.upload_directory = None
+        if 'upload_directory' in data:
+            self.upload_directory = data['upload_directory']

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -446,6 +446,17 @@ parameters = [
       image for images in show_images.values() for image in images
     ],
 ))@
+@[if upload_directory]@
+@(SNIPPET(
+    'publisher_publish-over-ssh',
+    config_name='ci_archives',
+    remote_directory=upload_directory,
+    source_files=[
+        'ros%d-%s-linux-%s-%s-ci.tar.bz2' % (ros_version, rosdistro_name, os_code_name, arch),
+    ],
+    remove_prefix=None,
+))@
+@[end if]@
 @[if benchmark_patterns]@
 @(SNIPPET(
     'publisher_benchmark',


### PR DESCRIPTION
Connected to ros-infrastructure/cookbook-ros-buildfarm#104

This change adds SSH publishing for storing CI archives on repo.ros2.org. As it stands, we have no plans to sync these archives off from the repo host, but that may change in the future.

For our immediate needs, getting the archive out of Jenkins should be good enough. We can re-evaluate later if bandwidth becomes a problem.