### PR TITLE
Call dpkg-buildpackage directly instead of apt-src

### DIFF
--- a/ros_buildfarm/binarydeb_job.py
+++ b/ros_buildfarm/binarydeb_job.py
@@ -141,7 +141,9 @@ def build_binarydeb(rosdistro_name, package_name, sourcepkg_dir, skip_tests=Fals
     cmd = ['apt-src', 'import', source, '--here', '--version', version]
     subprocess.check_call(cmd, cwd=source_dir, env=env)
 
-    cmd = ['apt-src', 'build', source]
+    cmd = ['dpkg-buildpackage', '-b', '-us', '-uc']
+    if skip_tests:
+        cmd += ['-Pnocheck']
     print("Invoking '%s' in '%s'" % (' '.join(cmd), source_dir))
     try:
         subprocess.check_call(cmd, cwd=source_dir, env=env)


### PR DESCRIPTION
The apt-src build wrapper around dpkg-buildpackage doesn't expose the necessary configurations to specify build profiles, meaning that we can't disable the tests using nocheck.

I was pretty sure that this scenario was working correctly, but clearly I was mistaken or something has changed since it was implemented.