### PR TITLE
Run rosdep init and update in build_and_test devel tasks

### DIFF
--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -109,6 +109,8 @@ RUN pip3 install -U auto_abi_checker
 # TODO(nuclearsandwich) add link to Debian bug report when one is opened.
 RUN which update-ccache-symlinks >/dev/null 2>&1 && update-ccache-symlinks
 
+RUN rosdep init
+
 USER buildfarm
 ENTRYPOINT ["sh", "-c"]
 @{
@@ -124,6 +126,7 @@ if not testing:
     if run_abichecker:
         cmd += ' --run-abichecker'
 else:
+    cmd = 'rosdep update && ' + cmd
     cmd += \
         ' /tmp/ros_buildfarm/scripts/devel/build_and_test.py' + \
         ' --rosdistro-name %s' % rosdistro_name + \


### PR DESCRIPTION
Init and update rosdep database before running tests in devel tasks.

Having an environment with non-initialized rosdep database is (IMO) invalid, as the commands to init and update rosdep are present in every tutorial to installing ROS, even if no packages are intended to be built on the host system.

Fixes a part of #923 (and e.g. running catkin_lint directly from a CMake test target as reported in https://github.com/fkie/catkin_lint/issues/108).