### PR TITLE
Use raw strings when specifying regular expressions

### DIFF
--- a/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
@@ -256,7 +256,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 ))@
 @(SNIPPET(
     'publisher_description-setter',
-    regexp="Package '[^']+' version: (\S+)",
+    regexp=r"Package '[^']+' version: (\S+)",
     # to prevent overwriting the description of failed builds
     regexp_for_failed='ThisRegExpShouldNeverMatch',
 ))@

--- a/ros_buildfarm/templates/release/deb/import_package_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/import_package_job.xml.em
@@ -64,7 +64,7 @@
   <publishers>
 @(SNIPPET(
     'publisher_description-setter',
-    regexp='Importing package: (\S+)',
+    regexp=r'Importing package: (\S+)',
     # to prevent overwriting the description of failed builds
     regexp_for_failed='ThisRegExpShouldNeverMatch',
 ))@

--- a/ros_buildfarm/templates/release/deb/sourcepkg_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/sourcepkg_job.xml.em
@@ -157,7 +157,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
   <publishers>
 @(SNIPPET(
     'publisher_description-setter',
-    regexp="Package '[^']+' version: (\S+)",
+    regexp=r"Package '[^']+' version: (\S+)",
     # to prevent overwriting the description of failed builds
     regexp_for_failed='ThisRegExpShouldNeverMatch',
 ))@

--- a/ros_buildfarm/templates/release/rpm/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_job.xml.em
@@ -173,7 +173,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 ))@
 @(SNIPPET(
     'publisher_description-setter',
-    regexp="Package '[^']+' version: (\S+)",
+    regexp=r"Package '[^']+' version: (\S+)",
     # to prevent overwriting the description of failed builds
     regexp_for_failed='ThisRegExpShouldNeverMatch',
 ))@

--- a/ros_buildfarm/templates/release/rpm/sourcepkg_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sourcepkg_job.xml.em
@@ -151,7 +151,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
   <publishers>
 @(SNIPPET(
     'publisher_description-setter',
-    regexp="Package '[^']+' version: (\S+)",
+    regexp=r"Package '[^']+' version: (\S+)",
     # to prevent overwriting the description of failed builds
     regexp_for_failed='ThisRegExpShouldNeverMatch',
 ))@


### PR DESCRIPTION
Addresses warnings like this coming out of EmPy:
```
<string>:3: SyntaxWarning: invalid escape sequence '\S'
```