### PR TITLE
Add support for custom_rosdep_urls in build files

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -597,3 +597,15 @@ The following options are valid in version ``1`` (beside the generic options):
   to, if desired.
   By default, the resulting archives are only available to other jobs within
   Jenkins.
+
+The following options are valid as keys in the ``_config`` dict under
+``targets``:
+
+* ``custom_rosdep_urls``: a list of URLs containing rosdep sources.list.d entry
+  files that are downloaded into /etc/ros/rosdep/sources.list.d at the beginning
+  of the doc job after running *rosdep init*.
+  Note that *rosdep init* will add the 20-default.list file from the public
+  rosdistro by default.
+  To override this, add an entry to this list corresponding to the
+  20-default.list file from your forked rosdistro repository.
+

--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -284,6 +284,7 @@ def _get_ci_job_config(
         'repository_names': repository_names,
         'package_names': package_names,
         'package_dependencies': package_dependencies,
+        'custom_rosdep_urls': build_file.custom_rosdep_urls,
 
         'skip_rosdep_keys': build_file.skip_rosdep_keys,
         'install_packages': build_file.install_packages,

--- a/ros_buildfarm/config/build_file.py
+++ b/ros_buildfarm/config/build_file.py
@@ -73,6 +73,14 @@ class BuildFile(object):
                     self.targets[os_name][os_code_name][arch] = \
                         data['targets'][os_name][os_code_name][arch]
 
+        self.custom_rosdep_urls = []
+        if '_config' in data['targets']:
+            if 'custom_rosdep_urls' in data['targets']['_config']:
+                self.custom_rosdep_urls = \
+                    data['targets']['_config']['custom_rosdep_urls']
+                assert isinstance(self.custom_rosdep_urls, list)
+
+
         self.shared_ccache = False
         if 'shared_ccache' in data:
             self.shared_ccache = bool(data['shared_ccache'])

--- a/ros_buildfarm/config/build_file.py
+++ b/ros_buildfarm/config/build_file.py
@@ -80,7 +80,6 @@ class BuildFile(object):
                     data['targets']['_config']['custom_rosdep_urls']
                 assert isinstance(self.custom_rosdep_urls, list)
 
-
         self.shared_ccache = False
         if 'shared_ccache' in data:
             self.shared_ccache = bool(data['shared_ccache'])

--- a/ros_buildfarm/config/build_file.py
+++ b/ros_buildfarm/config/build_file.py
@@ -63,20 +63,15 @@ class BuildFile(object):
             assert isinstance(self.tag_blacklist, list)
 
         self.targets = {}
-        self.custom_rosdep_urls = []
         for os_name in data.get('targets', {}).keys():
             if os_name == '_config':
-                if 'custom_rosdep_urls' in data['targets']['_config']:
-                    self.custom_rosdep_urls = \
-                        data['targets']['_config']['custom_rosdep_urls']
-                    assert isinstance(self.custom_rosdep_urls, list)
-            else:
-                self.targets[os_name] = {}
-                for os_code_name in data['targets'][os_name].keys():
-                    self.targets[os_name][os_code_name] = {}
-                    for arch in data['targets'][os_name][os_code_name].keys():
-                        self.targets[os_name][os_code_name][arch] = \
-                            data['targets'][os_name][os_code_name][arch]
+                continue
+            self.targets[os_name] = {}
+            for os_code_name in data['targets'][os_name].keys():
+                self.targets[os_name][os_code_name] = {}
+                for arch in data['targets'][os_name][os_code_name].keys():
+                    self.targets[os_name][os_code_name][arch] = \
+                        data['targets'][os_name][os_code_name][arch]
 
         self.shared_ccache = False
         if 'shared_ccache' in data:

--- a/ros_buildfarm/config/build_file.py
+++ b/ros_buildfarm/config/build_file.py
@@ -63,22 +63,19 @@ class BuildFile(object):
             assert isinstance(self.tag_blacklist, list)
 
         self.targets = {}
+        self.custom_rosdep_urls = []
         for os_name in data.get('targets', {}).keys():
             if os_name == '_config':
-                continue
+                if 'custom_rosdep_urls' in data['targets']['_config']:
+                    self.custom_rosdep_urls = \
+                        data['targets']['_config']['custom_rosdep_urls']
+                    assert isinstance(self.custom_rosdep_urls, list)
             self.targets[os_name] = {}
             for os_code_name in data['targets'][os_name].keys():
                 self.targets[os_name][os_code_name] = {}
                 for arch in data['targets'][os_name][os_code_name].keys():
                     self.targets[os_name][os_code_name][arch] = \
                         data['targets'][os_name][os_code_name][arch]
-
-        self.custom_rosdep_urls = []
-        if '_config' in data['targets']:
-            if 'custom_rosdep_urls' in data['targets']['_config']:
-                self.custom_rosdep_urls = \
-                    data['targets']['_config']['custom_rosdep_urls']
-                assert isinstance(self.custom_rosdep_urls, list)
 
         self.shared_ccache = False
         if 'shared_ccache' in data:

--- a/ros_buildfarm/config/build_file.py
+++ b/ros_buildfarm/config/build_file.py
@@ -70,12 +70,13 @@ class BuildFile(object):
                     self.custom_rosdep_urls = \
                         data['targets']['_config']['custom_rosdep_urls']
                     assert isinstance(self.custom_rosdep_urls, list)
-            self.targets[os_name] = {}
-            for os_code_name in data['targets'][os_name].keys():
-                self.targets[os_name][os_code_name] = {}
-                for arch in data['targets'][os_name][os_code_name].keys():
-                    self.targets[os_name][os_code_name][arch] = \
-                        data['targets'][os_name][os_code_name][arch]
+            else:
+                self.targets[os_name] = {}
+                for os_code_name in data['targets'][os_name].keys():
+                    self.targets[os_name][os_code_name] = {}
+                    for arch in data['targets'][os_name][os_code_name].keys():
+                        self.targets[os_name][os_code_name][arch] = \
+                            data['targets'][os_name][os_code_name][arch]
 
         self.shared_ccache = False
         if 'shared_ccache' in data:

--- a/ros_buildfarm/config/ci_build_file.py
+++ b/ros_buildfarm/config/ci_build_file.py
@@ -152,3 +152,10 @@ class CIBuildFile(BuildFile):
         self.upload_directory = None
         if 'upload_directory' in data:
             self.upload_directory = data['upload_directory']
+
+        self.custom_rosdep_urls = []
+        if '_config' in data['targets']:
+            if 'custom_rosdep_urls' in data['targets']['_config']:
+                self.custom_rosdep_urls = \
+                    data['targets']['_config']['custom_rosdep_urls']
+                assert isinstance(self.custom_rosdep_urls, list)

--- a/ros_buildfarm/scripts/ci/create_workspace_task_generator.py
+++ b/ros_buildfarm/scripts/ci/create_workspace_task_generator.py
@@ -19,9 +19,9 @@ from urllib.request import urlretrieve
 
 from apt import Cache
 from ros_buildfarm.argument import add_argument_arch
+from ros_buildfarm.argument import add_argument_custom_rosdep_urls
 from ros_buildfarm.argument import \
     add_argument_distribution_repository_key_files
-from ros_buildfarm.argument import add_argument_custom_rosdep_urls
 from ros_buildfarm.argument import add_argument_distribution_repository_urls
 from ros_buildfarm.argument import add_argument_dockerfile_dir
 from ros_buildfarm.argument import add_argument_env_vars

--- a/ros_buildfarm/scripts/ci/create_workspace_task_generator.py
+++ b/ros_buildfarm/scripts/ci/create_workspace_task_generator.py
@@ -21,6 +21,7 @@ from apt import Cache
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import \
     add_argument_distribution_repository_key_files
+from ros_buildfarm.argument import add_argument_custom_rosdep_urls
 from ros_buildfarm.argument import add_argument_distribution_repository_urls
 from ros_buildfarm.argument import add_argument_dockerfile_dir
 from ros_buildfarm.argument import add_argument_env_vars
@@ -50,6 +51,7 @@ def main(argv=sys.argv[1:]):
     add_argument_os_code_name(parser)
     add_argument_arch(parser)
 
+    add_argument_custom_rosdep_urls(parser)
     add_argument_distribution_repository_key_files(parser)
     add_argument_distribution_repository_urls(parser)
     add_argument_dockerfile_dir(parser)
@@ -105,7 +107,7 @@ def main(argv=sys.argv[1:]):
 
         'rosdistro_name': args.rosdistro_name,
 
-        'custom_rosdep_urls': [],
+        'custom_rosdep_urls': args.custom_rosdep_urls,
 
         'uid': get_user_id(),
 

--- a/ros_buildfarm/scripts/ci/run_ci_job.py
+++ b/ros_buildfarm/scripts/ci/run_ci_job.py
@@ -24,6 +24,7 @@ from ros_buildfarm.argument import add_argument_build_tool_args
 from ros_buildfarm.argument import add_argument_build_tool_test_args
 from ros_buildfarm.argument import \
     add_argument_distribution_repository_key_files
+from ros_buildfarm.argument import add_argument_custom_rosdep_urls
 from ros_buildfarm.argument import add_argument_distribution_repository_urls
 from ros_buildfarm.argument import add_argument_dockerfile_dir
 from ros_buildfarm.argument import add_argument_env_vars
@@ -56,6 +57,7 @@ def main(argv=sys.argv[1:]):
     add_argument_arch(parser)
 
     add_argument_build_tool(parser, required=True)
+    add_argument_custom_rosdep_urls(parser)
     add_argument_distribution_repository_key_files(parser)
     add_argument_distribution_repository_urls(parser)
     add_argument_dockerfile_dir(parser)

--- a/ros_buildfarm/scripts/ci/run_ci_job.py
+++ b/ros_buildfarm/scripts/ci/run_ci_job.py
@@ -22,9 +22,9 @@ from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_tool
 from ros_buildfarm.argument import add_argument_build_tool_args
 from ros_buildfarm.argument import add_argument_build_tool_test_args
+from ros_buildfarm.argument import add_argument_custom_rosdep_urls
 from ros_buildfarm.argument import \
     add_argument_distribution_repository_key_files
-from ros_buildfarm.argument import add_argument_custom_rosdep_urls
 from ros_buildfarm.argument import add_argument_distribution_repository_urls
 from ros_buildfarm.argument import add_argument_dockerfile_dir
 from ros_buildfarm.argument import add_argument_env_vars

--- a/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
@@ -80,6 +80,7 @@ cmds = [
     ' --repository-names ' + ' '.join(repository_names) + \
     ((' --package-names ' + ' '.join(package_names)) if package_names else '') + \
     (' --package-dependencies' if package_dependencies else '') + \
+    ' --custom_rosdep_urls '  + ' '.join(custom_rosdep_urls) + \
     ' --test-branch "%s"' % (test_branch) + \
     ' --skip-rosdep-keys ' + ' '.join(skip_rosdep_keys) + \
     ' --package-selection-args ' + ' '.join(package_selection_args),

--- a/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
@@ -80,7 +80,7 @@ cmds = [
     ' --repository-names ' + ' '.join(repository_names) + \
     ((' --package-names ' + ' '.join(package_names)) if package_names else '') + \
     (' --package-dependencies' if package_dependencies else '') + \
-    ' --custom_rosdep_urls '  + ' '.join(custom_rosdep_urls) + \
+    ' --custom-rosdep-urls '  + ' '.join(custom_rosdep_urls) + \
     ' --test-branch "%s"' % (test_branch) + \
     ' --skip-rosdep-keys ' + ' '.join(skip_rosdep_keys) + \
     ' --package-selection-args ' + ' '.join(package_selection_args),

--- a/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
@@ -72,7 +72,7 @@ RUN echo "@today_str"
 ))@
 
 # needed for 'vcs custom --git --args merge' invocation
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q --no-install-recommends sudo
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q --no-install-recommends sudo wget
 RUN sudo -H -u buildfarm -- git config --global user.email "jenkins@@ros.invalid" && sudo -H -u buildfarm -- git config --global user.name "Jenkins ROS"
 
 @(TEMPLATE(

--- a/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/create_workspace.Dockerfile.em
@@ -72,7 +72,7 @@ RUN echo "@today_str"
 ))@
 
 # needed for 'vcs custom --git --args merge' invocation
-RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q --no-install-recommends sudo wget
+RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y --no-install-recommends sudo wget
 RUN sudo -H -u buildfarm -- git config --global user.email "jenkins@@ros.invalid" && sudo -H -u buildfarm -- git config --global user.name "Jenkins ROS"
 
 @(TEMPLATE(


### PR DESCRIPTION
In addition to the existing support of the parameter `custom_rosdep_urls` for the doc and source files, the PR adds the support for the build files so it can be used for things like nightly jobs.

I tested it here https://citest.build.osrfoundation.org/view/Rci/job/Rci__nightly-release_ubuntu_noble_amd64/26/ which builds gz-rendering8 (outside of ROS) using the packages.osrfoundation.org repository and an external rosdep rule to resolve `libogre-next-2.3-dev` to the package of the same name hosted in packages.o.o.