### PR TITLE
Update label expression for jobs running on Jenkins built-in agent.

### DIFF
--- a/ros_buildfarm/templates/misc/check_agents_job.xml.em
+++ b/ros_buildfarm/templates/misc/check_agents_job.xml.em
@@ -25,7 +25,7 @@
 @(SNIPPET(
     'scm_null',
 ))@
-  <assignedNode>master</assignedNode>
+  <assignedNode>built-in || master</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/misc/check_failing_jobs.xml.em
+++ b/ros_buildfarm/templates/misc/check_failing_jobs.xml.em
@@ -22,7 +22,7 @@
 @(SNIPPET(
     'scm_null',
 ))@
-  <assignedNode>master</assignedNode>
+  <assignedNode>built-in || master</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/misc/dashboard_job.xml.em
+++ b/ros_buildfarm/templates/misc/dashboard_job.xml.em
@@ -25,7 +25,7 @@
 @(SNIPPET(
     'scm_null',
 ))@
-  <assignedNode>master</assignedNode>
+  <assignedNode>built-in || master</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/misc/rosdistro_cache_job.xml.em
+++ b/ros_buildfarm/templates/misc/rosdistro_cache_job.xml.em
@@ -30,7 +30,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>master</assignedNode>
+  <assignedNode>built-in || master</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/release/release_trigger-broken-with-non-broken-upstream_job.xml.em
+++ b/ros_buildfarm/templates/release/release_trigger-broken-with-non-broken-upstream_job.xml.em
@@ -25,7 +25,7 @@
 @(SNIPPET(
     'scm_null',
 ))@
-  <assignedNode>master</assignedNode>
+  <assignedNode>built-in || master</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/snippet/trigger-jobs_job.xml.em
+++ b/ros_buildfarm/templates/snippet/trigger-jobs_job.xml.em
@@ -52,7 +52,7 @@
 @(SNIPPET(
     'scm_null',
 ))@
-  <assignedNode>master</assignedNode>
+  <assignedNode>built-in || master</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>


### PR DESCRIPTION
Jenkins is updating the terminology for the node built into the Jenkins
server [1]. This label expression should make the management jobs we run
on the built-in node forward-compatible with the updated name once we
update Jenkins to a version which uses the updated naming and continue
working in the meantime. Once the name-change is sufficiently far back
we can simplify the expression again by removing the old agent name.

[1]: https://www.jenkins.io/doc/book/managing/built-in-node-migration/