### PR TITLE
Adding break-system-packages pip option for noble in devel_task

### DIFF
--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -63,18 +63,11 @@ RUN echo "@today_str"
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-yaml
 
 @[if build_tool == 'colcon']@
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-pip
-@# colcon-core.package_identification.python needs at least setuptools 30.3.0
 @# pytest-rerunfailures enables usage of --retest-until-pass
 @(TEMPLATE(
     'snippet/install_pytest-rerunfailures.Dockerfile.em',
     os_name=os_name,
 ))@
-@[ if os_code_name == 'noble']@
-RUN pip3 install -U setuptools==59.6.0 --break-system-packages
-@[ else]@
-RUN pip3 install -U setuptools==59.6.0
-@[ end if]@
 @[end if]@
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
 

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -70,7 +70,11 @@ RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-pi
     'snippet/install_pytest-rerunfailures.Dockerfile.em',
     os_name=os_name,
 ))@
+@[ if os_code_name == 'noble']@
+RUN pip3 install -U setuptools==59.6.0 --break-system-packages
+@[ else]@
 RUN pip3 install -U setuptools==59.6.0
+@[ end if]@
 @[end if]@
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
 


### PR DESCRIPTION
Rpr jobs are failing due to the `externally-managed-environment` pip error, i.e.:

https://build.ros2.org/job/Rpr__rosbag2__ubuntu_noble_amd64/4/console

This PR adds a conditional to use `--break-system-packages`  when installing `setuptools` with `pip3`.

Maybe not affecting Rpr jobs but I was wondering if some other templates installing pip packages should also be updated, thoughts?