### PR TITLE
Additional fixes for RPM triggers for upload jobs

### DIFF
--- a/ros_buildfarm/scripts/release/generate_release_trigger_upload_jobs.py
+++ b/ros_buildfarm/scripts/release/generate_release_trigger_upload_jobs.py
@@ -17,13 +17,14 @@ import sys
 
 from ros_buildfarm.argument import add_argument_config_url
 from ros_buildfarm.argument import add_argument_dry_run
-from ros_buildfarm.common import get_release_job_prefix
 from ros_buildfarm.common import JobValidationError
 from ros_buildfarm.common import package_format_mapping
 from ros_buildfarm.config import get_index
 from ros_buildfarm.config import get_release_build_files
 from ros_buildfarm.jenkins import configure_job
 from ros_buildfarm.jenkins import connect
+from ros_buildfarm.release_job import get_sync_packages_to_main_job_name
+from ros_buildfarm.release_job import get_sync_packages_to_testing_job_name
 from ros_buildfarm.templates import expand_template
 
 
@@ -82,28 +83,24 @@ def get_upstream_job_names(config, repo):
         for rosdistro, package_formats in package_formats_per_rosdistro.items():
             for package_format in package_formats:
                 upstream_job_names.append(
-                    '{0}_sync-packages-to-{1}{2}'.format(
-                        get_release_job_prefix(rosdistro), repo,
-                        '' if package_format == 'deb' else '-' + package_format))
+                    get_sync_packages_to_main_job_name(rosdistro, package_format))
     elif repo == 'testing':
         for rosdistro in distributions:
-            architectures_by_code_name = {}
+            platforms = {}
             build_files = get_release_build_files(config, rosdistro)
             for build_file in build_files.values():
                 for os_name in build_file.targets.keys():
+                    platforms.setdefault(os_name, {})
                     for code_name, architectures in build_file.targets[os_name].items():
-                        architectures_by_code_name[code_name] = \
-                            architectures_by_code_name.get(code_name, set()) | \
-                            set(architectures.keys())
+                        platforms[os_name].setdefault(code_name, set())
+                        platforms[os_name][code_name].update(architectures.keys())
 
-            for code_name, archs in architectures_by_code_name.items():
-                for arch in archs:
-                    upstream_job_names.append(
-                        '{prefix}_sync-packages-to-{repo}_{code_name}_{arch}'.format(
-                            prefix=get_release_job_prefix(rosdistro),
-                            repo=repo,
-                            code_name=code_name,
-                            arch=arch))
+            for os_name, code_names in platforms.items():
+                for code_name, architectures in code_names.items():
+                    for arch in architectures:
+                        upstream_job_names.append(
+                            get_sync_packages_to_testing_job_name(
+                                rosdistro, os_name, code_name, arch))
     else:
         raise JobValidationError("Unknown upstream jobs for job 'upload_{}'." % repo)
     for package_format in set(


### PR DESCRIPTION
It turns out that the format of the sync-to-testing job names is even more complicated than what was constructed here, so we were still adding incorrect job names there. The previous update to this function didn't regress that, but it also didn't fix it.

It turns out that there are functions to just do the formatting for us, so we should just use that.

Follow-up to #1052

Here's the diff, note that `rhel_` now appears in the RHEL job names.
```
Skipped 'upload_main' because the config is the same (dry run)
Updating job 'upload_testing' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -26 +26 @@
    -      <upstreamProjects>Hrel_sync-packages-to-testing_8_x86_64,Hrel_sync-packages-to-testing_jammy_amd64,Hrel_sync-packages-to-testing_jammy_arm64,Irel_sync-packages-to-testing_9_x86_64,Irel_sync-packages-to-testing_jammy_amd64,Irel_sync-packages-to-testing_jammy_arm64,Jrel_sync-packages-to-testing_9_x86_64,Jrel_sync-packages-to-testing_noble_amd64,Jrel_sync-packages-to-testing_noble_arm64,Rrel_sync-packages-to-testing_9_x86_64,Rrel_sync-packages-to-testing_noble_amd64,Rrel_sync-packages-to-testing_noble_arm64,import_upstream,import_upstream_rpm</upstreamProjects>
    +      <upstreamProjects>Hrel_sync-packages-to-testing_jammy_amd64,Hrel_sync-packages-to-testing_jammy_arm64,Hrel_sync-packages-to-testing_rhel_8_x86_64,Irel_sync-packages-to-testing_jammy_amd64,Irel_sync-packages-to-testing_jammy_arm64,Irel_sync-packages-to-testing_rhel_9_x86_64,Jrel_sync-packages-to-testing_noble_amd64,Jrel_sync-packages-to-testing_noble_arm64,Jrel_sync-packages-to-testing_rhel_9_x86_64,Rrel_sync-packages-to-testing_noble_amd64,Rrel_sync-packages-to-testing_noble_arm64,Rrel_sync-packages-to-testing_rhel_9_x86_64,import_upstream,import_upstream_rpm</upstreamProjects>
    >>>
```