### PR TITLE
Add distutils package needed by colcon.

### DIFF
--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -60,7 +60,7 @@ RUN echo "@today_str"
     os_code_name=os_code_name,
 ))@
 
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-yaml
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-yaml python3-distutils
 
 @[if build_tool == 'colcon']@
 @# pytest-rerunfailures enables usage of --retest-until-pass

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -60,7 +60,7 @@ RUN echo "@today_str"
     os_code_name=os_code_name,
 ))@
 
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-yaml python3-distutils
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-yaml python3-setuptools
 
 @[if build_tool == 'colcon']@
 @# pytest-rerunfailures enables usage of --retest-until-pass


### PR DESCRIPTION
Dev jobs are failing like: https://build.ros2.org/view/Rdev/job/Rdev__rqt_srv__ubuntu_noble_amd64/2/console with:
```
ERROR:colcon.colcon_core.extension_point:Exception loading extension 'colcon_core.package_identification.python_setup_py': No module named 'distutils'
```

This PR adds `python3-distutils` to the `devel_task.Dockerfile.em` file in an effort to fix the missing dependency.