### PR TITLE
Work around for broken EPEL 8 mock configs

### DIFF
--- a/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
@@ -35,6 +35,9 @@ RUN echo "@(today_str)"
 
 RUN @(package_manager) update -y
 
+# Workaround for broken mock configs for EPEL 8
+RUN echo -e "include('templates/almalinux-8.tpl')\ninclude('templates/epel-8.tpl')\n\nconfig_opts['root'] = 'epel-8-x86_64'\nconfig_opts['target_arch'] = 'x86_64'\nconfig_opts['legal_host_arches'] = ('x86_64',)" > /etc/mock/epel-8-x86_64.cfg
+
 @[for i, key in enumerate(distribution_repository_keys)]@
 RUN echo -e "@('\\n'.join(key.splitlines()))" > /etc/pki/mock/RPM-GPG-KEY-ros-buildfarm-@(i)
 @[end for]@

--- a/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
@@ -35,6 +35,9 @@ RUN echo "@(today_str)"
 
 RUN @(package_manager) update -y
 
+# Workaround for broken mock configs for EPEL 8
+RUN echo -e "include('templates/almalinux-8.tpl')\ninclude('templates/epel-8.tpl')\n\nconfig_opts['root'] = 'epel-8-x86_64'\nconfig_opts['target_arch'] = 'x86_64'\nconfig_opts['legal_host_arches'] = ('x86_64',)" > /etc/mock/epel-8-x86_64.cfg
+
 @[for i, key in enumerate(distribution_repository_keys)]@
 RUN echo -e "@('\\n'.join(key.splitlines()))" > /etc/pki/mock/RPM-GPG-KEY-ros-buildfarm-@(i)
 @[end for]@


### PR DESCRIPTION
It seems that CentOS yanked the CentOS 8 repositories, and the folks at mock/EPEL weren't ready for it, so now all epel-8-*.cfg mock builds are failing. This is a hacky workaround to force almalinux until they can get their heads on straight.