### PR TITLE
Do not install ccache unless shared_ccache is used in binarydeb

### DIFF
--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -496,6 +496,12 @@ def add_argument_skip_tests(parser):
         help='Skip execution of tests as part of the package build process.')
 
 
+def add_argument_install_ccache(parser):
+    parser.add_argument(
+        '--install-ccache', action='store_true',
+        help='Install the ccache binary packages in the system.')
+
+
 def check_len_action(minargs, maxargs):
     class CheckLength(argparse.Action):
 

--- a/ros_buildfarm/scripts/release/create_binarydeb_task_generator.py
+++ b/ros_buildfarm/scripts/release/create_binarydeb_task_generator.py
@@ -26,6 +26,7 @@ from ros_buildfarm.argument import \
 from ros_buildfarm.argument import add_argument_distribution_repository_urls
 from ros_buildfarm.argument import add_argument_dockerfile_dir
 from ros_buildfarm.argument import add_argument_env_vars
+from ros_buildfarm.argument import add_argument_install_ccache
 from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
 from ros_buildfarm.argument import add_argument_package_name
@@ -56,6 +57,7 @@ def main(argv=sys.argv[1:]):
     add_argument_dockerfile_dir(parser)
     add_argument_env_vars(parser)
     add_argument_skip_tests(parser)
+    add_argument_install_ccache(parser)
     args = parser.parse_args(argv)
 
     debian_package_name = get_os_package_name(
@@ -107,6 +109,7 @@ def main(argv=sys.argv[1:]):
         'dependencies': debian_pkg_names,
         'dependency_versions': debian_pkg_versions,
         'skip_tests': args.skip_tests,
+        'install_ccache': args.install_ccache,
         'install_lists': [],
 
         'rosdistro_name': args.rosdistro_name,

--- a/ros_buildfarm/scripts/release/run_binarydeb_job.py
+++ b/ros_buildfarm/scripts/release/run_binarydeb_job.py
@@ -16,7 +16,7 @@ import argparse
 import copy
 import sys
 
-from ros_buildfarm.argument import add_argument_append_timestamp
+from ros_buildfarm.argument import add_argument_append_timestamp, add_argument_install_ccache
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_binarypkg_dir
 from ros_buildfarm.argument import \
@@ -55,6 +55,7 @@ def main(argv=sys.argv[1:]):
     add_argument_append_timestamp(parser)
     add_argument_env_vars(parser)
     add_argument_skip_tests(parser)
+    add_argument_install_ccache(parser)
     args = parser.parse_args(argv)
 
     data = copy.deepcopy(args.__dict__)
@@ -69,6 +70,7 @@ def main(argv=sys.argv[1:]):
 
         'skip_download_sourcepkg': args.skip_download_sourcepkg,
         'skip_tests': args.skip_tests,
+        'install_ccache': args.install_ccache,
 
         'binarypkg_dir': '/tmp/binarydeb',
         'build_environment_variables': ['%s=%s' % key_value for key_value in args.env_vars.items()],

--- a/ros_buildfarm/templates/release/deb/binarypkg_create_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/deb/binarypkg_create_task.Dockerfile.em
@@ -105,6 +105,7 @@ cmds.append(
     ' --binarypkg-dir ' + binarypkg_dir +
     ' --env-vars ' + ' '.join(build_environment_variables) +
     ' --dockerfile-dir ' + dockerfile_dir +
+    (' --install-ccache ' if install_ccache else '')) +
     (' --skip-tests' if skip_tests else ''))
 }@
 CMD ["@(' && '.join(cmds))"]

--- a/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
@@ -112,6 +112,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' --dockerfile-dir $WORKSPACE/docker_generating_docker' +
         ' --env-vars ' + ' '.join(build_environment_variables) +
         (' --append-timestamp' if append_timestamp else '') +
+        (' --install-ccache' if shared_ccache else '') +
         (' --skip-tests' if skip_tests else ''),
         'echo "# END SECTION"',
         '',

--- a/ros_buildfarm/templates/release/deb/binarypkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/deb/binarypkg_task.Dockerfile.em
@@ -66,11 +66,13 @@ RUN . /etc/os-release && test "$VERSION_ID" = "20.04" && test "$(uname -m)" = "a
     os_code_name=os_code_name,
 ))@
 
+@[if install_ccache]@
 @(TEMPLATE(
     'snippet/install_ccache.Dockerfile.em',
     os_name=os_name,
     os_code_name=os_code_name,
 ))@
+@[endif]
 
 @(TEMPLATE(
     'snippet/set_environment_variables.Dockerfile.em',


### PR DESCRIPTION
Currently the sharing of compilation artifacts through ccache is conditional after #844, which enable the support for sharing with the host using the `shared_ccache` option in the build files. The ccache binaries are currently being installed unconditionally thought.

The PR changes the behavior to install the ccache binaries only when the `shared_ccache` option is being used.