### PR TITLE
Always install workspace package in ROS 2 devel jobs

### DIFF
--- a/scripts/devel/create_devel_task_generator.py
+++ b/scripts/devel/create_devel_task_generator.py
@@ -125,7 +125,7 @@ def main(argv=sys.argv[1:]):
     elif 'catkin' not in pkg_names:
         debian_pkg_names += resolve_names(['catkin'], **context)
     if args.ros_version == 2:
-        debian_pkg_names.append('ros-%s-ros-workspace' % (args.rosdistro_name,))
+        debian_pkg_names += resolve_names(['ros_buildfarm'], **context)
     print('Always install the following generic dependencies:')
     for debian_pkg_name in sorted(debian_pkg_names):
         print('  -', debian_pkg_name)

--- a/scripts/devel/create_devel_task_generator.py
+++ b/scripts/devel/create_devel_task_generator.py
@@ -125,7 +125,7 @@ def main(argv=sys.argv[1:]):
     elif 'catkin' not in pkg_names:
         debian_pkg_names += resolve_names(['catkin'], **context)
     if args.ros_version == 2:
-        debian_pkg_names += resolve_names(['ros_buildfarm'], **context)
+        debian_pkg_names += resolve_names(['ros_workspace'], **context)
     print('Always install the following generic dependencies:')
     for debian_pkg_name in sorted(debian_pkg_names):
         print('  -', debian_pkg_name)

--- a/scripts/devel/create_devel_task_generator.py
+++ b/scripts/devel/create_devel_task_generator.py
@@ -124,6 +124,8 @@ def main(argv=sys.argv[1:]):
         ]
     elif 'catkin' not in pkg_names:
         debian_pkg_names += resolve_names(['catkin'], **context)
+    if args.ros_version == 2:
+        debian_pkg_names.append('ros-%s-ros-workspace' % (args.rosdistro_name,))
     print('Always install the following generic dependencies:')
     for debian_pkg_name in sorted(debian_pkg_names):
         print('  -', debian_pkg_name)


### PR DESCRIPTION
This will revert devel jobs to the previous behavior while leaving the CI jobs workspace-less.

As an alternative, we could look through the resolved list of packages and only install the workspace package if we see any other packages in the list that start with `ros-$ROSDISTRO-*`. It's a bit of a violation, though, because rosdep is responsible for transforming package names into debian names.

Fixes: #950