### PR TITLE
Ignore SIGINT on Windows.

### DIFF
--- a/scripts/subprocess_reaper.py
+++ b/scripts/subprocess_reaper.py
@@ -170,4 +170,9 @@ if __name__ == '__main__':
     # ignore SIGTERM so that if the parent process is killed
     # and forwards the signal, this script does not die
     signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    # When running on Windows the script is receiving a SIGINT
+    # resulting in a KeyboardInterrupt. Sadly this means that
+    # the script is not ^C-able on Windows.
+    if sys.platform == 'win32':
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
     sys.exit(main())


### PR DESCRIPTION
When running this script in Windows jenkins jobs it's receiving a SIGINT rather than SIGTERM.

You might be wondering, when does this ever run on Windows? Well at one point I was looking at using this under ros2/ci: https://github.com/ros2/ci/pull/374