### PR TITLE
Don't use setuptools >= 66 in CI

### DIFF
--- a/.github/actions/setup/setuptools.txt
+++ b/.github/actions/setup/setuptools.txt
@@ -1,2 +1,2 @@
 setuptools == 43.0.0 ; python_version < '3.5'
-setuptools ; python_version >= '3.5'
+setuptools < 66 ; python_version >= '3.5'


### PR DESCRIPTION
We aren't ready for the breaking changes this version of setuptools introduces, so let's pin it to unblock CI.