### PR TITLE
Clean up any dangling cidfiles (Container ID files) in workspace.

### DIFF
--- a/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_independent_docker_job.xml.em
@@ -75,7 +75,8 @@
       'rm -fr $WORKSPACE/repositories',
       'mkdir -p $WORKSPACE/repositories',
       'rm -fr $WORKSPACE/docker_generating_docker',
-      'mkdir -p $WORKSPACE/docker_generating_docker'
+      'mkdir -p $WORKSPACE/docker_generating_docker',
+      'rm -f $WORKSPACE/*.cid',
     ])
 ))@
 @(SNIPPET(


### PR DESCRIPTION
We previously built container images in a `docker_containers` subdirectory, but that directory and its cleanup were removed in #881 which results in the cidfile left in workspace between runs.