### PR TITLE
Fix `pytest-rerunfailures` installation by using apt instead of pip

### DIFF
--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -69,7 +69,6 @@ RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-pi
 @(TEMPLATE(
     'snippet/install_pytest-rerunfailures.Dockerfile.em',
     os_name=os_name,
-    os_code_name=os_code_name,
 ))@
 RUN pip3 install -U setuptools==59.6.0
 @[end if]@

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -66,7 +66,12 @@ RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-pip
 @# colcon-core.package_identification.python needs at least setuptools 30.3.0
 @# pytest-rerunfailures enables usage of --retest-until-pass
-RUN pip3 install -U setuptools==59.6.0 pytest-rerunfailures
+@(TEMPLATE(
+    'snippet/install_pytest-rerunfailures.Dockerfile.em',
+    os_name=os_name,
+    os_code_name=os_code_name,
+))@
+RUN pip3 install -U setuptools==59.6.0
 @[end if]@
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
 

--- a/ros_buildfarm/templates/snippet/install_pytest-rerunfailures.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/install_pytest-rerunfailures.Dockerfile.em
@@ -1,0 +1,4 @@
+@[if os_name == 'debian' or os_name == 'ubuntu' and os_code_name in ['jammy', 'noble']]@
+@# python3-pytest-rerunfailures is supported since Ubuntu jammy
+RUN for i in 1 2 3; do apt-get update && apt-get install -q -y python3-pytest-rerunfailures && apt-get clean && break || if [ $i -lt 3 ]; then sleep 5; else false; fi; done
+@[end if]@

--- a/ros_buildfarm/templates/snippet/install_pytest-rerunfailures.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/install_pytest-rerunfailures.Dockerfile.em
@@ -1,4 +1,4 @@
-@[if os_name == 'debian' or os_name == 'ubuntu' and os_code_name in ['jammy', 'noble']]@
+@[if os_name == 'debian' or os_name == 'ubuntu']@
 @# python3-pytest-rerunfailures is supported since Ubuntu jammy
 RUN for i in 1 2 3; do apt-get update && apt-get install -q -y python3-pytest-rerunfailures && apt-get clean && break || if [ $i -lt 3 ]; then sleep 5; else false; fi; done
 @[end if]@


### PR DESCRIPTION
See https://github.com/ros2/ci/pull/744

I used the same template as `install_python3.Dockerfile.em` for pytest-rerunfailures package