### PR TITLE
Declare test dependencies in [test] extra

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          python -m pip install -U catkin-pkg EmPy jenkinsapi PyYAML rosdistro vcstool
-          python -m pip install -U flake8 flake8-class-newline flake8-docstrings flake8-import-order pep8 pyflakes pytest
+          python -m pip install -U -e .[test]
       - name: Run tests
         run: |
           python -m pytest -s test

--- a/setup.py
+++ b/setup.py
@@ -32,13 +32,16 @@ kwargs = {
     'install_requires': [
         'empy',
         'PyYAML'],
-    'tests_require': [
-        'flake8 >= 3.7',
-        'flake8-class-newline',
-        'flake8_docstrings',
-        'flake8-import-order',
-        'pep8',
-        'pyflakes'],
+    'extras_require': {
+        'test': [
+            'flake8 >= 3.7',
+            'flake8-class-newline',
+            'flake8_docstrings',
+            'flake8-import-order',
+            'pep8',
+            'pyflakes',
+            'pytest'],
+    },
     'author': 'Dirk Thomas',
     'author_email': 'dthomas@osrfoundation.org',
     'maintainer': 'ROS Infrastructure Team',


### PR DESCRIPTION
Formally declaring the test dependencies somewhere is a good idea, and allows tools like `colcon` to discover them.

['extras_require']['test'] is where we put these dependencies in colcon itself, but there doesn't appear to be a strong consensus among the packaging community regarding where to list these, and many options aren't compatible with python 2, which is still supported in this package. This option seems to meet all of our needs.