### PR TITLE
Add os code name mapping for Ubuntu Noble.

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -318,6 +318,7 @@ def get_short_os_code_name(os_code_name):
         'focal': 'F',
         'jammy': 'J',
         'jessie': 'J',
+        'noble': 'N',
         'saucy': 'S',
         'stretch': 'S',
         'trusty': 'T',


### PR DESCRIPTION
Opening this PR to add Ubuntu noble code mapping.