### PR TITLE
Add support for bare file paths in index URL

### DIFF
--- a/ros_buildfarm/config/__init__.py
+++ b/ros_buildfarm/config/__init__.py
@@ -35,6 +35,9 @@ logger = logging.getLogger(__name__)
 
 
 def load_yaml(url):
+    # Resolve relative file paths from CWD
+    url = urljoin('file://' + os.getcwd() + '/', url)
+
     class SafeLoaderWithInclude(yaml.SafeLoader):
 
         def include(self, node):

--- a/ros_buildfarm/config/index.py
+++ b/ros_buildfarm/config/index.py
@@ -126,6 +126,6 @@ class Index(object):
 
 def _resolve_url(base_url, value):
     parts = urlparse(value)
-    if not parts[0]:  # schema
+    if base_url and not parts[0]:  # schema
         value = base_url + '/' + value
     return value


### PR DESCRIPTION
This change enhances the URL resolution to support specifying bare file paths for the index URL. Previously, absolute file paths could be converted to URL syntax ('file:///foo/bar'), but with this change, any specified URL which lacks a schema will be treated as a file path. A relative file path is also supported, and is resolved from the current working directory (as expected).

This change leverages these traits of 'urljoin':
* If the url lacks a schema and is relative, the two urls are combined
* If the url lacks a schema and is absolute, the base_url schema is combined with the original url
* If the url has a schema, the url is not changed

A great example where this behavior is desirable (and expected) is when using the `validate_config_index.py` script to inspect a local `ros_buildfarm_config` index, where you currently must use a `file:///...` absolute URL ([like this](https://github.com/ros2/ros_buildfarm_config/blob/76594141959dd88976c60c6d9429e28236bcf98f/.github/workflows/ci.yaml#L22)).