### PR TITLE
Use job-specific ccache directory.

### DIFF
--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -203,6 +203,7 @@ if pull_request:
         'echo "# BEGIN SECTION: Run Dockerfile - build and install"',
     ] + ([
         'if [ ! -d "$HOME/.ccache" ]; then mkdir $HOME/.ccache; fi',
+        'if [ ! -d "$HOME/.ccache/' + job_name +'" ]; then mkdir "$HOME/.ccache/' + job_name + '"; fi',
     ]  if shared_ccache else []) + [
         ('if [ ! -c /dev/nvidia[0-9] ]; then echo "--require-gpu-support is enabled but can not detect nvidia support installed" && exit 1; fi' if require_gpu_support else ''),
         'docker run' +
@@ -212,7 +213,7 @@ if pull_request:
         ' -e=TRAVIS=$TRAVIS' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/ws:/tmp/ws' +
-        (' -v $HOME/.ccache:/home/buildfarm/.ccache' if shared_ccache else '') +
+        (' -v "$HOME/.ccache/' + job_name + '":/home/buildfarm/.ccache' if shared_ccache else '') +
         ' devel_build_and_install.%s_%s' % (rosdistro_name, source_repo_spec.name.lower()),
         'cd -',  # restore pwd when used in scripts
         'echo "# END SECTION"',
@@ -237,6 +238,7 @@ if pull_request:
         '',
     ] + ([
         'if [ ! -d "$HOME/.ccache" ]; then mkdir $HOME/.ccache; fi',
+        'if [ ! -d "$HOME/.ccache/' + job_name +'" ]; then mkdir "$HOME/.ccache/' + job_name + '"; fi',
     ] if shared_ccache else []) + [
         'docker run' +
         (' --env=DISPLAY=:0.0 --env=QT_X11_NO_MITSHM=1 --volume=/tmp/.X11-unix:/tmp/.X11-unix:rw  --gpus all' if require_gpu_support else '') +
@@ -245,7 +247,7 @@ if pull_request:
         ' -e=TRAVIS=$TRAVIS' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/ws:/tmp/ws' +
-        (' -v $HOME/.ccache:/home/buildfarm/.ccache' if shared_ccache else '') +
+        (' -v "$HOME/.ccache/' + job_name + '":/home/buildfarm/.ccache' if shared_ccache else '') +
         ' devel_build_and_test.%s_%s' % (rosdistro_name, source_repo_spec.name.lower()),
         'cd -',  # restore pwd when used in scripts
         'echo "# END SECTION"',


### PR DESCRIPTION
Sharing ccache between builds via docker volume mounting was made optional and off by default in #844.

Part of the reasoning behind that was due to the possibility for deleterious interaction between different jobs via the host's ccache directory.

Long term, I'd actually like to explore using something like [sccache](https://github.com/mozilla/sccache) to enable caching across multiple hosts but in the current state that would only widen the blast radius.

I've started with devel jobs which, along with ci jobs, are most affected by the removal of a shared ccache since each job builds once to install and once to test. If this reviews well I'll figure out the best way to spread this out among the other job types.

This would allow us to re-enable ccache for builds since each job could only affect its own ccache directory.

---

As an aside, I'd really like to find a way to improve the readability of the shell snippets.
Joining an array of strings with newlines is a cute solution to keep things inline but the mix of quoting, escaping, and conditional logic with empy templates and python strings is courting disaster and I'd like to take the pulse on a refactor which either moves the script contents into f-strings (now that our oldest supported platform, Focal, supports them) or into separate empy files entirely.

---

As a further aside, I'd rather not actually use subdirectories of `~/.ccache` since on a non-dedicated host (such as my local workstation) this use of ~/.ccache conflicts with the default use of that directory. I'll propose `$XDG_CACHE_HOME/ros_buildfarm/ccache/$job_name`.

---

Using rclcpp on my local workstation as a case study.
#### Build 1
build-and-install `colcon build` step: 1min 22s
build-and-test `colcon build` step: 7min 24s

#### Build 2 (using the same ccache directory)
build-and-install `colcon build` step: 6.07s
build-and-test `colcon build` step: 40.4s