### PR TITLE
Switch from 'include_package_data' to 'package_data'

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include README.md
-recursive-include ros_buildfarm/templates *

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,13 @@ kwargs = {
     'packages': find_packages(exclude=['test']),
     'package_data': {
         'ros_buildfarm.templates': [
-            '**/*.css',
-            '**/*.em',
-            '**/*.groovy',
-            '**/*.js',
-            '**/*.parser',
+            '*/*/*.css',
+            '*.em',
+            '*/*.em',
+            '*/*/*.em',
+            '*/*.groovy',
+            '*/*/*.js',
+            '*/*/*.parser',
         ],
     },
     'scripts': scripts,

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,16 @@ kwargs = {
     # - stdeb.cfg
     'version': '3.0.1-master',
     'packages': find_packages(exclude=['test']),
+    'package_data': {
+        'ros_buildfarm.templates': [
+            '**/*.css',
+            '**/*.em',
+            '**/*.groovy',
+            '**/*.js',
+            '**/*.parser',
+        ],
+    },
     'scripts': scripts,
-    'include_package_data': True,
     'zip_safe': False,
     'install_requires': [
         'empy<4',


### PR DESCRIPTION
The former results in quite a few warning messages during the package build with modern setuptools, such as:

<details>

```
********************************************************************************
############################
# Package would be ignored #
############################
Python recognizes 'ros_buildfarm.templates.status.js' as an importable package[^1],
but it is absent from setuptools' `packages` configuration.

This leads to an ambiguous overall configuration. If you want to distribute this
package, please make sure that 'ros_buildfarm.templates.status.js' is explicitly added
to the `packages` configuration field.

Alternatively, you can also rely on setuptools' discovery methods
(for example by using `find_namespace_packages(...)`/`find_namespace:`
instead of `find_packages(...)`/`find:`).

You can read more about "package discovery" on setuptools documentation page:

- https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

If you don't want 'ros_buildfarm.templates.status.js' to be distributed and are
already explicitly excluding 'ros_buildfarm.templates.status.js' via
`find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
you can try to use `exclude_package_data`, or `include-package-data=False` in
combination with a more fine grained `package-data` configuration.

You can read more about "package data files" on setuptools documentation page:

- https://setuptools.pypa.io/en/latest/userguide/datafiles.html


[^1]: For Python, any directory (with suitable naming) can be imported,
      even if it does not contain any `.py` files.
      On the other hand, currently there is no concept of package data
      directory, all directories are treated like packages.
********************************************************************************
```

</details>