### PR TITLE
Create checksum files with CI archives

### DIFF
--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -362,10 +362,14 @@ parameters = [
     'builder_shell',
     script='\n'.join([
         'echo "# BEGIN SECTION: Compress install space"',
-        'tar -cjf $WORKSPACE/ros%d-%s-linux-%s-%s-ci.tar.bz2 ' % (ros_version, rosdistro_name, os_code_name, arch) +
-        ' -C $WORKSPACE/ws' +
+        'cd $WORKSPACE',
+        'tar -cjf ros%d-%s-linux-%s-%s-ci.tar.bz2' % (ros_version, rosdistro_name, os_code_name, arch) +
+        ' -C ws' +
         ' --transform "s/^install_isolated/ros%d-linux/"' % (ros_version) +
         ' install_isolated',
+        'sha256sum -b ros%d-%s-linux-%s-%s-ci.tar.bz2' % (ros_version, rosdistro_name, os_code_name, arch) +
+        ' > ros%d-%s-linux-%s-%s-ci-CHECKSUM' % (ros_version, rosdistro_name, os_code_name, arch),
+        'cd -',
         'echo "# END SECTION"',
     ]),
 ))@
@@ -457,6 +461,7 @@ parameters = [
     'archive_artifacts',
     artifacts=[
       'ros%d-%s-linux-%s-%s-ci.tar.bz2' % (ros_version, rosdistro_name, os_code_name, arch),
+      'ros%d-%s-linux-%s-%s-ci-CHECKSUM' % (ros_version, rosdistro_name, os_code_name, arch),
     ] + archive_files + [
       image for images in show_images.values() for image in images
     ],
@@ -468,6 +473,7 @@ parameters = [
     remote_directory=upload_directory,
     source_files=[
         'ros%d-%s-linux-%s-%s-ci.tar.bz2' % (ros_version, rosdistro_name, os_code_name, arch),
+        'ros%d-%s-linux-%s-%s-ci-CHECKSUM' % (ros_version, rosdistro_name, os_code_name, arch),
     ],
     remove_prefix=None,
 ))@


### PR DESCRIPTION
Create a sha256 file for use with the sha256sum tool to verify the integrity of artifacts created by the CI jobs. Make these files available in both the Jenkins UI alongside the the tarballs, and also upload them over SSH (where applicable).

In future work, I'd like to make the `-CHECKSUM` file clear-signed. It appears that the `sha256sum` program can ignore the GPG signature information, so there is no need to ship a detached signature.

For now, we can add the `-CHECKSUM` file as-is, and we won't need to change the mechanism to consume it when the signing work lands.

Test build on Jenkins to verify that Jenkins processes the new file correctly: [![Build Status](https://build.ros2.org/buildStatus/icon?job=Rci__drake-ros-underlay_ubuntu_focal_amd64&build=11)](https://build.ros2.org/view/Rci/job/Rci__drake-ros-underlay_ubuntu_focal_amd64/11/)