### PR TITLE
Pin setuptools to 59.6.0.

### DIFF
--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -64,7 +64,7 @@ RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-pip
 @# colcon-core.package_identification.python needs at least setuptools 30.3.0
 @# pytest-rerunfailures enables usage of --retest-until-pass
-RUN pip3 install -U setuptools pytest-rerunfailures
+RUN pip3 install -U setuptools==59.6.0 pytest-rerunfailures
 @[end if]@
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
 


### PR DESCRIPTION
Versions later than that are arbitrarily adding an additional
local path, throwing all of our tools off.

This is meant to be a temporary fix until we completely remove
the need to use pip to install any packages.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that we are attempting to fix the CI jobs here, but the change is in `devel_task.Dockerfile.em`.  As far as I can tell, the CI jobs reuse this Dockerfile template, so this is the correct place.  Please let me know if I'm wrong about this.  But because this is used on both the devel jobs and the CI jobs, the possibility for breakage is doubled.

Also note that I've not tested this on a "live" buildfarm yet.  Not sure if we should deploy it to the test buildfarm first or not, I'll wait for feedback before trying that.