### PR TITLE
Deal with RPM *-SPECPARTS build subdirectory

### DIFF
--- a/ros_buildfarm/binaryrpm_job.py
+++ b/ros_buildfarm/binaryrpm_job.py
@@ -80,7 +80,14 @@ def build_binaryrpm(
     mock_root_path = subprocess.check_output(
         ['mock', '--root', 'ros_buildfarm', '--print-root-path']).decode('utf-8').strip()
     mock_build_path = os.path.join(mock_root_path, 'builddir', 'build', 'BUILD')
-    package_root = os.path.join(mock_build_path, os.listdir(mock_build_path)[0])
+    for subdir in os.listdir(mock_build_path):
+        if subdir.endswith('-SPECPARTS'):
+            continue
+
+        package_root = os.path.join(mock_build_path, subdir)
+        break
+    else:
+        assert False, "Failed to determine package build root"
 
     # output package maintainers for job notification
     from catkin_pkg.package import parse_package


### PR DESCRIPTION
In typical RPM builds, the `BUILD` directory contains only a single subdirectory, which is where the package sources are extracted to prior to building.

Beginning with RPM 4.19, a -SPECPARTS subdirectory is created to facilitate dynamic spec file generation. We need to explicitly ignore it when we go looking for where the sources were extracted.