### PR TITLE
Teach CI jobs to pull released packages from rosdistro

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -521,6 +521,14 @@ The following options are valid in version ``1`` (beside the generic options):
   checkout into the workspace with their branch specified in the ``source``
   entry.
 
+* ``package_names``: the names of released packages in the rosdistro to be
+  checked into the workspace at the version specified in the ``release``
+  entry.
+
+* ``package_dependencies``: a boolean flag which indiciates when to include any
+  necessary recursive dependencies to build the packages specified in
+  ``package_names``. Defaults to ``false``.
+
 * ``archive_files``: a list of workspace-relative paths and/or glob expressions to
   files to be kept as additional build artifacts.
 

--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -309,11 +309,19 @@ def add_argument_dry_run(parser):
         help='Only show the changes without apply them to Jenkins')
 
 
-def add_argument_package_names(parser):
+def add_argument_package_names(parser, optional=False):
     parser.add_argument(
         '--package-names',
-        nargs='+',
+        nargs='*' if optional else '+',
         help='A space separated list of package names')
+
+
+def add_argument_package_dependencies(parser):
+    parser.add_argument(
+        '--package-dependencies',
+        action='store_true',
+        help='Also include recursive dependencies of packages specified in '
+             '--package-names.')
 
 
 def add_argument_repository_names(parser, optional=False):

--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -208,6 +208,8 @@ def configure_ci_job(
         os_code_name, arch,
         build_file.repos_files,
         build_file.repository_names,
+        build_file.package_names,
+        build_file.package_dependencies,
         underlay_source_jobs,
         underlay_source_paths,
         trigger_timer, trigger_jobs,
@@ -230,8 +232,8 @@ def configure_ci_view(jenkins, view_name, dry_run=False):
 def _get_ci_job_config(
         index, rosdistro_name, build_file, os_name,
         os_code_name, arch,
-        repos_files, repository_names, underlay_source_jobs,
-        underlay_source_paths, trigger_timer,
+        repos_files, repository_names, package_names, package_dependencies,
+        underlay_source_jobs, underlay_source_paths, trigger_timer,
         trigger_jobs, is_disabled=False):
     template_name = 'ci/ci_job.xml.em'
 
@@ -279,6 +281,8 @@ def _get_ci_job_config(
 
         'repos_file_urls': repos_files,
         'repository_names': repository_names,
+        'package_names': package_names,
+        'package_dependencies': package_dependencies,
 
         'skip_rosdep_keys': build_file.skip_rosdep_keys,
         'install_packages': build_file.install_packages,

--- a/ros_buildfarm/config/ci_build_file.py
+++ b/ros_buildfarm/config/ci_build_file.py
@@ -87,6 +87,15 @@ class CIBuildFile(BuildFile):
             self.repository_names = data['repository_names']
             assert isinstance(self.repository_names, list)
 
+        self.package_names = []
+        if 'package_names' in data:
+            self.package_names = data['package_names']
+            assert isinstance(self.package_names, list)
+
+        self.package_dependencies = None
+        if 'package_dependencies' in data:
+            self.package_dependencies = bool(data['package_dependencies'])
+
         self.skip_rosdep_keys = []
         if 'skip_rosdep_keys' in data:
             self.skip_rosdep_keys = data['skip_rosdep_keys']

--- a/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
@@ -76,6 +76,8 @@ cmds = [
     ' --dockerfile-dir /tmp/docker_create_workspace' + \
     ' --repos-file-urls ' + ' '.join('file:///tmp/%s' % repos_file for repos_file in repos_file_names) + \
     ' --repository-names ' + ' '.join(repository_names) + \
+    ((' --package-names ' + ' '.join(package_names)) if package_names else '') + \
+    (' --package-dependencies' if package_dependencies else '') + \
     ' --test-branch "%s"' % (test_branch) + \
     ' --skip-rosdep-keys ' + ' '.join(skip_rosdep_keys) + \
     ' --package-selection-args ' + ' '.join(package_selection_args),

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -55,6 +55,18 @@ parameters = [
     },
     {
         'type': 'string',
+        'name': 'package_names',
+        'default_value': ' '.join(package_names),
+        'description': 'Released package names from the rosdistro to be built (space-separated)',
+    },
+    {
+        'type': 'boolean',
+        'name': 'package_dependencies',
+        'default_value': package_dependencies,
+        'description': 'If selected, dependencies for packages in package_names will also be built',
+    },
+    {
+        'type': 'string',
         'name': 'test_branch',
         'default_value': test_branch or '',
         'description': 'Branch to attempt to checkout before doing batch job',
@@ -179,6 +191,7 @@ parameters = [
         'echo "# BEGIN SECTION: Generate Dockerfile - CI tasks"',
         'export TZ="%s"' % timezone,
         'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
+	'if [ "$package_dependencies" = "true" ]; then package_dependencies_arg=--package-dependencies; fi',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/ci/run_ci_job.py' +
         ' ' + rosdistro_name +
         ' ' + os_name +
@@ -191,6 +204,8 @@ parameters = [
         ' --dockerfile-dir $WORKSPACE/docker_generating_dockers' +
         ' --repos-file-urls $repos_file_urls' +
         ' --repository-names $repository_names' +
+        ' --package-names $package_names' +
+        ' $package_dependencies_arg' +
         ' --test-branch "$test_branch"' +
         ' --skip-rosdep-keys ' + ' '.join(skip_rosdep_keys) +
         ' --install-packages $install_packages' +

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -191,7 +191,7 @@ parameters = [
         'echo "# BEGIN SECTION: Generate Dockerfile - CI tasks"',
         'export TZ="%s"' % timezone,
         'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
-	'if [ "$package_dependencies" = "true" ]; then package_dependencies_arg=--package-dependencies; fi',
+        'if [ "$package_dependencies" = "true" ]; then package_dependencies_arg=--package-dependencies; fi',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/ci/run_ci_job.py' +
         ' ' + rosdistro_name +
         ' ' + os_name +

--- a/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
@@ -100,6 +100,8 @@ cmds = [
     ' --workspace-root ' + workspace_root[-1] + \
     ' --repos-file-urls ' + ' '.join('file:///tmp/%s' % repos_file for repos_file in repos_file_names) + \
     ' --repository-names ' + ' '.join(repository_names) + \
+    ((' --package-names ' + ' '.join(package_names)) if package_names else '') + \
+    (' --package-dependencies' if package_dependencies else '') + \
     ' --test-branch "%s"' % (test_branch),
 
     'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \

--- a/scripts/ci/create_workspace_task_generator.py
+++ b/scripts/ci/create_workspace_task_generator.py
@@ -28,6 +28,8 @@ from ros_buildfarm.argument import add_argument_dockerfile_dir
 from ros_buildfarm.argument import add_argument_env_vars
 from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
+from ros_buildfarm.argument import add_argument_package_dependencies
+from ros_buildfarm.argument import add_argument_package_names
 from ros_buildfarm.argument import add_argument_package_selection_args
 from ros_buildfarm.argument import add_argument_repos_file_urls
 from ros_buildfarm.argument import add_argument_repository_names
@@ -57,6 +59,8 @@ def main(argv=sys.argv[1:]):
     add_argument_package_selection_args(parser)
     add_argument_repos_file_urls(parser)
     add_argument_repository_names(parser, optional=True)
+    add_argument_package_names(parser, optional=True)
+    add_argument_package_dependencies(parser)
     add_argument_skip_rosdep_keys(parser)
     add_argument_test_branch(parser)
     parser.add_argument(
@@ -65,7 +69,7 @@ def main(argv=sys.argv[1:]):
         help='The root path of the workspace to compile')
     args = parser.parse_args(argv)
 
-    assert args.repos_file_urls or args.repository_names
+    assert args.repos_file_urls or args.repository_names or args.package_names
 
     repos_file_names = []
     for index, repos_file_url in enumerate(args.repos_file_urls):
@@ -114,6 +118,8 @@ def main(argv=sys.argv[1:]):
 
         'repos_file_names': repos_file_names,
         'repository_names': args.repository_names,
+        'package_names': args.package_names,
+        'package_dependencies': args.package_dependencies,
         'test_branch': args.test_branch,
 
         'skip_rosdep_keys': args.skip_rosdep_keys,

--- a/scripts/ci/run_ci_job.py
+++ b/scripts/ci/run_ci_job.py
@@ -32,6 +32,8 @@ from ros_buildfarm.argument import add_argument_env_vars
 from ros_buildfarm.argument import add_argument_install_packages
 from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
+from ros_buildfarm.argument import add_argument_package_dependencies
+from ros_buildfarm.argument import add_argument_package_names
 from ros_buildfarm.argument import add_argument_package_selection_args
 from ros_buildfarm.argument import add_argument_repos_file_urls
 from ros_buildfarm.argument import add_argument_repository_names
@@ -66,6 +68,8 @@ def main(argv=sys.argv[1:]):
     a3 = add_argument_build_tool_test_args(parser)
     add_argument_repos_file_urls(parser)
     add_argument_repository_names(parser, optional=True)
+    add_argument_package_names(parser, optional=True)
+    add_argument_package_dependencies(parser)
     add_argument_ros_version(parser)
     add_argument_skip_rosdep_keys(parser)
     add_argument_test_branch(parser)
@@ -79,7 +83,7 @@ def main(argv=sys.argv[1:]):
     for k, v in remainder_args.items():
         setattr(args, k, v)
 
-    assert args.repos_file_urls or args.repository_names
+    assert args.repos_file_urls or args.repository_names or args.package_names
 
     repos_file_names = []
     for index, repos_file_url in enumerate(args.repos_file_urls):


### PR DESCRIPTION
The CI jobs can already pull packages from two sources:
- One or more ros2.repos files
- The 'source' stanzas in rosdistro

This change adds the capability to pull packages from the 'release' stanzas in rosdistro, and also adds a flag to pull recursive dependencies.

At the moment, I'm considering it out-of-scope to handle omitting recursive dependencies that are already present in an underlay, but that's something to note for future work.