### PR TITLE
Add 'list_priorities.py' helper script

### DIFF
--- a/ros_buildfarm/config/__init__.py
+++ b/ros_buildfarm/config/__init__.py
@@ -67,40 +67,45 @@ def get_distribution_file(index, rosdistro_name, build_file):
 def get_ci_build_files(index, dist_name):
     data = _get_build_file_data(index, dist_name, 'ci_builds')
     build_files = {}
-    for k, v in data.items():
+    for (k, url), v in data.items():
         build_files[k] = CIBuildFile(k, v)
+        build_files[k].url = url
     return build_files
 
 
 def get_release_build_files(index, dist_name):
     data = _get_build_file_data(index, dist_name, 'release_builds')
     build_files = {}
-    for k, v in data.items():
+    for (k, url), v in data.items():
         build_files[k] = ReleaseBuildFile(k, v)
+        build_files[k].url = url
     return build_files
 
 
 def get_source_build_files(index, dist_name):
     data = _get_build_file_data(index, dist_name, 'source_builds')
     build_files = {}
-    for k, v in data.items():
+    for (k, url), v in data.items():
         build_files[k] = SourceBuildFile(k, v)
+        build_files[k].url = url
     return build_files
 
 
 def get_doc_build_files(index, dist_name):
     data = _get_build_file_data(index, dist_name, 'doc_builds')
     build_files = {}
-    for k, v in data.items():
+    for (k, url), v in data.items():
         build_files[k] = DocBuildFile(k, v)
+        build_files[k].url = url
     return build_files
 
 
 def get_global_doc_build_files(index):
     data = _load_build_file_data(index.doc_builds)
     build_files = {}
-    for k, v in data.items():
+    for (k, url), v in data.items():
         build_files[k] = DocBuildFile(k, v)
+        build_files[k].url = url
     return build_files
 
 
@@ -124,5 +129,5 @@ def _load_build_file_data(entries):
 
     data = {}
     for k, v in entries.items():
-        data[k] = _load_yaml_data(v)
+        data[(k, v)] = _load_yaml_data(v)
     return data

--- a/ros_buildfarm/scripts/misc/list_priorities.py
+++ b/ros_buildfarm/scripts/misc/list_priorities.py
@@ -1,0 +1,62 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+
+from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.config import (
+    get_ci_build_files,
+    get_doc_build_files,
+    get_global_doc_build_files,
+    get_index,
+    get_release_build_files,
+    get_source_build_files,
+)
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Print Jenkins job priority for all configured jobs")
+    add_argument_config_url(parser)
+    args = parser.parse_args(argv)
+
+    index = get_index(args.config_url)
+
+    priorities = {}
+    for dist_name in index.distributions.keys():
+        _process_priorities(priorities, get_ci_build_files(index, dist_name))
+        _process_priorities(priorities, get_doc_build_files(index, dist_name))
+        _process_priorities(priorities, get_release_build_files(index, dist_name))
+        _process_priorities(priorities, get_source_build_files(index, dist_name))
+
+    _process_priorities(priorities, get_global_doc_build_files(index))
+
+    for priority, jobs in sorted(priorities.items()):
+        print(priority)
+        for key, name in sorted(jobs):
+            print('  %s::%s' % (key, name))
+
+
+def _process_priorities(priorities, configs):
+    for config in configs.values():
+        for k, v in config.__dict__.items():
+            if k.endswith('_priority'):
+                priority = getattr(config, k)
+                priorities.setdefault(priority, set())
+                priorities[priority].add((k, config.url))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/misc/list_priorities.py
+++ b/scripts/misc/list_priorities.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from runpy import run_module
+
+
+if __name__ == '__main__':
+    run_module('ros_buildfarm.scripts.misc.list_priorities', run_name='__main__')


### PR DESCRIPTION
This is a port of the 'list_priorities.py' helper script which has been [living in the ros_buildfarm_config repository](https://github.com/ros2/ros_buildfarm_config/blob/76594141959dd88976c60c6d9429e28236bcf98f/list_priorities.py) for some time now.

When combined with #974, this is the difference between the output of this script and the original `list_priorities.py`:
```diff
@@ -96,7 +96,6 @@
 77
   jenkins_source_job_priority::foxy/release-build.yaml
   jenkins_source_job_priority::foxy/release-focal-arm64-build.yaml
-  jenkins_source_job_priority::foxy/release-focal-armhf-build.yaml
 80
   jenkins_binary_job_priority::rolling/release-build.yaml
   jenkins_binary_job_priority::rolling/release-rhel-build.yaml
@@ -115,5 +114,3 @@
 89
   jenkins_job_priority::humble/doc-build.yaml
   jenkins_job_priority::rolling/doc-build.yaml
-97
-  jenkins_binary_job_priority::foxy/release-focal-armhf-build.yaml
```

The changes stem from the fact that `foxy/release-focal-armhf-build.yaml` still exists but is commented out in the index.yaml. Other than that, this script should perfectly reproduce the desired behavior of `list_priorities.py'.