### PR TITLE
Remove python 2.7, melodic, and foxy, due to being unsupported anymore

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,8 +38,8 @@ jobs:
       - name: Run job
         uses: ./.github/actions/audit
         with:
-          ros_distro: melodic
-          os_code_name: bionic
+          ros_distro: noetic
+          os_code_name: focal
 
   ros1_config:
     name: ROS 1 Config Validation
@@ -74,8 +74,8 @@ jobs:
       - name: Run job
         uses: ./.github/actions/devel
         with:
-          ros_distro: melodic
-          os_code_name: bionic
+          ros_distro: noetic
+          os_code_name: focal
           build_tool: ${{matrix.build_tool}}
           repo: roscpp_core
 
@@ -97,8 +97,8 @@ jobs:
       - name: Run job
         uses: ./.github/actions/doc
         with:
-          ros_distro: melodic
-          os_code_name: bionic
+          ros_distro: noetic
+          os_code_name: focal
           repo: roscpp_core
 
   ros1_prerelease:
@@ -119,8 +119,8 @@ jobs:
       - name: Run job
         uses: ./.github/actions/prerelease
         with:
-          ros_distro: melodic
-          os_code_name: bionic
+          ros_distro: noetic
+          os_code_name: focal
           overlay_pkg: roscpp
           underlay_repos: roscpp_core
 
@@ -148,8 +148,8 @@ jobs:
       - name: Run job
         uses: ./.github/actions/prerelease
         with:
-          ros_distro: melodic
-          os_code_name: bionic
+          ros_distro: noetic
+          os_code_name: focal
           source_dir: ${{github.workspace}}/dummy_package
 
   ros1_release:
@@ -170,8 +170,8 @@ jobs:
       - name: Run job
         uses: ./.github/actions/release
         with:
-          ros_distro: melodic
-          os_code_name: bionic
+          ros_distro: noetic
+          os_code_name: focal
           pkg_name: rostime
 
   ros1_release_reconfigure:
@@ -192,7 +192,7 @@ jobs:
       - name: Run job
         uses: ./.github/actions/release_reconfigure
         with:
-          ros_distro: melodic
+          ros_distro: noetic
           pkg_names: rostime
 
   ros1_status_pages:
@@ -213,7 +213,7 @@ jobs:
       - name: Run job
         uses: ./.github/actions/status_pages
         with:
-          ros_distro: melodic
+          ros_distro: noetic
 
   ros1_sync_criteria_check:
     name: ROS 1 Sync Criteria Check
@@ -229,8 +229,8 @@ jobs:
       - name: Run job
         uses: ./.github/actions/sync_criteria_check
         with:
-          ros_distro: melodic
-          os_code_name: bionic
+          ros_distro: noetic
+          os_code_name: focal
 
   ros1_trigger:
     name: ROS 1 Trigger
@@ -246,7 +246,7 @@ jobs:
       - name: Run job
         uses: ./.github/actions/trigger
         with:
-          ros_distro: melodic
+          ros_distro: noetic
 
   ros2_audit:
     name: ROS 2 Audit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.6']
+        python: ['3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.5', '3.6']
+        python: ['3.5', '3.6']
         build_tool: [null]
         include:
           - python: '3.6'
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.5', '3.6']
+        python: ['3.5', '3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.5', '3.6']
+        python: ['3.5', '3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -129,7 +129,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.5', '3.6']
+        python: ['3.5', '3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.5', '3.6']
+        python: ['3.5', '3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.5', '3.6']
+        python: ['3.5', '3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -200,7 +200,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.5', '3.6']
+        python: ['3.5', '3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -220,7 +220,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.5', '3.6']
+        python: ['3.5', '3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -237,7 +237,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.5', '3.6']
+        python: ['3.5', '3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -260,8 +260,8 @@ jobs:
         uses: ./.github/actions/audit
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
-          ros_distro: foxy
-          os_code_name: focal
+          ros_distro: humble
+          os_code_name: jammy
 
   ros2_ci:
     name: ROS 2 CI
@@ -276,24 +276,24 @@ jobs:
         uses: ./.github/actions/ci
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
-          ros_distro: foxy
-          os_code_name: focal
+          ros_distro: humble
+          os_code_name: jammy
           package_selection_args: --packages-up-to ament_flake8
       - name: Run job 2
         id: underlay2
         uses: ./.github/actions/ci
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
-          ros_distro: foxy
-          os_code_name: focal
+          ros_distro: humble
+          os_code_name: jammy
           underlay_dirs: ${{steps.underlay1.outputs.install_dir}}
           package_selection_args: --packages-skip-up-to ament_flake8 --packages-up-to ament_pep257
       - name: Run job 3
         uses: ./.github/actions/ci
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
-          ros_distro: foxy
-          os_code_name: focal
+          ros_distro: humble
+          os_code_name: jammy
           underlay_dirs: ${{steps.underlay1.outputs.install_dir}} ${{steps.underlay2.outputs.install_dir}}
           package_selection_args: --packages-skip-up-to ament_flake8 ament_pep257 --packages-up-to ament_cmake_ros
 
@@ -320,8 +320,8 @@ jobs:
         uses: ./.github/actions/devel
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
-          ros_distro: foxy
-          os_code_name: focal
+          ros_distro: humble
+          os_code_name: jammy
           repo: rcutils
 
   ros2_doc:
@@ -353,8 +353,8 @@ jobs:
         uses: ./.github/actions/prerelease
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
-          ros_distro: foxy
-          os_code_name: focal
+          ros_distro: humble
+          os_code_name: jammy
           overlay_pkg: rcutils
           underlay_repos: ament_cmake_ros
 


### PR DESCRIPTION
Python 2.7 has been removed as an option from github actions as a base image causing all of these to fail. As all of our distros are on python 3 default platforms now we don't need to test this anymore.