### PR TITLE
Use agent_on_jenkins label for jobs which should run on that node.

### DIFF
--- a/ros_buildfarm/templates/ci/ci_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_reconfigure-jobs_job.xml.em
@@ -40,7 +40,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master</assignedNode>
+  <assignedNode>agent_on_jenkins || agent_on_master</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/devel/devel_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_reconfigure-jobs_job.xml.em
@@ -45,7 +45,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master</assignedNode>
+  <assignedNode>agent_on_jenkins || agent_on_master</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/doc/doc_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_reconfigure-jobs_job.xml.em
@@ -45,7 +45,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master</assignedNode>
+  <assignedNode>agent_on_jenkins || agent_on_master</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/release/release_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/release/release_reconfigure-jobs_job.xml.em
@@ -45,7 +45,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master</assignedNode>
+  <assignedNode>agent_on_jenkins || agent_on_master</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/release/release_trigger-jobs_job.xml.em
+++ b/ros_buildfarm/templates/release/release_trigger-jobs_job.xml.em
@@ -58,7 +58,7 @@ if missed_jobs:
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master</assignedNode>
+  <assignedNode>agent_on_jenkins || agent_on_master</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/status/blocked_releases_page_job.xml.em
+++ b/ros_buildfarm/templates/status/blocked_releases_page_job.xml.em
@@ -30,7 +30,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master||buildagent</assignedNode>
+  <assignedNode>agent_on_master || buildagent</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/status/blocked_releases_page_job.xml.em
+++ b/ros_buildfarm/templates/status/blocked_releases_page_job.xml.em
@@ -30,7 +30,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master || buildagent</assignedNode>
+  <assignedNode>agent_on_jenkins || agent_on_master || buildagent</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/status/blocked_source_entries_page_job.xml.em
+++ b/ros_buildfarm/templates/status/blocked_source_entries_page_job.xml.em
@@ -30,7 +30,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master||buildagent</assignedNode>
+  <assignedNode>agent_on_master || buildagent</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/status/blocked_source_entries_page_job.xml.em
+++ b/ros_buildfarm/templates/status/blocked_source_entries_page_job.xml.em
@@ -30,7 +30,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master || buildagent</assignedNode>
+  <assignedNode>agent_on_jenkins || agent_on_master || buildagent</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/status/release_compare_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_compare_page_job.xml.em
@@ -30,7 +30,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master||buildagent</assignedNode>
+  <assignedNode>agent_on_master || buildagent</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/status/release_compare_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_compare_page_job.xml.em
@@ -30,7 +30,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master || buildagent</assignedNode>
+  <assignedNode>agent_on_jenkins || agent_on_master || buildagent</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/status/release_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_status_page_job.xml.em
@@ -30,7 +30,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master||buildagent</assignedNode>
+  <assignedNode>agent_on_master || buildagent</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/status/release_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_status_page_job.xml.em
@@ -30,7 +30,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master || buildagent</assignedNode>
+  <assignedNode>agent_on_jenkins || agent_on_master || buildagent</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/status/repos_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/repos_status_page_job.xml.em
@@ -30,7 +30,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master||buildagent</assignedNode>
+  <assignedNode>agent_on_master || buildagent</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ros_buildfarm/templates/status/repos_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/repos_status_page_job.xml.em
@@ -30,7 +30,7 @@
     refspec=None,
 ))@
   <scmCheckoutRetryCount>2</scmCheckoutRetryCount>
-  <assignedNode>agent_on_master || buildagent</assignedNode>
+  <assignedNode>agent_on_jenkins || agent_on_master || buildagent</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>


### PR DESCRIPTION
The agent_on_master was renamed to agent_on_jenkins in the migration to
cookbook-ros-buildfarm and Ubuntu 20.04. To maintain compatibility the
cookbook still applies the label agent_on_master to the agent_on_jenkins
but since Jenkins upstream is updating the name of the built-in agent
this seems like a good time to update the labels in ROS build farm.

A future release of ROS Buildfarm can remove the old names and simplify
the label expressions again.