### PR TITLE
Working to bring CI back to green

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -310,7 +310,7 @@ jobs:
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
           ros_distro: rolling
-          os_code_name: jammy
+          os_code_name: noble
           repo: rcl
           output_directory: ws/docs_output
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -337,7 +337,7 @@ jobs:
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
           ros_distro: rolling
-          os_code_name: noble
+          os_code_name: jammy
           repo: rcl
           output_directory: ws/docs_output
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,8 +38,8 @@ jobs:
       - name: Run job
         uses: ./.github/actions/audit
         with:
-          ros_distro: melodic
-          os_code_name: bionic
+          ros_distro: noetic
+          os_code_name: focal
 
   ros1_config:
     name: ROS 1 Config Validation
@@ -74,8 +74,8 @@ jobs:
       - name: Run job
         uses: ./.github/actions/devel
         with:
-          ros_distro: melodic
-          os_code_name: bionic
+          ros_distro: noetic
+          os_code_name: focal
           build_tool: ${{matrix.build_tool}}
           repo: roscpp_core
 
@@ -97,8 +97,8 @@ jobs:
       - name: Run job
         uses: ./.github/actions/doc
         with:
-          ros_distro: melodic
-          os_code_name: bionic
+          ros_distro: noetic
+          os_code_name: focal
           repo: roscpp_core
 
   ros1_prerelease:
@@ -119,8 +119,8 @@ jobs:
       - name: Run job
         uses: ./.github/actions/prerelease
         with:
-          ros_distro: melodic
-          os_code_name: bionic
+          ros_distro: noetic
+          os_code_name: focal
           overlay_pkg: roscpp
           underlay_repos: roscpp_core
 
@@ -148,8 +148,8 @@ jobs:
       - name: Run job
         uses: ./.github/actions/prerelease
         with:
-          ros_distro: melodic
-          os_code_name: bionic
+          ros_distro: noetic
+          os_code_name: focal
           source_dir: ${{github.workspace}}/dummy_package
 
   ros1_release:
@@ -170,8 +170,8 @@ jobs:
       - name: Run job
         uses: ./.github/actions/release
         with:
-          ros_distro: melodic
-          os_code_name: bionic
+          ros_distro: noetic
+          os_code_name: focal
           pkg_name: rostime
 
   ros1_release_reconfigure:
@@ -192,7 +192,7 @@ jobs:
       - name: Run job
         uses: ./.github/actions/release_reconfigure
         with:
-          ros_distro: melodic
+          ros_distro: noetic
           pkg_names: rostime
 
   ros1_status_pages:
@@ -213,7 +213,7 @@ jobs:
       - name: Run job
         uses: ./.github/actions/status_pages
         with:
-          ros_distro: melodic
+          ros_distro: noetic
 
   ros1_sync_criteria_check:
     name: ROS 1 Sync Criteria Check
@@ -229,8 +229,8 @@ jobs:
       - name: Run job
         uses: ./.github/actions/sync_criteria_check
         with:
-          ros_distro: melodic
-          os_code_name: bionic
+          ros_distro: noetic
+          os_code_name: focal
 
   ros1_trigger:
     name: ROS 1 Trigger
@@ -246,7 +246,7 @@ jobs:
       - name: Run job
         uses: ./.github/actions/trigger
         with:
-          ros_distro: melodic
+          ros_distro: noetic
 
   ros2_audit:
     name: ROS 2 Audit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,33 +52,6 @@ jobs:
       - name: Validate configration
         run: validate_config_index.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml
 
-  ros1_devel:
-    name: ROS 1 Devel
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python: ['3.5', '3.6']
-        build_tool: [null]
-        include:
-          - python: '3.6'
-            build_tool: colcon
-    steps:
-      - name: Check out project
-        uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{matrix.python}}
-      - name: Install dependencies
-        uses: ./.github/actions/setup
-      - name: Run job
-        uses: ./.github/actions/devel
-        with:
-          ros_distro: noetic
-          os_code_name: focal
-          build_tool: ${{matrix.build_tool}}
-          repo: roscpp_core
-
   ros1_doc:
     name: ROS 1 Doc
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -260,7 +260,7 @@ jobs:
         uses: ./.github/actions/audit
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
-          ros_distro: foxy
+          ros_distro: humble
           os_code_name: focal
 
   ros2_ci:
@@ -276,7 +276,7 @@ jobs:
         uses: ./.github/actions/ci
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
-          ros_distro: foxy
+          ros_distro: humble
           os_code_name: focal
           package_selection_args: --packages-up-to ament_flake8
       - name: Run job 2
@@ -284,7 +284,7 @@ jobs:
         uses: ./.github/actions/ci
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
-          ros_distro: foxy
+          ros_distro: humble
           os_code_name: focal
           underlay_dirs: ${{steps.underlay1.outputs.install_dir}}
           package_selection_args: --packages-skip-up-to ament_flake8 --packages-up-to ament_pep257
@@ -292,7 +292,7 @@ jobs:
         uses: ./.github/actions/ci
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
-          ros_distro: foxy
+          ros_distro: humble
           os_code_name: focal
           underlay_dirs: ${{steps.underlay1.outputs.install_dir}} ${{steps.underlay2.outputs.install_dir}}
           package_selection_args: --packages-skip-up-to ament_flake8 ament_pep257 --packages-up-to ament_cmake_ros
@@ -320,7 +320,7 @@ jobs:
         uses: ./.github/actions/devel
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
-          ros_distro: foxy
+          ros_distro: humble
           os_code_name: focal
           repo: rcutils
 
@@ -353,7 +353,7 @@ jobs:
         uses: ./.github/actions/prerelease
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
-          ros_distro: foxy
+          ros_distro: humble
           os_code_name: focal
           overlay_pkg: rcutils
           underlay_repos: ament_cmake_ros

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.6']
+        python: ['3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.5', '3.6']
+        python: ['3.5', '3.6']
         build_tool: [null]
         include:
           - python: '3.6'
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.5', '3.6']
+        python: ['3.5', '3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.5', '3.6']
+        python: ['3.5', '3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -129,7 +129,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.5', '3.6']
+        python: ['3.5', '3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.5', '3.6']
+        python: ['3.5', '3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.5', '3.6']
+        python: ['3.5', '3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -200,7 +200,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.5', '3.6']
+        python: ['3.5', '3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -220,7 +220,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.5', '3.6']
+        python: ['3.5', '3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -237,7 +237,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['2.7', '3.5', '3.6']
+        python: ['3.5', '3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -261,7 +261,7 @@ jobs:
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
           ros_distro: humble
-          os_code_name: focal
+          os_code_name: jammy
 
   ros2_ci:
     name: ROS 2 CI
@@ -277,7 +277,7 @@ jobs:
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
           ros_distro: humble
-          os_code_name: focal
+          os_code_name: jammy
           package_selection_args: --packages-up-to ament_flake8
       - name: Run job 2
         id: underlay2
@@ -285,7 +285,7 @@ jobs:
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
           ros_distro: humble
-          os_code_name: focal
+          os_code_name: jammy
           underlay_dirs: ${{steps.underlay1.outputs.install_dir}}
           package_selection_args: --packages-skip-up-to ament_flake8 --packages-up-to ament_pep257
       - name: Run job 3
@@ -293,7 +293,7 @@ jobs:
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
           ros_distro: humble
-          os_code_name: focal
+          os_code_name: jammy
           underlay_dirs: ${{steps.underlay1.outputs.install_dir}} ${{steps.underlay2.outputs.install_dir}}
           package_selection_args: --packages-skip-up-to ament_flake8 ament_pep257 --packages-up-to ament_cmake_ros
 
@@ -321,7 +321,7 @@ jobs:
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
           ros_distro: humble
-          os_code_name: focal
+          os_code_name: jammy
           repo: rcutils
 
   ros2_doc:
@@ -354,7 +354,7 @@ jobs:
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
           ros_distro: humble
-          os_code_name: focal
+          os_code_name: jammy
           overlay_pkg: rcutils
           underlay_repos: ament_cmake_ros
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -337,7 +337,7 @@ jobs:
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
           ros_distro: rolling
-          os_code_name: jammy
+          os_code_name: noble
           repo: rcl
           output_directory: ws/docs_output
 
@@ -371,7 +371,7 @@ jobs:
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
           ros_distro: rolling
-          os_code_name: jammy
+          os_code_name: noble
           pkg_name: rcutils
 
   ros2_release_reconfigure:
@@ -421,7 +421,7 @@ jobs:
         with:
           config_url: https://raw.githubusercontent.com/ros2/ros_buildfarm_config/ros2/index.yaml
           ros_distro: rolling
-          os_code_name: jammy
+          os_code_name: noble
 
   ros2_sync_criteria_check_rpm:
     name: ROS 2 Sync Criteria Check (RPM)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ kwargs = {
     'include_package_data': True,
     'zip_safe': False,
     'install_requires': [
-        'empy',
+        'empy<4',
         'PyYAML'],
     'extras_require': {
         'test': [


### PR DESCRIPTION
It's failing with several recent changes. This PR is to just try to resolve that and unblock other changes. 

I think python 2.7, empy 4.x and possibly setuptools/pip are updated/need updating. 