### PR TITLE
Add rosdoc2 job to CI workflow.

### DIFF
--- a/.github/actions/doc/action.yaml
+++ b/.github/actions/doc/action.yaml
@@ -27,6 +27,10 @@ inputs:
   repo:
     description: Name of the package repository to build
     required: true
+  output_directory:
+    description: Directory to scan for generated output
+    required: true
+    default: generated_documentation/api_rosdoc
 
 runs:
   using: composite
@@ -49,5 +53,5 @@ runs:
         echo ::endgroup::
 
         echo ::group::Show results
-        ls -alR generated_documentation/api_rosdoc
+        ls -alR ${{inputs.output_directory}}
         echo ::endgroup::

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -325,6 +325,22 @@ jobs:
           os_code_name: focal
           repo: rcutils
 
+  ros2_doc:
+    name: ROS 2 Doc
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+      - name: Run job
+        uses: ./.github/actions/doc
+        with:
+          config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
+          ros_distro: rolling
+          os_code_name: jammy
+          repo: rcl
+
   ros2_prerelease:
     name: ROS 2 Prerelease
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -340,6 +340,7 @@ jobs:
           ros_distro: rolling
           os_code_name: jammy
           repo: rcl
+          output_directory: ws/docs_output
 
   ros2_prerelease:
     name: ROS 2 Prerelease


### PR DESCRIPTION
ROS 2 doc jobs aren't currently covered by our battery of CI tests. This adds one which will probably fail on this PR but has also been cherry picked temporarily onto #948 and should pass there.