### PR TITLE
Use environment to configure breaking system packages.

### DIFF
--- a/ros_buildfarm/scripts/doc/build_rosdoc2.py
+++ b/ros_buildfarm/scripts/doc/build_rosdoc2.py
@@ -45,12 +45,17 @@ def main(argv=sys.argv[1:]):
     clean_workspace(args.workspace_root)
 
     with Scope('SUBSECTION', 'Installing rosdoc2'):
+        env = {
+            **os.environ,
+            'PIP_BREAK_SYSTEM_PACKAGES': '1',
+        }
+
         pip_rc = subprocess.call(['python3',
                                   '-m',
                                   'pip',
                                   'install',
-                                  '--break-system-packages',
                                   '.'],
+                                 env=env,
                                  cwd=args.rosdoc2_dir)
         if pip_rc:
             return pip_rc


### PR DESCRIPTION
This resolves the regression in this script on platforms with older versions of pip.

Fixes a regression introduced in #1031.