### PR TITLE
Set a sane HOME for binarypkg jobs

### DIFF
--- a/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
@@ -168,7 +168,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_build_binarydeb/docker.cid' +
-        ' -e=HOME=' +
+        ' -e=HOME=/home/buildfarm' +
         ' -e=TRAVIS=$TRAVIS' +
         ' --net=host' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +


### PR DESCRIPTION
The comment above this invocation indicates that apt needs HOME to be set to something, but the variable is set to an empty string. This is even more critical for running the buildfarm using rootless Podman, because `/` is no longer writable and seems to be the default if HOME is empty.