### PR TITLE
Try to avoid installing stuff via pip

### DIFF
--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -61,10 +61,12 @@ RUN echo "@today_str"
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-yaml
 
 @[if build_tool == 'colcon']@
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-pip
 @# colcon-core.package_identification.python needs at least setuptools 30.3.0
 @# pytest-rerunfailures enables usage of --retest-until-pass
-RUN pip3 install -U setuptools==59.6.0 pytest-rerunfailures
+@# using a regex to install python3-pytest-rerunfailures like this effectively makes it optional.
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y '^python3-(pip|pytest-rerunfailures|setuptools)$'
+@# use pip to upgrade if necessary
+RUN pip3 install 'setuptools>=30.3.0,<60.0.0' pytest-rerunfailures
 @[end if]@
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
 

--- a/ros_buildfarm/templates/doc/doc_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/doc_task.Dockerfile.em
@@ -60,9 +60,10 @@ RUN echo "@today_str"
 ))@
 
 @[if build_tool == 'colcon']@
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-pip
 @# colcon-core.package_identification.python needs at least version 30.3.0
-RUN pip3 install -U setuptools
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-pip python3-setuptools
+@# use pip to upgrade if necessary
+RUN pip3 install 'setuptools>=30.3.0,<60.0.0'
 @[end if]@
 
 @(TEMPLATE(


### PR DESCRIPTION
This change should allow platforms which can satisfy specific python version requirements through apt to avoid unnecessarily installing packages via pip.