### PR TITLE
Add new seccomp warning text to ignore pattern.

### DIFF
--- a/ros_buildfarm/templates/snippet/builder_system-groovy_extract-warnings.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy_extract-warnings.xml.em
@@ -15,7 +15,7 @@ try {
   r = build.getLogReader()
   br = new BufferedReader(r)
   pattern = Pattern.compile(".*WARNING:.*")
-  ignore_pattern = Pattern.compile(".*WARNING: (You're not using the default seccomp profile|No swap limit support).*")
+  ignore_pattern = Pattern.compile(".*WARNING: (You're not using the default seccomp profile|daemon is not using the default seccomp profile|No swap limit support).*")
   def warnings = []
   def line
   while ((line = br.readLine()) != null) {


### PR DESCRIPTION
Recent versions of docker give a slightly different seccomp warning.

Before example: 
```
08:24:05 # BEGIN SECTION: Look for warnings
08:24:05 Found 1 warnings:
08:24:05 
08:24:05 - WARNING: daemon is not using the default seccomp profile
08:24:05 
08:24:05 Marking build as unstable
```

After example:
```
08:24:50 # BEGIN SECTION: Look for warnings
08:24:50 No warnings found
08:24:50 # END SECTION
```