### PR TITLE
Mark CI jobs unstable based on static analysis

### DIFF
--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -451,7 +451,7 @@ parameters = [
 @(SNIPPET(
     'publisher_warnings',
     build_tool=build_tool,
-    unstable_threshold='',
+    unstable_threshold='1',
 ))@
 @(SNIPPET(
     'archive_artifacts',


### PR DESCRIPTION
The threshold for this gate is '1' on ci.ros2.org, and I'm not sure why it was ever left unset here.

Will result in changes like this to the job XML of each CI job:
```
    <<<
    --- remote config
    +++ new config
    @@ -464 +464,7 @@
    -      <qualityGates />
    +      <qualityGates>
    +        <io.jenkins.plugins.analysis.core.util.QualityGate>
    +          <threshold>1</threshold>
    +          <type>TOTAL</type>
    +          <status>WARNING</status>
    +        </io.jenkins.plugins.analysis.core.util.QualityGate>
    +      </qualityGates>
    >>>
```