### PR TITLE
Restore exec dependencies during non-test system packaging

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -631,9 +631,10 @@ def get_direct_dependencies(
         return None
     pkg = cached_pkgs[pkg_name]
     pkg_deps = (pkg.buildtool_depends + pkg.build_depends +
-                pkg.buildtool_export_depends + pkg.build_export_depends)
+                pkg.buildtool_export_depends + pkg.build_export_depends +
+                pkg.exec_depends)
     if include_test_deps:
-        pkg_deps += pkg.exec_depends + pkg.test_depends
+        pkg_deps += pkg.test_depends
     # test dependencies are treated similar to build dependencies by bloom
     # so if configured to include test dependencies, we need them here to
     # ensure that all dependencies are available before starting a build


### PR DESCRIPTION
The exec dependencies were dropped in a previous change to control the inclusion of test dependencies. The exec dependencies must be present to run tests, but because they aren't necessarily needed to build, they were dropped when the tests aren't going to run. However, the buildfarm's invalidation logic will remove downstream package which declare an exec_depend on a package, so the relationship must be maintained even though the invalidation isn't actually necessary.

Follow-up to #903