### PR TITLE
Stop testing Python 3.5 support.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['3.5', '3.6']
+        python: ['3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['3.5', '3.6']
+        python: ['3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['3.5', '3.6']
+        python: ['3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['3.5', '3.6']
+        python: ['3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['3.5', '3.6']
+        python: ['3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -173,7 +173,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['3.5', '3.6']
+        python: ['3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -193,7 +193,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['3.5', '3.6']
+        python: ['3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2
@@ -210,7 +210,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['3.5', '3.6']
+        python: ['3.6']
     steps:
       - name: Check out project
         uses: actions/checkout@v2


### PR DESCRIPTION
Immediately motivated by these builds breaking on GitHub Actions: https://github.com/actions/setup-python/issues/866 but we also do not need to support Ubuntu 16.04 any longer.

I think we should do one more release of ros_buildfarm, if possible, before allowing e.g. f-strings and other newer language features. But if ever there was a repo that wanted f-strings it's this one.