### PR TITLE
Stop implicitly installing the ros_workspace package

### DIFF
--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -66,9 +66,6 @@ RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-pi
 @# pytest-rerunfailures enables usage of --retest-until-pass
 RUN pip3 install -U setuptools pytest-rerunfailures
 @[end if]@
-@[if ros_version == 2]@
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ros-@(rosdistro_name)-ros-workspace
-@[end if]@
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
 
 @[if run_abichecker]@


### PR DESCRIPTION
This will only affect ROS 2 builds.

At some point, it was necessary for CI and/or Devel jobs to unconditionally install the ros_workspace package. There are some recent developments and goals which would benefit from discontinuing this practice and letting the debians install the workspace as a dependency only when called for.

This is an exploratory PR to see what classes of jobs will fall over outright without this behavior. If things look okay, I'll try to come up with some more contrived cases to break things.