### PR TITLE
Stop considering disabled packages to be regressions

### DIFF
--- a/ros_buildfarm/status_page.py
+++ b/ros_buildfarm/status_page.py
@@ -366,6 +366,8 @@ def get_regressions(
         debian_pkg_name = package_descriptor.debian_pkg_name
 
         regressions[pkg_name] = {}
+        if not package_descriptor.version:
+            continue
         for target in targets:
             regressions[pkg_name][target] = False
             main_version = \


### PR DESCRIPTION
The status pages consider obsolete packages being removed from repositories to be regressions because the main repository has the package but the building repository doesn't.

The term doesn't cleanly apply to disabled packages, so just ignore them.