### PR TITLE
Drop support for CentOS/RHEL 7

### DIFF
--- a/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
@@ -1,45 +1,25 @@
-@{
-package_manager = 'dnf'
-python3_pkgversion = '3'
-
-if os_name == 'rhel' and os_code_name.isnumeric() and int(os_code_name) < 8:
-    package_manager = 'yum'
-    python3_pkgversion = '36'
-}@
 # generated from @template_name
 
 @[if os_name in ['rhel']]@
 FROM almalinux:@(os_code_name)
 
-# Enable EPEL on RHEL
-RUN @(package_manager) install -y epel-release
+# Enable CRB and EPEL on RHEL
+RUN dnf install --refresh -y epel-release && crb enable
 @[else]@
 FROM @(os_name):@(os_code_name)
 @[end if]@
 
-RUN @(package_manager) update -y
+RUN dnf update --refresh -y
 
-@[if os_name in ['rhel']]@
-# Enable CRB on RHEL
-RUN crb enable
-@[end if]@
-
-RUN @(package_manager) install -y dnf{,-command\(download\)} mock{,-{core-configs,scm}} python@(python3_pkgversion){,-{catkin_pkg,empy,rosdistro,yaml}}
+RUN dnf install --refresh -y --setopt=install_weak_deps=False dnf{,-command\(download\)} git mock{,-{core-configs,scm}} python3{,-{catkin_pkg,empy,rosdistro,yaml}}
 
 RUN useradd -u @(uid) -l -m buildfarm
 RUN usermod -a -G mock buildfarm
 
-# Clean up after updates and freshen cache
-RUN @(package_manager) clean dbcache packages
-RUN @(package_manager) makecache
-
-# "Expire" the cache to force the next operation to check again
-RUN @(package_manager) clean expire-cache
-
 # automatic invalidation once every day
 RUN echo "@(today_str)"
 
-RUN @(package_manager) update -y
+RUN dnf update --refresh -y
 
 # Workaround for broken mock configs for EPEL 8
 RUN echo -e "include('templates/almalinux-8.tpl')\ninclude('templates/epel-8.tpl')\n\nconfig_opts['root'] = 'epel-8-x86_64'\nconfig_opts['target_arch'] = 'x86_64'\nconfig_opts['legal_host_arches'] = ('x86_64',)" > /etc/mock/epel-8-x86_64.cfg

--- a/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
+++ b/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
@@ -10,7 +10,7 @@ config_opts['use_bootstrap'] = False
 config_opts['chroot_setup_cmd'] += ' python3-rpm-macros'
 
 # Install weak dependencies to get group members
-config_opts[f'{config_opts.package_manager}_builddep_opts'] = config_opts.get(f'{config_opts.package_manager}_builddep_opts', []) + ['--setopt=install_weak_deps=True']
+config_opts[f'dnf_builddep_opts'] = config_opts.get(f'dnf_builddep_opts', []) + ['--setopt=install_weak_deps=True']
 
 @[if env_vars]@
 # Set environment vars from the build config
@@ -29,19 +29,10 @@ config_opts['macros']['%__cmake3_in_source_build'] = '1'
 # Required for running mock in Docker
 config_opts['use_nspawn'] = False
 
-@[if os_name == 'rhel' and os_code_name == '7']@
-# Inject g++ 8 into RHEL 7 builds
-config_opts['chroot_setup_cmd'] += ' devtoolset-8-gcc-c++ devtoolset-8-make-nonblocking'
-config_opts['macros']['%_buildshell'] = '/usr/bin/scl enable devtoolset-8 -- /bin/sh'
-
-# Disable weak dependencies on RHEL 7 builds
-config_opts['macros']['%_without_weak_deps'] = '1'
-@[else]@
 # Add g++, which is an assumed dependency in ROS
 config_opts['chroot_setup_cmd'] += ' gcc-c++ make'
-@[end if]@
 
-config_opts[f'{config_opts.package_manager}.conf'] += """
+config_opts[f'dnf.conf'] += """
 @[for i, url in enumerate(distribution_repository_urls)]@
 [ros-buildfarm-@(i)]
 name=ROS Buildfarm Repository @(i) - $basearch

--- a/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
@@ -1,45 +1,25 @@
-@{
-package_manager = 'dnf'
-python3_pkgversion = '3'
-
-if os_name == 'rhel' and os_code_name.isnumeric() and int(os_code_name) < 8:
-    package_manager = 'yum'
-    python3_pkgversion = '36'
-}@
 # generated from @template_name
 
 @[if os_name in ['rhel']]@
 FROM almalinux:@(os_code_name)
 
-# Enable EPEL on RHEL
-RUN @(package_manager) install -y epel-release
+# Enable CRB and EPEL on RHEL
+RUN dnf install --refresh -y epel-release && crb enable
 @[else]@
 FROM @(os_name):@(os_code_name)
 @[end if]@
 
-RUN @(package_manager) update -y
+RUN dnf update --refresh -y
 
-@[if os_name in ['rhel']]@
-# Enable CRB on RHEL
-RUN crb enable
-@[end if]@
-
-RUN @(package_manager) install -y dnf{,-command\(download\)} mock{,-{core-configs,scm}} python@(python3_pkgversion){,-{catkin_pkg,empy,rosdistro,yaml}}
+RUN dnf install --refresh -y --setopt=install_weak_deps=False dnf{,-command\(download\)} git mock{,-{core-configs,scm}} python3{,-{catkin_pkg,empy,rosdistro,yaml}}
 
 RUN useradd -u @(uid) -l -m buildfarm
 RUN usermod -a -G mock buildfarm
 
-# Clean up after updates and freshen cache
-RUN @(package_manager) clean dbcache packages
-RUN @(package_manager) makecache
-
-# "Expire" the cache to force the next operation to check again
-RUN @(package_manager) clean expire-cache
-
 # automatic invalidation once every day
 RUN echo "@(today_str)"
 
-RUN @(package_manager) update -y
+RUN dnf update --refresh -y
 
 # Workaround for broken mock configs for EPEL 8
 RUN echo -e "include('templates/almalinux-8.tpl')\ninclude('templates/epel-8.tpl')\n\nconfig_opts['root'] = 'epel-8-x86_64'\nconfig_opts['target_arch'] = 'x86_64'\nconfig_opts['legal_host_arches'] = ('x86_64',)" > /etc/mock/epel-8-x86_64.cfg


### PR DESCRIPTION
We never officially supported RHEL 7, though we did target it prior to announcing official support for RHEL 8.

The use of `config_opts.package_manager` in this way will break with newer releases of Fedora (and eventually RHEL) where it has become a macro itself, which may resolve to `dnf5`.