### PR TITLE
Use deprecated out-of-tree build in rosdoc2.

### DIFF
--- a/scripts/doc/build_rosdoc2.py
+++ b/scripts/doc/build_rosdoc2.py
@@ -52,6 +52,7 @@ def main(argv=sys.argv[1:]):
                                   'pip',
                                   'install',
                                   '--no-warn-script-location',
+                                  '--use-deprecated=out-of-tree-build',
                                   '.'],
                                  cwd=args.rosdoc2_dir)
         if pip_rc:


### PR DESCRIPTION
pip 21.3 switches to in-tree builds by default, deprecating out-of-tree builds.
This deprecated feature is also slated for removal entirely in 22.1.

Since rosdoc2 is currently mounted read-only the current build script isn't capable of building it in place.

There is an issue on pip[1] regarding this behavior where they largely conclude that this is setuptools' problem. I couldn't really find a 1:1 parallel issue in setuptools.

Longer term solutions to this problem likely involve choosing a PEP517 compliant builder such as build[2] which has an out-of-tree build option or just re-locating the rosdoc2 source to a rewritable directory before installing it.

[1]: https://github.com/pypa/pip/issues/10586
[2]: https://pypa-build.readthedocs.io/en/latest/