### PR TITLE
Update legacy version as it's not compatible after setuptools 66+

### DIFF
--- a/ros_buildfarm/__init__.py
+++ b/ros_buildfarm/__init__.py
@@ -17,4 +17,4 @@
 # same version as in:
 # - setup.py
 # - stdeb.cfg
-__version__ = '3.0.1-master'
+__version__ = '3.0.1+master'

--- a/ros_buildfarm/git.py
+++ b/ros_buildfarm/git.py
@@ -175,6 +175,8 @@ def get_hash(path):
 
 def _get_version_parts():
     version_parts = __version__.split('-', 1)
+    if len(version_parts) < 2:
+        version_parts = __version__.split('+', 1)
     if len(version_parts) == 2:
         return version_parts
     return version_parts[0], None

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ kwargs = {
     # same version as in:
     # - ros_buildfarm/__init__.py
     # - stdeb.cfg
-    'version': '3.0.1-master',
+    'version': '3.0.1+master',
     'python_requires': '>=3.6',
     'packages': find_packages(exclude=['test']),
     'package_data': {


### PR DESCRIPTION
It seems that legacy versions are not supported after setuptools 66+: https://github.com/pypa/setuptools/issues/2497.

This results in the the following error:
```
setuptools.extern.packaging.version.InvalidVersion: Invalid version: '3.0.1-master'
```

I updated the version so it works, not sure if this is the correct one we want to set so feel free to suggest a different one.