### PR TITLE
Unify approach to using 'logging' module

### DIFF
--- a/ros_buildfarm/config/__init__.py
+++ b/ros_buildfarm/config/__init__.py
@@ -31,7 +31,7 @@ from .loader import load_url
 from .release_build_file import ReleaseBuildFile
 from .source_build_file import SourceBuildFile
 
-logger = logging.getLogger('ros_buildfarm.config')
+logger = logging.getLogger(__name__)
 
 
 def load_yaml(url):

--- a/ros_buildfarm/debian_repo.py
+++ b/ros_buildfarm/debian_repo.py
@@ -18,6 +18,8 @@ import os
 from .common import PlatformPackageDescriptor
 from .http_cache import fetch_and_cache_gzip
 
+logger = logging.getLogger(__name__)
+
 
 def get_debian_repo_index(debian_repository_baseurl, target, cache_dir):
     url = os.path.join(
@@ -29,7 +31,7 @@ def get_debian_repo_index(debian_repository_baseurl, target, cache_dir):
 
     cache_filename = fetch_and_cache_gzip(url, cache_dir)
 
-    logging.debug('Reading file: %s' % cache_filename)
+    logger.debug('Reading file: %s' % cache_filename)
     # split package blocks
     with open(cache_filename, 'rb') as f:
         blocks = f.read().decode('utf8').split('\n\n')

--- a/ros_buildfarm/http_cache.py
+++ b/ros_buildfarm/http_cache.py
@@ -28,6 +28,8 @@ except ImportError:
     from urllib2 import URLError
     from urllib2 import urlopen
 
+logger = logging.getLogger(__name__)
+
 
 def fetch_and_cache_gzip(url, cache_dir):
     cache_filename = os.path.join(
@@ -49,7 +51,7 @@ def _fetch_gzip_url(url, dst_filename):
     dst_dirname = os.path.dirname(dst_filename)
     if not os.path.exists(dst_dirname):
         os.makedirs(dst_dirname)
-    logging.debug('Downloading gz url: %s' % url)
+    logger.debug('Downloading gz url: %s' % url)
     gz_str = _load_url(url)
     gz_stream = BytesIO(gz_str)
     g = GzipFile(fileobj=gz_stream, mode='rb')
@@ -61,7 +63,7 @@ def _fetch_plain_url(url, dst_filename):
     dst_dirname = os.path.dirname(dst_filename)
     if not os.path.exists(dst_dirname):
         os.makedirs(dst_dirname)
-    logging.debug('Downloading url: %s' % url)
+    logger.debug('Downloading url: %s' % url)
     with open(dst_filename, 'wb') as f:
         f.write(_load_url(url))
 

--- a/ros_buildfarm/rpm_repo.py
+++ b/ros_buildfarm/rpm_repo.py
@@ -20,6 +20,8 @@ from .common import PlatformPackageDescriptor
 from .http_cache import fetch_and_cache_gzip
 from .http_cache import fetch_and_cache_plaintext
 
+logger = logging.getLogger(__name__)
+
 
 def get_ros_rpm_repo_index(rpm_repository_baseurl, target, cache_dir):
     return get_rpm_repo_index(
@@ -44,7 +46,7 @@ def get_rpm_repo_index(rpm_repository_baseurl, target, cache_dir):
     primary_xml_cache_filename = fetch_and_cache_gzip(
         primary_xml_url, cache_dir)
 
-    logging.debug('Reading file: %s' % primary_xml_cache_filename)
+    logger.debug('Reading file: %s' % primary_xml_cache_filename)
     pkgdb = minidom.parse(primary_xml_cache_filename)
 
     # extract version number of every package
@@ -69,7 +71,7 @@ def get_rpm_repo_index(rpm_repository_baseurl, target, cache_dir):
 
 
 def _get_primary_xml_location(repomd_xml):
-    logging.debug('Reading file: %s' % repomd_xml)
+    logger.debug('Reading file: %s' % repomd_xml)
     repomd_data_elements = minidom.parse(
         repomd_xml).getElementsByTagName('data')
 


### PR DESCRIPTION
Some of these files were using the global logger and others weren't. This change makes them all use their own logger instances, which gives the user or downstream consumer better control over the output.