### PR TITLE
Increase the default timeout for Jenkins connections

### DIFF
--- a/ros_buildfarm/jenkins.py
+++ b/ros_buildfarm/jenkins.py
@@ -39,6 +39,7 @@ class JenkinsProxy(Jenkins):
         requester_kwargs = copy.copy(kwargs)
         requester_kwargs['baseurl'] = args[0]
         kwargs['requester'] = CrumbRequester(**requester_kwargs)
+        kwargs.setdefault('timeout', 120)
         super(JenkinsProxy, self).__init__(*args, **kwargs)
         self.__jobs = None
 


### PR DESCRIPTION
I've had this change sitting in my stage for years. With how stressed the Jenkins host is for build.ros2.org and build.ros.org, I find that it's always necessary to bump the timeout or the connection will continually fail, exiting the process.