### PR TITLE
Avoid jenkinsapi trying to fetch all jobs.

### DIFF
--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -215,7 +215,7 @@ def configure_ci_job(
         trigger_timer, trigger_jobs,
         is_disabled=is_disabled)
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-    if isinstance(jenkins, object) and jenkins is not None:
+    if isinstance(jenkins, object) and jenkins is not False:
         from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, job_name, job_config, dry_run=dry_run)
 

--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -80,7 +80,7 @@ def _configure_ci_jobs(
         ci_view_name: configure_ci_view(
             jenkins, ci_view_name, dry_run=dry_run)
     }
-    if not jenkins:
+    if jenkins is False:
         view_configs.update(views)
     groovy_data = {
         'dry_run': dry_run,

--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -215,7 +215,7 @@ def configure_ci_job(
         trigger_timer, trigger_jobs,
         is_disabled=is_disabled)
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-    if isinstance(jenkins, object) and jenkins is not False:
+    if isinstance(jenkins, object) and jenkins is not None:
         from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, job_name, job_config, dry_run=dry_run)
 

--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -73,14 +73,14 @@ def _configure_ci_jobs(
     # all further configuration will be handled by either the Jenkins API
     # or by a generated groovy script
     from ros_buildfarm.jenkins import connect
-    jenkins = connect(config.jenkins_url) if groovy_script is None else False
+    jenkins = connect(config.jenkins_url) if groovy_script is None else None
 
     view_configs = {}
     views = {
         ci_view_name: configure_ci_view(
             jenkins, ci_view_name, dry_run=dry_run)
     }
-    if jenkins is False:
+    if jenkins is None:
         view_configs.update(views)
     groovy_data = {
         'dry_run': dry_run,

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -334,7 +334,7 @@ def configure_devel_job(
         is_disabled=is_disabled, run_abichecker=run_abichecker,
         require_gpu_support=require_gpu_support)
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-    if isinstance(jenkins, object) and jenkins is not False:
+    if isinstance(jenkins, object) and jenkins is not None:
         from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, job_name, job_config, dry_run=dry_run)
 

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -90,7 +90,7 @@ def configure_devel_jobs(
     if build_file.test_pull_requests_force is not False:
         views[pull_request_view_name] = configure_devel_view(
             jenkins, pull_request_view_name, dry_run=dry_run)
-    if not jenkins:
+    if jenkins is False:
         view_configs.update(views)
     groovy_data = {
         'dry_run': dry_run,

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -334,7 +334,7 @@ def configure_devel_job(
         is_disabled=is_disabled, run_abichecker=run_abichecker,
         require_gpu_support=require_gpu_support)
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-    if isinstance(jenkins, object) and jenkins is not None:
+    if isinstance(jenkins, object) and jenkins is not False:
         from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, job_name, job_config, dry_run=dry_run)
 

--- a/ros_buildfarm/devel_job.py
+++ b/ros_buildfarm/devel_job.py
@@ -80,7 +80,7 @@ def configure_devel_jobs(
     # all further configuration will be handled by either the Jenkins API
     # or by a generated groovy script
     from ros_buildfarm.jenkins import connect
-    jenkins = connect(config.jenkins_url) if groovy_script is None else False
+    jenkins = connect(config.jenkins_url) if groovy_script is None else None
 
     view_configs = {}
     views = {}
@@ -90,7 +90,7 @@ def configure_devel_jobs(
     if build_file.test_pull_requests_force is not False:
         views[pull_request_view_name] = configure_devel_view(
             jenkins, pull_request_view_name, dry_run=dry_run)
-    if jenkins is False:
+    if jenkins is None:
         view_configs.update(views)
     groovy_data = {
         'dry_run': dry_run,

--- a/ros_buildfarm/doc_job.py
+++ b/ros_buildfarm/doc_job.py
@@ -77,13 +77,13 @@ def configure_doc_jobs(
     # all further configuration will be handled by either the Jenkins API
     # or by a generated groovy script
     from ros_buildfarm.jenkins import connect
-    jenkins = connect(config.jenkins_url) if groovy_script is None else False
+    jenkins = connect(config.jenkins_url) if groovy_script is None else None
 
     view_configs = {}
     views = {}
     views[doc_view_name] = configure_doc_view(
         jenkins, doc_view_name, dry_run=dry_run)
-    if jenkins is False:
+    if jenkins is None:
         view_configs.update(views)
     groovy_data = {
         'dry_run': dry_run,

--- a/ros_buildfarm/doc_job.py
+++ b/ros_buildfarm/doc_job.py
@@ -242,7 +242,7 @@ def configure_doc_job(
         build_file, os_name, os_code_name, arch, doc_repository,
         repo_name, dist_cache=dist_cache, is_disabled=is_disabled)
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-    if isinstance(jenkins, object) and jenkins is not None:
+    if isinstance(jenkins, object) and jenkins is not False:
         from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, job_name, job_config, dry_run=dry_run)
 
@@ -347,7 +347,7 @@ def configure_doc_metadata_job(
     job_config = _get_doc_metadata_job_config(
         config, config_url, rosdistro_name, doc_build_name, build_file)
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-    if isinstance(jenkins, object) and jenkins is not None:
+    if isinstance(jenkins, object) and jenkins is not False:
         from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, job_name, job_config, dry_run=dry_run)
 
@@ -402,7 +402,7 @@ def configure_doc_independent_job(
     job_config = _get_doc_independent_job_config(
         config, config_url, job_name, build_file)
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-    if isinstance(jenkins, object) and jenkins is not None:
+    if isinstance(jenkins, object) and jenkins is not False:
         from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, job_name, job_config, dry_run=dry_run)
 

--- a/ros_buildfarm/doc_job.py
+++ b/ros_buildfarm/doc_job.py
@@ -242,7 +242,7 @@ def configure_doc_job(
         build_file, os_name, os_code_name, arch, doc_repository,
         repo_name, dist_cache=dist_cache, is_disabled=is_disabled)
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-    if isinstance(jenkins, object) and jenkins is not False:
+    if isinstance(jenkins, object) and jenkins is not None:
         from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, job_name, job_config, dry_run=dry_run)
 
@@ -347,7 +347,7 @@ def configure_doc_metadata_job(
     job_config = _get_doc_metadata_job_config(
         config, config_url, rosdistro_name, doc_build_name, build_file)
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-    if isinstance(jenkins, object) and jenkins is not False:
+    if isinstance(jenkins, object) and jenkins is not None:
         from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, job_name, job_config, dry_run=dry_run)
 
@@ -402,7 +402,7 @@ def configure_doc_independent_job(
     job_config = _get_doc_independent_job_config(
         config, config_url, job_name, build_file)
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-    if isinstance(jenkins, object) and jenkins is not False:
+    if isinstance(jenkins, object) and jenkins is not None:
         from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, job_name, job_config, dry_run=dry_run)
 

--- a/ros_buildfarm/doc_job.py
+++ b/ros_buildfarm/doc_job.py
@@ -83,7 +83,7 @@ def configure_doc_jobs(
     views = {}
     views[doc_view_name] = configure_doc_view(
         jenkins, doc_view_name, dry_run=dry_run)
-    if not jenkins:
+    if jenkins is False:
         view_configs.update(views)
     groovy_data = {
         'dry_run': dry_run,

--- a/ros_buildfarm/jenkins.py
+++ b/ros_buildfarm/jenkins.py
@@ -57,7 +57,7 @@ _cached_jenkins = None
 
 def connect(jenkins_url):
     global _cached_jenkins
-    if _cached_jenkins and _cached_jenkins.base_server_url() == jenkins_url:
+    if _cached_jenkins is not None and _cached_jenkins.base_server_url() == jenkins_url:
         print("Reusing connection to Jenkins '%s'" % jenkins_url)
         return _cached_jenkins
 
@@ -90,7 +90,7 @@ def configure_view(
     view_config = get_view_config(
         template_name, view_name, include_regex=include_regex,
         filter_queue=filter_queue)
-    if not jenkins:
+    if jenkins is None:
         _cached_views[key] = view_config
         return view_config
     view_type = _get_view_type(view_config)

--- a/ros_buildfarm/jenkins.py
+++ b/ros_buildfarm/jenkins.py
@@ -38,6 +38,8 @@ class JenkinsProxy(Jenkins):
     def __init__(self, *args, **kwargs):  # noqa: D107
         requester_kwargs = copy.copy(kwargs)
         requester_kwargs['baseurl'] = args[0]
+        # Don't trigger jenkinsapi poll on initialization
+        kwargs['lazy'] = True
         kwargs['requester'] = CrumbRequester(**requester_kwargs)
         kwargs.setdefault('timeout', 120)
         super(JenkinsProxy, self).__init__(*args, **kwargs)

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -519,7 +519,7 @@ def configure_release_job(
         is_disabled=is_source_disabled,
         other_build_files_same_platform=other_build_files_same_platform)
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-    if isinstance(jenkins, object) and jenkins is not None:
+    if isinstance(jenkins, object) and jenkins is not False:
         from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, source_job_name, job_config, dry_run=dry_run)
     source_job_names.append(source_job_name)
@@ -561,7 +561,7 @@ def configure_release_job(
             cached_pkgs=cached_pkgs, upstream_job_names=upstream_job_names,
             is_disabled=is_disabled)
         # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-        if isinstance(jenkins, object) and jenkins is not None:
+        if isinstance(jenkins, object) and jenkins is not False:
             configure_job(jenkins, job_name, job_config, dry_run=dry_run)
         binary_job_names.append(job_name)
         job_configs[job_name] = job_config
@@ -784,7 +784,7 @@ def configure_import_package_job(
     job_config = _get_import_package_job_config(build_file, package_format)
 
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-    if isinstance(jenkins, object) and jenkins is not None:
+    if isinstance(jenkins, object) and jenkins is not False:
         from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, job_name, job_config, dry_run=dry_run)
     return (job_name, job_config)
@@ -827,7 +827,7 @@ def configure_sync_packages_to_testing_job(
         arch, config, build_file)
 
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-    if isinstance(jenkins, object) and jenkins is not None:
+    if isinstance(jenkins, object) and jenkins is not False:
         from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, job_name, job_config, dry_run=dry_run)
     return (job_name, job_config)
@@ -895,7 +895,7 @@ def configure_sync_packages_to_main_job(
         rosdistro_name, build_file, package_format)
 
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-    if isinstance(jenkins, object) and jenkins is not None:
+    if isinstance(jenkins, object) and jenkins is not False:
         from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, job_name, job_config, dry_run=dry_run)
     return (job_name, job_config)

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -131,7 +131,7 @@ def configure_release_jobs(
 
     # all further configuration will be handled by either the Jenkins API
     # or by a generated groovy script
-    jenkins = False
+    jenkins = None
     if groovy_script is None:
         from ros_buildfarm.jenkins import connect
         jenkins = connect(config.jenkins_url)
@@ -144,14 +144,14 @@ def configure_release_jobs(
             job_name, job_config = configure_import_package_job(
                 config_url, rosdistro_name, release_build_name,
                 config=config, build_file=build_file, jenkins=jenkins, dry_run=dry_run)
-            if jenkins is False:
+            if jenkins is None:
                 all_job_configs[job_name] = job_config
             break
 
     job_name, job_config = configure_sync_packages_to_main_job(
         config_url, rosdistro_name, release_build_name,
         config=config, build_file=build_file, jenkins=jenkins, dry_run=dry_run)
-    if jenkins is False:
+    if jenkins is None:
         all_job_configs[job_name] = job_config
 
     for os_name, os_code_name in platforms:
@@ -161,7 +161,7 @@ def configure_release_jobs(
                 os_name, os_code_name, arch,
                 config=config, build_file=build_file, jenkins=jenkins,
                 dry_run=dry_run)
-            if jenkins is False:
+            if jenkins is None:
                 all_job_configs[job_name] = job_config
 
     targets = []
@@ -172,7 +172,7 @@ def configure_release_jobs(
     views = configure_release_views(
         jenkins, rosdistro_name, release_build_name, targets,
         dry_run=dry_run)
-    if jenkins is False:
+    if jenkins is None:
         all_view_configs.update(views)
     groovy_data = {
         'dry_run': dry_run,

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -144,14 +144,14 @@ def configure_release_jobs(
             job_name, job_config = configure_import_package_job(
                 config_url, rosdistro_name, release_build_name,
                 config=config, build_file=build_file, jenkins=jenkins, dry_run=dry_run)
-            if not jenkins:
+            if jenkins is False:
                 all_job_configs[job_name] = job_config
             break
 
     job_name, job_config = configure_sync_packages_to_main_job(
         config_url, rosdistro_name, release_build_name,
         config=config, build_file=build_file, jenkins=jenkins, dry_run=dry_run)
-    if not jenkins:
+    if jenkins is False:
         all_job_configs[job_name] = job_config
 
     for os_name, os_code_name in platforms:
@@ -161,7 +161,7 @@ def configure_release_jobs(
                 os_name, os_code_name, arch,
                 config=config, build_file=build_file, jenkins=jenkins,
                 dry_run=dry_run)
-            if not jenkins:
+            if jenkins is False:
                 all_job_configs[job_name] = job_config
 
     targets = []
@@ -172,7 +172,7 @@ def configure_release_jobs(
     views = configure_release_views(
         jenkins, rosdistro_name, release_build_name, targets,
         dry_run=dry_run)
-    if not jenkins:
+    if jenkins is False:
         all_view_configs.update(views)
     groovy_data = {
         'dry_run': dry_run,

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -519,7 +519,7 @@ def configure_release_job(
         is_disabled=is_source_disabled,
         other_build_files_same_platform=other_build_files_same_platform)
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-    if isinstance(jenkins, object) and jenkins is not False:
+    if isinstance(jenkins, object) and jenkins is not None:
         from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, source_job_name, job_config, dry_run=dry_run)
     source_job_names.append(source_job_name)
@@ -561,7 +561,7 @@ def configure_release_job(
             cached_pkgs=cached_pkgs, upstream_job_names=upstream_job_names,
             is_disabled=is_disabled)
         # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-        if isinstance(jenkins, object) and jenkins is not False:
+        if isinstance(jenkins, object) and jenkins is not None:
             configure_job(jenkins, job_name, job_config, dry_run=dry_run)
         binary_job_names.append(job_name)
         job_configs[job_name] = job_config
@@ -784,7 +784,7 @@ def configure_import_package_job(
     job_config = _get_import_package_job_config(build_file, package_format)
 
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-    if isinstance(jenkins, object) and jenkins is not False:
+    if isinstance(jenkins, object) and jenkins is not None:
         from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, job_name, job_config, dry_run=dry_run)
     return (job_name, job_config)
@@ -827,7 +827,7 @@ def configure_sync_packages_to_testing_job(
         arch, config, build_file)
 
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-    if isinstance(jenkins, object) and jenkins is not False:
+    if isinstance(jenkins, object) and jenkins is not None:
         from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, job_name, job_config, dry_run=dry_run)
     return (job_name, job_config)
@@ -895,7 +895,7 @@ def configure_sync_packages_to_main_job(
         rosdistro_name, build_file, package_format)
 
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
-    if isinstance(jenkins, object) and jenkins is not False:
+    if isinstance(jenkins, object) and jenkins is not None:
         from ros_buildfarm.jenkins import configure_job
         configure_job(jenkins, job_name, job_config, dry_run=dry_run)
     return (job_name, job_config)


### PR DESCRIPTION
There's a malinteraction with the jenkinsapi library and Python convention which has been causing extremely large HTTP requests whenever the truthiness of an instance of the Jenkins class is tested.

Jenkins defines a `__len__` method which is used to determine truthiness. But this method triggers a fetch of every job on our Jenkins host which can take 2 - 5 minutes to return due to the sheer volume of jobs.

By avoiding this in favor of an explicit check of `is False` or `is None` as appropriate we can save taking a really big runtime hit and cut down on spurious failures due to timeouts.

By default the jenkinsapi Jenkins class will trigger an eager loading of all Jenkins jobs via the API. Our Jenkins server buckles under the weight of this and so we do not want to do this until we need to and ideally future changes will replace unfiltered polling completely. In order to prevent an initial poll when we first create the local Jenkins instance we also set the `lazy` kwarg.