### PR TITLE
Mount rosdoc2 source directory read-write.

### DIFF
--- a/ros_buildfarm/scripts/doc/build_rosdoc2.py
+++ b/ros_buildfarm/scripts/doc/build_rosdoc2.py
@@ -49,8 +49,7 @@ def main(argv=sys.argv[1:]):
                                   '-m',
                                   'pip',
                                   'install',
-                                  '--no-warn-script-location',
-                                  '--use-deprecated=out-of-tree-build',
+                                  '--break-system-packages',
                                   '.'],
                                  cwd=args.rosdoc2_dir)
         if pip_rc:

--- a/ros_buildfarm/templates/doc/rosdoc2_job.xml.em
+++ b/ros_buildfarm/templates/doc/rosdoc2_job.xml.em
@@ -178,7 +178,7 @@ else:
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_doc/docker.cid' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
-        ' -v $WORKSPACE/rosdoc2:/tmp/rosdoc2:ro' +
+        ' -v $WORKSPACE/rosdoc2:/tmp/rosdoc2' +
         ' -v $WORKSPACE/ws:/tmp/ws' +
         ' rosdoc2.%s_%s' % (rosdistro_name, doc_repo_spec.name.lower()),
         'echo "# END SECTION"',


### PR DESCRIPTION
Our deprecated out-of-tree build option has been removed which means that we now need to host our rosdoc2 sources in a read-write location to allow build artifacts to be generated in-tree.

Mounting read-write shouldn't matter overmuch because we delete and re-clone rosdoc2 each time the job runs[1].

[1]: https://github.com/ros-infrastructure/ros_buildfarm/blob/f8d8219b7b7566dcccd6b95a7cb880962cdd816e/ros_buildfarm/templates/doc/rosdoc2_job.xml.em#L94

This is an alternative to #1030 that is slightly lower touch.