### PR TITLE
Fix the argument type on --pulp-task-timeout

### DIFF
--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -426,7 +426,7 @@ def add_argument_pulp_resource_record(parser):
 def add_argument_pulp_task_timeout(parser):
     return parser.add_argument(
         '--pulp-task-timeout',
-        default=60.0,
+        type=float, default=60.0,
         help='Duration to wait (in seconds) for a pulp task to complete')
 
 


### PR DESCRIPTION
Without specifying the type, it will default to `str`, which will resulted in an error trying to add floats and strings. The type conversion doesn't get applied when the default value is used, so I didn't notice the problem until I actually tried to specify something on the command line.