### PR TITLE
Add logic for excluding group workaround dependencies

### DIFF
--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -88,7 +88,8 @@ def configure_release_jobs(
     cached_pkgs = _get_and_parse_distribution_cache(
         index, rosdistro_name, pkg_names,
         include_test_deps=build_file.include_test_dependencies,
-        include_group_deps=build_file.include_group_dependencies)
+        include_group_deps=build_file.include_group_dependencies,
+        disable_groups_workaround=build_file.include_group_dependencies)
     filtered_pkg_names = build_file.filter_packages(pkg_names)
     explicitly_ignored_without_recursion_pkg_names = \
         set(pkg_names) & set(build_file.package_ignore_list)
@@ -345,7 +346,8 @@ def configure_release_jobs(
 
 
 def _get_and_parse_distribution_cache(
-    index, rosdistro_name, pkg_names, include_test_deps, include_group_deps
+    index, rosdistro_name, pkg_names, include_test_deps, include_group_deps,
+    disable_groups_workaround,
 ):
     from catkin_pkg.package import parse_package_string
     from catkin_pkg.package import Dependency
@@ -358,6 +360,8 @@ def _get_and_parse_distribution_cache(
     }
 
     condition_context = get_package_condition_context(index, rosdistro_name)
+    if disable_groups_workaround:
+        condition_context['DISABLE_GROUPS_WORKAROUND'] = '1'
     for pkg in cached_pkgs.values():
         pkg.evaluate_conditions(condition_context)
     for pkg in cached_pkgs.values():
@@ -459,7 +463,8 @@ def configure_release_job(
         cached_pkgs = _get_and_parse_distribution_cache(
             index, rosdistro_name, [pkg_name],
             include_test_deps=build_file.include_test_dependencies,
-            include_group_deps=build_file.include_group_dependencies)
+            include_group_deps=build_file.include_group_dependencies,
+            disable_groups_workaround=build_file.include_group_dependencies)
     if jenkins is None:
         from ros_buildfarm.jenkins import connect
         jenkins = connect(config.jenkins_url)


### PR DESCRIPTION
This represents the first step in the journey to proper support for group dependencies in `ros_buildfarm`. Specifically, it sets the mechanism by which we disable the existing "pre-resolved" group dependencies present in the package manifests in the source repositories.

I chose the name `DISABLE_GROUPS_WORKAROUND` to act as the "feature flag" for a tool to use when expressing that it has support for group dependencies and doesn't want the pre-resolved dependencies to be present. I'm open to suggestions for a better name.

An example of how the package manifests would be modified for this change:
```patch
-  <build_depend>rmw_connextdds</build_depend>
+  <build_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rmw_connextdds</build_depend>
```

All manifests which pre-resolve groups would need to change, which (I believe) includes all manifests containing a `<group_depend>` element.

At present, `build_file.include_group_dependencies` is never `True` in production, so this flag should never be activated and no change in behavior is expected to any supported platforms or distributions.