### PR TITLE
Explicitly state no compatibility with flake8 >= 5.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,12 +34,13 @@ kwargs = {
         'PyYAML'],
     'extras_require': {
         'test': [
-            'flake8 >= 3.7',
+            'flake8 >= 3.7, < 5',
             'flake8-class-newline',
             'flake8_docstrings',
             'flake8-import-order',
             'pep8',
-            'pyflakes',
+            'pycodestyle < 2.9.0',
+            'pyflakes < 2.5.0',
             'pytest'],
     },
     'author': 'Dirk Thomas',


### PR DESCRIPTION
The latest release of flake8 drops API compatibility. We should eventually add support for the newer flake8, but this should keep CI running in the mean time.