### PR TITLE
Switch from hacky dist_suffix to release_suffix in RPMs

### DIFF
--- a/ros_buildfarm/binaryrpm_job.py
+++ b/ros_buildfarm/binaryrpm_job.py
@@ -69,7 +69,7 @@ def build_binaryrpm(
         '--rebuild', source_packages[0]]
 
     if append_timestamp:
-        cmd += ['--define', 'dist_suffix .%(date -u +%%Y%%m%%d.%%H%%M%%S)']
+        cmd += ['--define', 'release_suffix .%(date -u +%%Y%%m%%d.%%H%%M%%S)']
 
     if skip_tests:
         cmd += ['--without', 'tests']

--- a/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
+++ b/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
@@ -22,9 +22,6 @@ config_opts['environment']['@env_key'] = '@env_val'
 config_opts['macros']['%_empty_manifest_terminate_build'] = '%{nil}'
 config_opts['macros']['%_missing_build_ids_terminate_build'] = '%{nil}'
 
-# Hack the %{dist} macro to allow release suffixing
-config_opts['macros']['%dist'] = '.' + config_opts['dist'] + '%{?dist_suffix}'
-
 # Disable automatic out-of-source CMake builds
 config_opts['macros']['%__cmake_in_source_build'] = '1'
 config_opts['macros']['%__cmake3_in_source_build'] = '1'


### PR DESCRIPTION
This hack was used to suffix package versions with a timestamp before Bloom added support for the `release_suffix` macro in 0.9.2 (almost two years ago).

With this change, the build timestamps will no longer be added to packages which were released with bloom versions prior to 0.9.2.

This hack is no longer working correctly after we switched to AlmaLinux for the underlying mock configuration. The AlmaLinux config appends `.alma` to `config['dist']`, which this hack (incorrectly) assumes will contain the default value for the `%dist` macro in the RPM build.

Follow-up to #938
Related to ros-infrastructure/bloom#569