### PR TITLE
Disable Pulp operations in Jenkins RPM jobs

### DIFF
--- a/ros_buildfarm/templates/release/rpm/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_job.xml.em
@@ -158,46 +158,6 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
-        'echo "# BEGIN SECTION: Upload binaryrpm to Pulp"',
-        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
-        "ls binarypkg/*.rpm | grep -v -e 'src\.rpm$' -e '-debug\(info\|source\)-' > binarypkg/upload_list.txt && " +
-        'xargs -a binarypkg/upload_list.txt' +
-        ' python3 -u $WORKSPACE/ros_buildfarm/scripts/release/rpm/upload_package.py' +
-        ' --pulp-resource-record binarypkg/upload_record.txt',
-        'echo "# END SECTION"',
-        'echo "# BEGIN SECTION: Upload debug symbols"',
-        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
-        "ls binarypkg/*.rpm | grep -e '-debug\(info\|source\)-' > binarypkg/upload_list_debug.txt && " +
-        'xargs -a binarypkg/upload_list_debug.txt' +
-        ' python3 -u $WORKSPACE/ros_buildfarm/scripts/release/rpm/upload_package.py' +
-        ' --pulp-resource-record binarypkg/upload_record_debug.txt',
-        'echo "# END SECTION"',
-    ]),
-))@
-@(SNIPPET(
-    'builder_parameterized-trigger',
-    project=import_package_job_name,
-    parameters='\n'.join([
-        'DISTRIBUTION_NAME=ros-building-%s-%s-%s' % (
-            os_name, os_code_name, arch),
-        'INVALIDATE_DOWNSTREAM=true']),
-    parameter_files=['binarypkg/upload_record.txt'],
-    continue_on_failure=False,
-))@
-@(SNIPPET(
-    'builder_parameterized-trigger',
-    project=import_package_job_name,
-    parameters='\n'.join([
-        'DISTRIBUTION_NAME=ros-building-%s-%s-%s-debug' % (
-            os_name, os_code_name, arch),
-        'INVALIDATE_DOWNSTREAM=false']),
-    parameter_files=['binarypkg/upload_record_debug.txt'],
-    continue_on_failure=False,
-    missing_parameter_files_skip=True,
-))@
-@(SNIPPET(
-    'builder_shell',
-    script='\n'.join([
         'if [ "$skip_cleanup" = "false" ]; then',
         'echo "# BEGIN SECTION: Clean up to save disk space on agents"',
         'rm -f binarypkg/*.rpm binarypkg/source/*.rpm',
@@ -230,11 +190,6 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 ))@
   </publishers>
   <buildWrappers>
-@(SNIPPET(
-    'pulp_credentials',
-    credential_id=credential_id_pulp,
-    dest_credential_id=dest_credential_id,
-))@
 @[if timeout_minutes is not None]@
 @(SNIPPET(
     'build-wrapper_build-timeout',

--- a/ros_buildfarm/templates/release/rpm/import_upstream_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/import_upstream_job.xml.em
@@ -27,24 +27,6 @@
             'description': 'A specific text file or files containing RPM base URLs to import from. The default is the ros_bootstrap repository.',
             'default_value': '/home/jenkins-agent/ros_bootstrap_rpm_urls.txt',
         },
-        {
-            'type': 'string',
-            'name': 'REMOTE_SOURCE_EXPRESSION',
-            'description': 'Expression to match pulp remote repositories',
-            'default_value': '^ros-upstream-[^-]+-([^-]+-[^-]+-[^-]+(-debug)?)$',
-        },
-        {
-            'type': 'string',
-            'name': 'DISTRIBUTION_DEST_EXPRESSION',
-            'description': 'Expression to transform source remote to destination pulp distribution',
-            'default_value': '^ros-(building|testing|main)-\\1$',
-        },
-        {
-            'type': 'boolean',
-            'name': 'EXECUTE_IMPORT',
-            'description': 'If this is not true, it will only do a dry run and print the expect import, but not execute.',
-            'default_value': 'false',
-        },
     ],
 ))@
 @(SNIPPET(
@@ -86,26 +68,6 @@
         'echo "# END SECTION"',
     ]),
 ))@
-@(SNIPPET(
-    'builder_shell',
-    script='\n'.join([
-        'echo "# BEGIN SECTION: mirror repositories to pulp"',
-        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
-        'python3 -u $WORKSPACE/ros_buildfarm/scripts/release/rpm/mirror_repo.py' +
-        ' --remote-source-expression $REMOTE_SOURCE_EXPRESSION' +
-        ' --distribution-dest-expression "^\\g<0>$"',
-        'echo "# END SECTION"',
-        '',
-        'echo "# BEGIN SECTION: sync packages from mirrors to repos"',
-        'if [ "$EXECUTE_IMPORT" != "true" ]; then DRY_RUN_ARG="--dry-run"; fi',
-        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
-        'python3 -u $WORKSPACE/ros_buildfarm/scripts/release/rpm/sync_repo.py' +
-        ' --distribution-source-expression $REMOTE_SOURCE_EXPRESSION' +
-        ' --distribution-dest-expression $DISTRIBUTION_DEST_EXPRESSION' +
-        ' $DRY_RUN_ARG',
-        'echo "# END SECTION"',
-    ]),
-))@
   </builders>
   <publishers>
 @(SNIPPET(
@@ -116,11 +78,6 @@
 ))@
   </publishers>
   <buildWrappers>
-@(SNIPPET(
-    'pulp_credentials',
-    credential_id=credential_id_pulp,
-    dest_credential_id=dest_credential_id,
-))@
 @(SNIPPET(
     'build-wrapper_timestamper',
 ))@

--- a/ros_buildfarm/templates/release/rpm/sourcepkg_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sourcepkg_job.xml.em
@@ -137,27 +137,6 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
-        'echo "# BEGIN SECTION: Upload sourcerpm to Pulp"',
-        'export TZ="%s"' % timezone,
-        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
-        'python3 -u $WORKSPACE/ros_buildfarm/scripts/release/rpm/upload_package.py' +
-        ' --pulp-resource-record sourcepkg/upload_record.txt' +
-        ' sourcepkg/*.src.rpm',
-        'echo "# END SECTION"',
-    ]),
-))@
-@(SNIPPET(
-    'builder_parameterized-trigger',
-    project=import_package_job_name,
-    parameters='\n'.join([
-        'DISTRIBUTION_NAME=ros-building-%s-%s-SRPMS' % (
-            os_name, os_code_name)]),
-    parameter_files=['sourcepkg/upload_record.txt'],
-    continue_on_failure=True,
-))@
-@(SNIPPET(
-    'builder_shell',
-    script='\n'.join([
         'if [ "$skip_cleanup" = "false" ]; then',
         'echo "# BEGIN SECTION: Clean up to save disk space on agents"',
         'rm -fr sourcepkg',
@@ -193,11 +172,6 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 ))@
   </publishers>
   <buildWrappers>
-@(SNIPPET(
-    'pulp_credentials',
-    credential_id=credential_id_pulp,
-    dest_credential_id=dest_credential_id,
-))@
 @[if timeout_minutes is not None]@
 @(SNIPPET(
     'build-wrapper_build-timeout',

--- a/ros_buildfarm/templates/release/rpm/sync_packages_to_main_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sync_packages_to_main_job.xml.em
@@ -54,36 +54,6 @@
         'echo "# END SECTION"',
     ]),
 ))@
-@(SNIPPET(
-    'builder_shell',
-    script='\n'.join([
-        'echo "# BEGIN SECTION: sync packages to main repos in Pulp"',
-        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
-        'python3 -u $WORKSPACE/ros_buildfarm/scripts/release/rpm/sync_repo.py' +
-        ' --distribution-source-expression "^ros-testing-([^-]*-[^-]*-[^-]*(-debug)?)$"' +
-        ' --distribution-dest-expression "^ros-main-\\1$"' +
-        ' --package-name-expression "^ros-%s-.*"' % rosdistro_name +
-        ' --invalidate-expression "^ros-%s-.*"' % rosdistro_name,
-        'echo "# END SECTION"',
-    ]),
-))@
-@(SNIPPET(
-    'builder_shell',
-    script='\n'.join([
-        'echo "# BEGIN SECTION: mirror main Pulp repository content to disk"',
-    ] + [
-        'rsync --recursive --times --delete --itemize-changes rsync://127.0.0.1:1234/ros-main-%s-%s-SRPMS/ /var/repos/%s_pulp/main/%s/SRPMS/' % (os_name, os_code_name, os_name, os_code_name)
-        for os_name, os_versions in sync_targets.items() for os_code_name in os_versions
-    ] + [
-        'rsync --recursive --times --delete --exclude=debug --itemize-changes rsync://127.0.0.1:1234/ros-main-%s-%s-%s/ /var/repos/%s_pulp/main/%s/%s/' % (os_name, os_code_name, arch, os_name, os_code_name, arch)
-        for os_name, os_versions in sync_targets.items() for os_code_name, arches in os_versions.items() for arch in arches
-    ] + [
-        'rsync --recursive --times --delete --itemize-changes rsync://127.0.0.1:1234/ros-main-%s-%s-%s-debug/ /var/repos/%s_pulp/main/%s/%s/debug/' % (os_name, os_code_name, arch, os_name, os_code_name, arch)
-        for os_name, os_versions in sync_targets.items() for os_code_name, arches in os_versions.items() for arch in arches
-    ] + [
-        'echo "# END SECTION"',
-    ]),
-))@
   </builders>
   <publishers>
 @(SNIPPET(
@@ -94,11 +64,6 @@
 ))@
   </publishers>
   <buildWrappers>
-@(SNIPPET(
-    'pulp_credentials',
-    credential_id=credential_id_pulp,
-    dest_credential_id=dest_credential_id,
-))@
 @(SNIPPET(
     'build-wrapper_timestamper',
 ))@

--- a/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
@@ -99,29 +99,6 @@
         'echo "# END SECTION"',
     ]),
 ))@
-@(SNIPPET(
-    'builder_shell',
-    script='\n'.join([
-        'echo "# BEGIN SECTION: sync packages to testing repos"',
-        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
-        'python3 -u $WORKSPACE/ros_buildfarm/scripts/release/rpm/sync_repo.py' +
-        ' --distribution-source-expression "^ros-building-%s-%s-(SRPMS|%s(-debug)?)$"' % (os_name, os_code_name, arch) +
-        ' --distribution-dest-expression "^ros-testing-%s-%s-\\1$"' % (os_name, os_code_name) +
-        ' --package-name-expression "^ros-%s-.*"' % rosdistro_name +
-        ' --invalidate-expression "^ros-%s-.*"' % rosdistro_name,
-        'echo "# END SECTION"',
-    ]),
-))@
-@(SNIPPET(
-    'builder_shell',
-    script='\n'.join([
-        'echo "# BEGIN SECTION: mirror testing repository content to disk"',
-        'rsync --recursive --times --delete --itemize-changes rsync://127.0.0.1:1234/ros-testing-%s-%s-SRPMS/ /var/repos/%s_pulp/testing/%s/SRPMS/' % (os_name, os_code_name, os_name, os_code_name),
-        'rsync --recursive --times --delete --exclude=debug --itemize-changes rsync://127.0.0.1:1234/ros-testing-%s-%s-%s/ /var/repos/%s_pulp/testing/%s/%s/' % (os_name, os_code_name, arch, os_name, os_code_name, arch),
-        'rsync --recursive --times --delete --itemize-changes rsync://127.0.0.1:1234/ros-testing-%s-%s-%s-debug/ /var/repos/%s_pulp/testing/%s/%s/debug/' % (os_name, os_code_name, arch, os_name, os_code_name, arch),
-        'echo "# END SECTION"',
-    ]),
-))@
   </builders>
   <publishers>
 @(SNIPPET(
@@ -132,11 +109,6 @@
 ))@
   </publishers>
   <buildWrappers>
-@(SNIPPET(
-    'pulp_credentials',
-    credential_id=credential_id_pulp,
-    dest_credential_id=dest_credential_id,
-))@
 @(SNIPPET(
     'build-wrapper_timestamper',
 ))@


### PR DESCRIPTION
This change leaves much of the Pulp infrastructure code present, but removes Pulp completely from the job execution workflows.

Part of #972