### PR TITLE
Add support for group dependencies in release jobs

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -247,6 +247,10 @@ The following options are valid in version ``2`` (beside the generic options):
 * ``package_dependecy_behavior``: a dictionary with the following optional
   keys:
 
+  * ``include_group_dependencies``: a boolean flag indicating whether group
+    dependencies should be included in the package dependencies for each
+    binary job (default: ``false``).
+
   * ``include_test_dependencies``: a boolean flag indicating whether test and
     exec dependencies should be included in the package dependencies for each
     binary job (default: ``true``).

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -623,7 +623,10 @@ def get_xunit_publisher_types_and_patterns(
     return types
 
 
-def get_direct_dependencies(pkg_name, cached_pkgs, pkg_names, include_test_deps=True):
+def get_direct_dependencies(
+    pkg_name, cached_pkgs, pkg_names, include_test_deps=True,
+    include_group_deps=False,
+):
     if pkg_name not in cached_pkgs:
         return None
     pkg = cached_pkgs[pkg_name]
@@ -638,6 +641,10 @@ def get_direct_dependencies(pkg_name, cached_pkgs, pkg_names, include_test_deps=
         d.name for d in pkg_deps
         if d.name in pkg_names and
         d.evaluated_condition is not False])
+    if include_group_deps:
+        depends.update(
+            m for group_dep in pkg.group_depends for m in group_dep.members if
+            group_dep.evaluated_condition is not False)
     return depends
 
 

--- a/ros_buildfarm/config/release_build_file.py
+++ b/ros_buildfarm/config/release_build_file.py
@@ -121,10 +121,14 @@ class ReleaseBuildFile(BuildFile):
         if 'upload_host' in data:
             self.upload_host = data['upload_host']
 
+        self.include_group_dependencies = False
         self.include_test_dependencies = True
         self.run_package_tests = True
         if data.get('package_dependency_behavior'):
             assert isinstance(data['package_dependency_behavior'], dict)
+            if 'include_group_dependencies' in data['package_dependency_behavior']:
+                self.include_group_dependencies = \
+                    bool(data['package_dependency_behavior']['include_group_dependencies'])
             if 'include_test_dependencies' in data['package_dependency_behavior']:
                 self.include_test_dependencies = \
                     bool(data['package_dependency_behavior']['include_test_dependencies'])

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -87,7 +87,8 @@ def configure_release_jobs(
     pkg_names = dist_file.release_packages.keys()
     cached_pkgs = _get_and_parse_distribution_cache(
         index, rosdistro_name, pkg_names,
-        include_test_deps=build_file.include_test_dependencies)
+        include_test_deps=build_file.include_test_dependencies,
+        include_group_deps=build_file.include_group_dependencies)
     filtered_pkg_names = build_file.filter_packages(pkg_names)
     explicitly_ignored_without_recursion_pkg_names = \
         set(pkg_names) & set(build_file.package_ignore_list)
@@ -340,7 +341,9 @@ def configure_release_jobs(
             view_configs=all_view_configs)
 
 
-def _get_and_parse_distribution_cache(index, rosdistro_name, pkg_names, include_test_deps):
+def _get_and_parse_distribution_cache(
+    index, rosdistro_name, pkg_names, include_test_deps, include_group_deps
+):
     from catkin_pkg.package import parse_package_string
     from catkin_pkg.package import Dependency
     dist_cache = get_distribution_cache(index, rosdistro_name)
@@ -368,7 +371,8 @@ def _get_and_parse_distribution_cache(index, rosdistro_name, pkg_names, include_
         no_ros_workspace_dep = set(['ros_workspace']).union(
             get_direct_dependencies(
                 'ros_workspace', cached_pkgs, pkg_names,
-                include_test_deps=include_test_deps))
+                include_test_deps=include_test_deps,
+                include_group_deps=include_group_deps))
 
         for pkg_name, pkg in cached_pkgs.items():
             if pkg_name not in no_ros_workspace_dep:
@@ -449,7 +453,8 @@ def configure_release_job(
              build_file.abi_incompatibility_assumed):
         cached_pkgs = _get_and_parse_distribution_cache(
             index, rosdistro_name, [pkg_name],
-            include_test_deps=build_file.include_test_dependencies)
+            include_test_deps=build_file.include_test_dependencies,
+            include_group_deps=build_file.include_group_dependencies)
     if jenkins is None:
         from ros_buildfarm.jenkins import connect
         jenkins = connect(config.jenkins_url)
@@ -518,7 +523,9 @@ def configure_release_job(
     dependency_names = []
     if build_file.abi_incompatibility_assumed:
         dependency_names = get_direct_dependencies(
-            pkg_name, cached_pkgs, pkg_names)
+            pkg_name, cached_pkgs, pkg_names,
+            include_test_deps=build_file.include_test_dependencies,
+            include_group_deps=build_file.include_group_dependencies)
         # if dependencies are not yet available in rosdistro cache
         # skip binary jobs
         if dependency_names is None:


### PR DESCRIPTION
Neither the debs nor the RPMs currently generated by Bloom support this, but implementing the concept here is straightforward and it will make it easier to prototype solutions if it can be enabled via the build config.

This change should maintain the current behavior on the buildfarm, which ignores group dependencies in release jobs (except for topological ordering).