### PR TITLE
Switch from distutils LooseVersion to packaging.version

### DIFF
--- a/ros_buildfarm/templates/release/release_create_trigger_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/release_create_trigger_task.Dockerfile.em
@@ -37,7 +37,7 @@ RUN echo "@today_str"
     os_code_name=os_code_name,
 ))@
 
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-empy python3-pip python3-rosdistro-modules python3-yaml
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-empy python3-pip python3-packaging python3-rosdistro-modules python3-yaml
 RUN pip3 install jenkinsapi
 
 USER buildfarm

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ elif 'SKIP_PYTHON_SCRIPTS' in os.environ:
     kwargs['scripts'] = []
 else:
     kwargs['install_requires'] += [
-        'catkin_pkg >= 0.2.6', 'jenkinsapi', 'rosdistro >= 0.4.0', 'vcstool >= 0.1.37']
+        'catkin_pkg >= 0.2.6', 'jenkinsapi', 'packaging', 'rosdistro >= 0.4.0', 'vcstool >= 0.1.37']
 
 setup(**kwargs)


### PR DESCRIPTION
The distutils package is deprecated. It seems that the 'packaging' package provides is a widely-adopted and viable alternative to LooseVersion.

https://packaging.pypa.io/en/latest/version.html#packaging.version.parse