### PR TITLE
Add display of cpu info

### DIFF
--- a/ros_buildfarm/templates/snippet/builder_shell_docker-info.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_shell_docker-info.xml.em
@@ -1,6 +1,9 @@
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
+        'echo "# BEGIN SECTION: cpu info"',
+        'lscpu',
+        'echo "# END SECTION"',
         'echo "# BEGIN SECTION: docker version"',
         'docker version',
         'echo "# END SECTION"',


### PR DESCRIPTION
I had originally catted /proc/cpuinfo but it was very verbose


lscpu is in [util-linux](https://packages.ubuntu.com/focal/util-linux) which is in [essential] so should be available on systems.