### PR TITLE
Use a specific exception class for Pulp task failures

### DIFF
--- a/ros_buildfarm/pulp.py
+++ b/ros_buildfarm/pulp.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 class PulpTaskError(RuntimeError):
 
-    def __init__(self, task, state):
+    def __init__(self, task, state):  # noqa: D107
         super().__init__("Pulp task '%s' did not complete (%s)" % (task.pulp_href, state))
         self.task = task
 


### PR DESCRIPTION
I found it necessary to access the `task` instance to get additional error information while I was recovering the Pulp data this week.

In particular, an upload can fail if a package was already uploaded (i.e. has the same hash). The resulting `task` for the upload is marked as `failed`, but contains an extra field with the HREF of the existing `artifact` instance, which can be used to track down the existing package instance.