### PR TITLE
Instrument pulp import operations

### DIFF
--- a/scripts/release/rpm/import_package.py
+++ b/scripts/release/rpm/import_package.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+import logging
 import sys
 
 from ros_buildfarm.argument import add_argument_dry_run
@@ -30,6 +31,9 @@ from ros_buildfarm.pulp import PulpRpmClient
 
 
 def main(argv=sys.argv[1:]):
+    logging.basicConfig(
+        level=logging.DEBUG, format='%(name)s %(levelname)s %(asctime)s: %(message)s')
+
     parser = argparse.ArgumentParser(
         description='Import packages into a repository and publish it')
     parser.add_argument(


### PR DESCRIPTION
This should give us a better idea of what's taking so long in pulp imports. We should remove the call to `logging.basicConfig` in the `import_package.py` script once we're satisfied, but the instrumentation in `pulp.py` should stay.