### PR TITLE
Setup bazel single compilation thread in release deb/rpm

### DIFF
--- a/ros_buildfarm/templates/release/deb/binarypkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/deb/binarypkg_task.Dockerfile.em
@@ -23,6 +23,11 @@ ENV DEBIAN_FRONTEND noninteractive
     timezone=timezone,
 ))@
 
+@(TEMPLATE(
+    'snippet/setup_bazel_single_thread_builds.Dockerfile.em',
+    bazelrc_dir='/etc',
+))@
+
 RUN useradd -u @uid -l -m buildfarm
 
 @(TEMPLATE(

--- a/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
@@ -26,6 +26,11 @@ RUN crb enable
 
 RUN @(package_manager) install -y dnf{,-command\(download\)} mock{,-{core-configs,scm}} python@(python3_pkgversion){,-{catkin_pkg,empy,rosdistro,yaml}}
 
+@(TEMPLATE(
+    'snippet/setup_bazel_single_thread_builds.Dockerfile.em',
+    bazelrc_dir='/etc',
+))@
+
 RUN useradd -u @(uid) -l -m buildfarm
 RUN usermod -a -G mock buildfarm
 

--- a/ros_buildfarm/templates/snippet/setup_bazel_single_thread_builds.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/setup_bazel_single_thread_builds.Dockerfile.em
@@ -1,0 +1,1 @@
+RUN echo 'build --jobs=1' >> @bazelrc_dir/bazel.bazelrc


### PR DESCRIPTION
For preparing the buildfarm to host Bazel builds, one of the requirements is to have a single compilation thread during the release buildings. The is usually accomplish in deb creation by relying in the default behaviour of dpkg-buildpackage of using a single thread builds when using `make`.

In Bazel, we can [setup the jobs limits]( https://bazel.build/run/bazelrc) by having a user configuration `user.bazelrc` in HOME. The PR adds these files to the deb and rpm release Dockerfiles.

An alternative considered was to use environment variables to setup this preference (ala MAKEJOBS/MAKEFLAGS) but I was able to find any documentation in Bazel that supports this use case.