### PR TITLE
Enable CRB in RHEL containers

### DIFF
--- a/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
@@ -18,6 +18,12 @@ FROM @(os_name):@(os_code_name)
 @[end if]@
 
 RUN @(package_manager) update -y
+
+@[if os_name in ['rhel']]@
+# Enable CRB on RHEL
+RUN crb enable
+@[end if]@
+
 RUN @(package_manager) install -y dnf{,-command\(download\)} mock{,-{core-configs,scm}} python@(python3_pkgversion){,-{catkin_pkg,empy,rosdistro,yaml}}
 
 RUN useradd -u @(uid) -l -m buildfarm

--- a/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
@@ -18,6 +18,12 @@ FROM @(os_name):@(os_code_name)
 @[end if]@
 
 RUN @(package_manager) update -y
+
+@[if os_name in ['rhel']]@
+# Enable CRB on RHEL
+RUN crb enable
+@[end if]@
+
 RUN @(package_manager) install -y dnf{,-command\(download\)} mock{,-{core-configs,scm}} python@(python3_pkgversion){,-{catkin_pkg,empy,rosdistro,yaml}}
 
 RUN useradd -u @(uid) -l -m buildfarm


### PR DESCRIPTION
It seems that in RHEL 8 we were getting lucky that the CRB (powertools) repository wasn't needed to install the needed packages from EPEL, but that's not true on RHEL 9.

The `crb` command only appears to be supported in EPEL 8 and newer.