### PR TITLE
Use tar and ssh to publish package metadata files.

### DIFF
--- a/ros_buildfarm/templates/doc/doc_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_job.xml.em
@@ -254,7 +254,7 @@ else:
     'builder_shell',
     script='\n'.join([
         'echo "# BEGIN SECTION: Publish package metadata"',
-        'pushd "$WORKSPACE/generated_documentation"',
+        'cd "$WORKSPACE/generated_documentation"',
         'truncate -s 0 put_metadata',
         'echo "put api/**/manifest.yaml" >> put_metadata',
         'echo "put api/**/stamp" >> put_metadata',
@@ -267,7 +267,6 @@ else:
         'echo "bye" >> put_metadata',
         'sftp %s@%s:%s -b put_metadata' % \
           (upload_user, upload_host, os.path.join(upload_root, rosdistro_name)),
-        'popd',
         'echo "# END SECTION"',
         'if [ -d "$WORKSPACE/generated_documentation/api_rosdoc" ]; then',
         '  echo "# BEGIN SECTION: rsync API documentation to server"',

--- a/ros_buildfarm/templates/doc/doc_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_job.xml.em
@@ -255,17 +255,18 @@ else:
     script='\n'.join([
         'echo "# BEGIN SECTION: Publish package metadata"',
         'cd "$WORKSPACE/generated_documentation"',
-        'truncate -s 0 put_metadata',
-        'echo "put api/**/manifest.yaml" >> put_metadata',
-        'echo "put api/**/stamp" >> put_metadata',
-        'echo "put changelogs/**/*.html" >> put_metadata',
-        'echo "put symbols/*.tag" >> put_metadata',
-        'echo "put deps/*" >> put_metadata',
-        'echo "put hashes/*" >> put_metadata',
-        'echo "put locations/*" >> put_metadata',
-        'echo "put metapackage_deps/*" >> put_metadata',
-        'echo "bye" >> put_metadata',
-        'sftp %s@%s:%s -b put_metadata' % \
+        "ssh -T %s@%s 'test -d %s  || mkdir %s'" % \
+          (upload_user, upload_host, os.path.join(upload_root, rosdistro_name), os.path.join(upload_root, rosdistro_name)),
+        'tar -cz $(find -regextype posix-egrep' +
+        " -regex '\./api(/.+)?/manifest\.yaml'" +
+        " -o -regex '\./api(/.+)?/stamp'" +
+        " -o -regex '\./changelogs(/.+)?/[^/]+\.html'" +
+        " -o -regex '\./symbols/[^/]+\.tag'" +
+        " -o -regex '\./deps/[^/]+'" +
+        " -o -regex '\./hashes/[^/]+'" +
+        " -o -regex '\./locations/[^/]+'" +
+        " -o -regex '\./metapackage_deps/[^/]+')" +
+        ' | ssh -T %s@%s tar -C %s -xz' % \
           (upload_user, upload_host, os.path.join(upload_root, rosdistro_name)),
         'echo "# END SECTION"',
         'if [ -d "$WORKSPACE/generated_documentation/api_rosdoc" ]; then',

--- a/ros_buildfarm/templates/doc/doc_job.xml.em
+++ b/ros_buildfarm/templates/doc/doc_job.xml.em
@@ -251,25 +251,24 @@ else:
     ]),
 ))@
 @(SNIPPET(
-    'builder_publish-over-ssh',
-    config_name='docs',
-    remote_directory=rosdistro_name,
-    source_files=[
-        'generated_documentation/api/**/manifest.yaml',
-        'generated_documentation/api/**/stamp',
-        'generated_documentation/changelogs/**/*.html',
-        'generated_documentation/symbols/*.tag',
-
-        'generated_documentation/deps/*',
-        'generated_documentation/hashes/*',
-        'generated_documentation/locations/*',
-        'generated_documentation/metapackage_deps/*',
-    ],
-    remove_prefix='generated_documentation',
-))@
-@(SNIPPET(
     'builder_shell',
     script='\n'.join([
+        'echo "# BEGIN SECTION: Publish package metadata"',
+        'pushd "$WORKSPACE/generated_documentation"',
+        'truncate -s 0 put_metadata',
+        'echo "put api/**/manifest.yaml" >> put_metadata',
+        'echo "put api/**/stamp" >> put_metadata',
+        'echo "put changelogs/**/*.html" >> put_metadata',
+        'echo "put symbols/*.tag" >> put_metadata',
+        'echo "put deps/*" >> put_metadata',
+        'echo "put hashes/*" >> put_metadata',
+        'echo "put locations/*" >> put_metadata',
+        'echo "put metapackage_deps/*" >> put_metadata',
+        'echo "bye" >> put_metadata',
+        'sftp %s@%s:%s -b put_metadata' % \
+          (upload_user, upload_host, os.path.join(upload_root, rosdistro_name)),
+        'popd',
+        'echo "# END SECTION"',
         'if [ -d "$WORKSPACE/generated_documentation/api_rosdoc" ]; then',
         '  echo "# BEGIN SECTION: rsync API documentation to server"',
         '  cd $WORKSPACE/generated_documentation/api_rosdoc',


### PR DESCRIPTION
The publish-over-ssh plugin adds an extra configuration step that's hard to manage securely as it does not use the Jenkins ssh-agent and credential system, nor does it support openssh formatted or ed22519 keys, unlike the Jenkins private key credential.

Although it requires a bit more finagling ourselves, I think this is an equally valid way to publish this content which only requires one copy of the ssh private key in the ssh-agent and not an out-of-band system.

I chose sftp over rsync in order to batch the transfers of these smaller files without doing wildly long rsync commands.