### PR TITLE
Set PODMAN_USERNS=keep-id when invoking 'docker run'

### DIFF
--- a/.github/actions/release_reconfigure/action.yaml
+++ b/.github/actions/release_reconfigure/action.yaml
@@ -21,6 +21,8 @@ runs:
   using: composite
   steps:
     - id: ros_buildfarm_job
+      env:
+        PODMAN_USERNS: keep-id
       shell: bash
       run: |
         echo ::group::Generate job

--- a/.github/actions/sync_criteria_check/action.yaml
+++ b/.github/actions/sync_criteria_check/action.yaml
@@ -33,6 +33,8 @@ runs:
   using: composite
   steps:
     - id: ros_buildfarm_job
+      env:
+        PODMAN_USERNS: keep-id
       shell: bash
       run: |
         echo ::group::Generate job

--- a/.github/actions/trigger/action.yaml
+++ b/.github/actions/trigger/action.yaml
@@ -18,6 +18,8 @@ runs:
   using: composite
   steps:
     - id: ros_buildfarm_job
+      env:
+        PODMAN_USERNS: keep-id
       shell: bash
       run: |
         echo ::group::Generate job

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -120,9 +120,16 @@ Another job type can be used locally which is not offered on the build farm.
 * `prerelease jobs <jobs/prerelease_jobs.rst>`_ build and test ROS
   repositories as well as build and test released ROS packages depending on them
 
+
 Optimization
 ------------
 
 If you are going to be running one or more jobs on any machine we recommend `using squid-in-a-can <https://github.com/jpetazzo/squid-in-a-can>`_ to cache downloads.
 It can greatly speed up download times and saves a lot of bandwidth.
 It's used by all our developers as well as on all the build machines.
+
+
+Software required to execute jobs
+---------------------------------
+Beyond the administrative requirements for generating jobs, the only noteworth software for executing jobs whether locally or via Jenkins is a container engine compatible with the Docker client CLI.
+Currently, the only engines tested with ``ros_buildfarm`` are the Docker CE or rootless Podman.

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -230,6 +230,8 @@ parameters = [
         'mkdir -p $WORKSPACE/docker_create_workspace',
         'mkdir -p $WORKSPACE/docker_build_and_install',
         'mkdir -p $WORKSPACE/docker_build_and_test',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_generating_dockers/docker.cid' +
@@ -271,6 +273,8 @@ parameters = [
     ] + [
         'mkdir -p %s' % (dir) for dir in underlay_source_paths
     ] + [
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_create_workspace/docker.cid' +
@@ -316,6 +320,8 @@ parameters = [
     ] + ([
         'echo "# BEGIN SECTION: ccache stats (before)"',
         'mkdir -p $HOME/.ccache',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_build_and_install/docker_ccache_before.cid' +
@@ -331,6 +337,8 @@ parameters = [
         'export UNDERLAY%d_JOB_SPACE=$WORKSPACE/underlay%d/ros%d-linux' % (i + 1, i + 1, local_ros_version)
         for i, local_ros_version in zip(range(len(underlay_source_jobs)), [ros_version] * len(underlay_source_jobs))
     ] + [
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_build_and_install/docker.cid' +
@@ -348,6 +356,8 @@ parameters = [
     ] + ([
         '',
         'echo "# BEGIN SECTION: ccache stats (after)"',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_build_and_install/docker_ccache_after.cid' +
@@ -394,6 +404,8 @@ parameters = [
     ] + ([
         'echo "# BEGIN SECTION: ccache stats (before)"',
         'mkdir -p $HOME/.ccache',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_build_and_test/docker_ccache_before.cid' +
@@ -411,6 +423,8 @@ parameters = [
     ] + [
         'rm -fr $WORKSPACE/ws/test_results',
         'mkdir -p $WORKSPACE/ws/test_results',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_build_and_test/docker.cid' +
@@ -428,6 +442,8 @@ parameters = [
     ] + ([
         '',
         'echo "# BEGIN SECTION: ccache stats (after)"',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_build_and_test/docker_ccache_after.cid' +

--- a/ros_buildfarm/templates/ci/ci_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_reconfigure-jobs_job.xml.em
@@ -111,6 +111,8 @@ if (repository_names) {
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - reconfigure jobs for %s"' % (ci_build_name),
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         '# -e=GIT_BRANCH= is required since Jenkins leaves the wc in detached state',
         'docker run' +
         ' --rm ' +

--- a/ros_buildfarm/templates/devel/devel_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_job.xml.em
@@ -167,6 +167,8 @@ if pull_request:
         'rm -fr $WORKSPACE/docker_build_and_test',
         'mkdir -p $WORKSPACE/docker_build_and_install',
         'mkdir -p $WORKSPACE/docker_build_and_test',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_generating_dockers/docker.cid' +
@@ -205,6 +207,8 @@ if pull_request:
         'if [ ! -d "$HOME/.ccache" ]; then mkdir $HOME/.ccache; fi',
     ]  if shared_ccache else []) + [
         ('if [ ! -c /dev/nvidia[0-9] ]; then echo "--require-gpu-support is enabled but can not detect nvidia support installed" && exit 1; fi' if require_gpu_support else ''),
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         (' --env=DISPLAY=:0.0 --env=QT_X11_NO_MITSHM=1 --volume=/tmp/.X11-unix:/tmp/.X11-unix:rw --gpus all' if require_gpu_support else '') +
         ' --rm ' +
@@ -238,6 +242,8 @@ if pull_request:
     ] + ([
         'if [ ! -d "$HOME/.ccache" ]; then mkdir $HOME/.ccache; fi',
     ] if shared_ccache else []) + [
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         (' --env=DISPLAY=:0.0 --env=QT_X11_NO_MITSHM=1 --volume=/tmp/.X11-unix:/tmp/.X11-unix:rw  --gpus all' if require_gpu_support else '') +
         ' --rm ' +

--- a/ros_buildfarm/templates/devel/devel_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/devel/devel_reconfigure-jobs_job.xml.em
@@ -113,6 +113,8 @@ if (repository_names) {
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - reconfigure jobs"',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         '# -e=GIT_BRANCH= is required since Jenkins leaves the wc in detached state',
         'docker run' +
         ' --rm ' +

--- a/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
@@ -120,6 +120,8 @@ else:
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Docker - %s"' % doc_repository_name,
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm' +
         ' --net=host' +

--- a/ros_buildfarm/templates/doc/doc_independent_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_job.xml.em
@@ -120,6 +120,8 @@ else:
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - doc independent"',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_doc_independent/docker.cid' +

--- a/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_metadata_job.xml.em
@@ -95,6 +95,8 @@
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - doc metadata"',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_doc_metadata/docker.cid' +

--- a/ros_buildfarm/templates/doc/doc_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_reconfigure-jobs_job.xml.em
@@ -113,6 +113,8 @@ if (repository_names) {
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - reconfigure jobs"',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         '# -e=GIT_BRANCH= is required since Jenkins leaves the wc in detached state',
         'docker run' +
         ' --rm ' +

--- a/ros_buildfarm/templates/doc/rosdoc2_job.xml.em
+++ b/ros_buildfarm/templates/doc/rosdoc2_job.xml.em
@@ -141,6 +141,8 @@ else:
         'echo "# BEGIN SECTION: Run Dockerfile - generating doc task"',
         'rm -fr $WORKSPACE/docker_doc',
         'mkdir -p $WORKSPACE/docker_doc',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_generating_docker/docker.cid' +
@@ -174,6 +176,8 @@ else:
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - doc"',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_doc/docker.cid' +

--- a/ros_buildfarm/templates/misc/rosdistro_cache_job.xml.em
+++ b/ros_buildfarm/templates/misc/rosdistro_cache_job.xml.em
@@ -81,6 +81,8 @@
         'echo "# BEGIN SECTION: Run Dockerfile - rosdistro cache"',
         'rm -fr $WORKSPACE/rosdistro_cache',
         'mkdir -p $WORKSPACE/rosdistro_cache',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_generate_rosdistro_cache/docker.cid' +

--- a/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
@@ -131,6 +131,8 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
     ] + ([
         'if [ ! -d "$HOME/.ccache" ]; then mkdir $HOME/.ccache; fi',
     ] if shared_ccache else []) + [
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_generating_docker/docker.cid' +
@@ -165,6 +167,8 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
     ] + ([
         'if [ ! -d "$HOME/.ccache" ]; then mkdir $HOME/.ccache; fi',
     ] if shared_ccache else []) + [
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_build_binarydeb/docker.cid' +
@@ -223,6 +227,8 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 @#         'echo "# END SECTION"',
 @#         '',
 @#         'echo "# BEGIN SECTION: Run Dockerfile - install"',
+@#         '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+@#         'export PODMAN_USERNS=keep-id',
 @#         'docker run' +
 @#         ' --rm ' +
 @#         ' --cidfile=$WORKSPACE/docker_install_binarydeb/docker.cid' +

--- a/ros_buildfarm/templates/release/deb/sourcepkg_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/sourcepkg_job.xml.em
@@ -110,6 +110,8 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         'echo "# BEGIN SECTION: Run Dockerfile - generate sourcedeb"',
         'rm -fr $WORKSPACE/sourcedeb',
         'mkdir -p $WORKSPACE/sourcedeb/source',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_sourcedeb/docker.cid' +

--- a/ros_buildfarm/templates/release/release_reconfigure-jobs_job.xml.em
+++ b/ros_buildfarm/templates/release/release_reconfigure-jobs_job.xml.em
@@ -113,6 +113,8 @@ if (package_names) {
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Run Dockerfile - reconfigure jobs"',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         '# -e=GIT_BRANCH= is required since Jenkins leaves the wc in detached state',
         'docker run' +
         ' --rm ' +

--- a/ros_buildfarm/templates/release/release_trigger-jobs_job.xml.em
+++ b/ros_buildfarm/templates/release/release_trigger-jobs_job.xml.em
@@ -122,6 +122,8 @@ if missed_jobs:
         'echo "# BEGIN SECTION: Run Dockerfile - trigger jobs"',
         'rm -fr $WORKSPACE/package_repo_cache',
         'mkdir -p $WORKSPACE/package_repo_cache',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_trigger_jobs/docker.cid' +

--- a/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sync_packages_to_testing_job.xml.em
@@ -82,6 +82,8 @@
         'echo "# BEGIN SECTION: Run Dockerfile - check sync condition"',
         'rm -fr $WORKSPACE/package_repo_cache',
         'mkdir -p $WORKSPACE/package_repo_cache',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_check_sync_criteria/docker.cid' +

--- a/ros_buildfarm/templates/status/blocked_releases_page_job.xml.em
+++ b/ros_buildfarm/templates/status/blocked_releases_page_job.xml.em
@@ -82,6 +82,8 @@
         'echo "# BEGIN SECTION: Run Dockerfile - blocked_releases page"',
         'rm -fr $WORKSPACE/blocked_releases_page',
         'mkdir -p $WORKSPACE/blocked_releases_page',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_generate_blocked_releases_page/docker.cid' +

--- a/ros_buildfarm/templates/status/blocked_source_entries_page_job.xml.em
+++ b/ros_buildfarm/templates/status/blocked_source_entries_page_job.xml.em
@@ -82,6 +82,8 @@
         'echo "# BEGIN SECTION: Run Dockerfile - blocked_source_entries page"',
         'rm -fr $WORKSPACE/blocked_source_entries_page',
         'mkdir -p $WORKSPACE/blocked_source_entries_page',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_generate_blocked_source_entries_page/docker.cid' +

--- a/ros_buildfarm/templates/status/release_compare_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_compare_page_job.xml.em
@@ -83,6 +83,8 @@
         'echo "# BEGIN SECTION: Run Dockerfile - compare page"',
         'rm -fr $WORKSPACE/compare_page',
         'mkdir -p $WORKSPACE/compare_page',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_generate_compare_page/docker.cid' +

--- a/ros_buildfarm/templates/status/release_status_page_job.xml.em
+++ b/ros_buildfarm/templates/status/release_status_page_job.xml.em
@@ -85,6 +85,8 @@
         'rm -fr $WORKSPACE/status_page',
         'mkdir -p $WORKSPACE/package_repo_cache',
         'mkdir -p $WORKSPACE/status_page',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_generate_status_page/docker.cid' +


### PR DESCRIPTION
The way Dockerfiles are structured in ros_buildfarm, we're dependent on the UID staying the same when the container is run.

Setting PODMAN_USERNS=keep-id when the `docker` command is backed by Podman will in effect preserve the behavior of Docker we're relying on here. When the `docker` command is backed by Docker, this shouldn't change the behavior at all.

So far, this change combined with #1013 has enabled use of Podman for all `release` and `devel` jobs locally.