### PR TITLE
Disable jobs downstream of packages with nulled release versions

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -664,11 +664,12 @@ def get_package_manifests(dist):
 
 
 def get_implicitly_ignored_package_names(cached_pkgs, explicitly_ignored_pkg_names):
+    pkg_names = set(explicitly_ignored_pkg_names).union(cached_pkgs.keys())
     # get direct dependencies from distro cache for each package
     direct_dependencies = {}
     for pkg_name in cached_pkgs.keys():
         direct_dependencies[pkg_name] = get_direct_dependencies(
-            pkg_name, cached_pkgs, cached_pkgs) or set([])
+            pkg_name, cached_pkgs, pkg_names) or set([])
 
     # find recursive downstream deps for all explicitly ignored packages
     ignored_pkg_names = set(explicitly_ignored_pkg_names)

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -94,6 +94,7 @@ def configure_release_jobs(
     explicitly_ignored_pkg_names = \
         set(pkg_names) - set(filtered_pkg_names) - explicitly_ignored_without_recursion_pkg_names
 
+    # Get package names for which the release version is missing, indicating the release has been "disabled" in the distribution file.
     upstream_disabled_pkg_names = set(
         p for r in dist_file.repositories.values()
         if r.release_repository and not r.release_repository.version

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -93,6 +93,13 @@ def configure_release_jobs(
         set(pkg_names) & set(build_file.package_ignore_list)
     explicitly_ignored_pkg_names = \
         set(pkg_names) - set(filtered_pkg_names) - explicitly_ignored_without_recursion_pkg_names
+
+    upstream_disabled_pkg_names = set(
+        p for r in dist_file.repositories.values()
+        if r.release_repository and not r.release_repository.version
+        for p in r.release_repository.package_names)
+    explicitly_ignored_pkg_names |= upstream_disabled_pkg_names
+
     if explicitly_ignored_pkg_names:
         print(('The following packages are being %s because of ' +
                'white-/blacklisting:') %

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -94,7 +94,8 @@ def configure_release_jobs(
     explicitly_ignored_pkg_names = \
         set(pkg_names) - set(filtered_pkg_names) - explicitly_ignored_without_recursion_pkg_names
 
-    # Get package names for which the release version is missing, indicating the release has been "disabled" in the distribution file.
+    # Get package names for which the release version is missing,
+    # indicating the release has been "disabled" in the distribution file.
     upstream_disabled_pkg_names = set(
         p for r in dist_file.repositories.values()
         if r.release_repository and not r.release_repository.version


### PR DESCRIPTION
When the 'version' value in the 'release' stanza of a repository entry in the rosdistro index is encountered, the job is omitted from the Jenkins configuration.

This change ensures that any packages downstream of those packages are disabled and do not run.