### PR TITLE
Copy rosdoc2 sources into docker image instead of bind-mounting them read-only.

### DIFF
--- a/ros_buildfarm/scripts/doc/build_rosdoc2.py
+++ b/ros_buildfarm/scripts/doc/build_rosdoc2.py
@@ -49,6 +49,7 @@ def main(argv=sys.argv[1:]):
                                   '-m',
                                   'pip',
                                   'install',
+                                  '--break-system-packages',
                                   '.'],
                                  cwd=args.rosdoc2_dir)
         if pip_rc:

--- a/ros_buildfarm/scripts/doc/build_rosdoc2.py
+++ b/ros_buildfarm/scripts/doc/build_rosdoc2.py
@@ -49,8 +49,6 @@ def main(argv=sys.argv[1:]):
                                   '-m',
                                   'pip',
                                   'install',
-                                  '--no-warn-script-location',
-                                  '--use-deprecated=out-of-tree-build',
                                   '.'],
                                  cwd=args.rosdoc2_dir)
         if pip_rc:

--- a/ros_buildfarm/scripts/doc/build_rosdoc2.py
+++ b/ros_buildfarm/scripts/doc/build_rosdoc2.py
@@ -63,7 +63,7 @@ def main(argv=sys.argv[1:]):
             env['PATH'] = ''
         else:
             env['PATH'] += ':'
-        env['PATH'] += '/home/buildfarm/.local/bin'
+        env['PATH'] += os.path.join(env['HOME'], '.local/bin')
 
         source_space = os.path.join(args.workspace_root, 'src')
         print("Crawling for packages in workspace '%s'" % (source_space))

--- a/ros_buildfarm/templates/doc/rosdoc2_job.xml.em
+++ b/ros_buildfarm/templates/doc/rosdoc2_job.xml.em
@@ -167,6 +167,8 @@ else:
         'sleep 1',
         '',
         'echo "# BEGIN SECTION: Build Dockerfile - doc"',
+	'# copy rosdoc2 into image build context directory',
+	'cp -r $WORKSPACE/rosdoc2 $WORKSPACE/docker_doc/rosdoc2',
         '# build and run build_and_install Dockerfile',
         'cd $WORKSPACE/docker_doc',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/misc/docker_pull_baseimage.py',
@@ -178,7 +180,6 @@ else:
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_doc/docker.cid' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
-        ' -v $WORKSPACE/rosdoc2:/tmp/rosdoc2:ro' +
         ' -v $WORKSPACE/ws:/tmp/ws' +
         ' rosdoc2.%s_%s' % (rosdistro_name, doc_repo_spec.name.lower()),
         'echo "# END SECTION"',

--- a/ros_buildfarm/templates/doc/rosdoc2_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/rosdoc2_task.Dockerfile.em
@@ -44,6 +44,7 @@ RUN echo "@today_str"
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y -o Debug::pkgProblemResolver=yes build-essential python3-catkin-pkg-modules doxygen graphviz openssh-client python3 python3-yaml python3-pip rsync
 
 USER buildfarm
+COPY rosdoc2 /tmp/rosdoc2
 ENTRYPOINT ["sh", "-c"]
 @{
 cmd = 'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \

--- a/ros_buildfarm/templates/doc/rosdoc2_task.Dockerfile.em
+++ b/ros_buildfarm/templates/doc/rosdoc2_task.Dockerfile.em
@@ -43,8 +43,8 @@ RUN echo "@today_str"
 
 RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y -o Debug::pkgProblemResolver=yes build-essential python3-catkin-pkg-modules doxygen graphviz openssh-client python3 python3-yaml python3-pip rsync
 
+COPY --chown=@uid:@uid rosdoc2 /tmp/rosdoc2
 USER buildfarm
-COPY rosdoc2 /tmp/rosdoc2
 ENTRYPOINT ["sh", "-c"]
 @{
 cmd = 'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \


### PR DESCRIPTION
This is being explored as a fix for #1029.
The deprecated option that we were relying on to allow rosdoc2 to be built from a read-only source directory has been removed and I did not find a suitable PEP517 builder with an out-of-tree option.

I probably could have just cut `:ro` from the docker run invocation and called it a day and I may open that PR to see how it compares. I was trying to avoid modifying the system host's rosdoc2 clone, but given that most of this occurs in the bootstrap task I don't think that these portions of the workspace are preserved at all between job runs so that concern may be groundless.

For this solution, I copied in the source directory first to the docker build context and then into the image itself before installing it with `--break-system-packages` which seems to be required even when installing into a local user directory.

One thing I _don't_ like about this approach and the mixing of pip and break-system-packages is the fact that dependencies unsatisfied when `pip install . ...` is invoked will be pulled in from pip along with our local project. I would like to mitigate this with the installation of dependencies from apt before pip is invoked with an option not to also install dependencies. Whether I do this with a full rosdep setup or by eye is TBD.