### PR TITLE
Use --break-system-packages when installing setuptools on noble.

### DIFF
--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -70,7 +70,7 @@ RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-pi
     'snippet/install_pytest-rerunfailures.Dockerfile.em',
     os_name=os_name,
 ))@
-RUN pip3 install -U setuptools==59.6.0
+RUN pip3 install -U setuptools==59.6.0@[if os_code_name == 'noble' ] --break-system-packages @[end if]
 @[end if]@
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
 

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -63,11 +63,14 @@ RUN echo "@today_str"
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-yaml
 
 @[if build_tool == 'colcon']@
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y python3-pip
+@# colcon-core.package_identification.python needs at least setuptools 30.3.0
 @# pytest-rerunfailures enables usage of --retest-until-pass
 @(TEMPLATE(
     'snippet/install_pytest-rerunfailures.Dockerfile.em',
     os_name=os_name,
 ))@
+RUN pip3 install -U setuptools==59.6.0
 @[end if]@
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y ccache
 


### PR DESCRIPTION
Reverts ros-infrastructure/ros_buildfarm#1026 which started out with this approach and then was altered (by me) to remove the pip install entirely. This is an alternative fix to #1027 while we determine what is actually needed to rely fully on apt.