### PR TITLE
Handle virtual deb packages when querying apt cache

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -172,7 +172,11 @@ def get_distribution_repository_keys(urls, key_files):
 def get_binary_package_versions(apt_cache, debian_pkg_names):
     versions = {}
     for debian_pkg_name in debian_pkg_names:
-        pkg = apt_cache[debian_pkg_name]
+        pkg = apt_cache.get(debian_pkg_name)
+        if not pkg:
+            prov = apt_cache.get_providing_packages(debian_pkg_name)
+            assert len(prov) == 1
+            pkg = apt_cache[prov[0]]
         versions[debian_pkg_name] = max(pkg.versions).version
     return versions
 


### PR DESCRIPTION
These virtual packages are supported by the rosdep tool, so should be acceptable for use here as well.