### PR TITLE
Add !relative_url YAML constructor

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -10,6 +10,20 @@ example and can be found on
 `GitHub (ros-infrastructure/ros_buildfarm_config) <https://github.com/ros-infrastructure/ros_buildfarm_config>`_.
 
 
+Special YAML tags
+-----------------
+
+YAML tags can be used to treat certain data in the configuration different.
+
+The following special tags are available in ROS build farm configuration
+files:
+
+* ``!include``: parse the YAML file at the given relative URL and include it
+  under the node where the tag was found.
+* ``!relative_url``: resolve the given relative URL to an absolute URL based
+  from the file in which the tag was found.
+
+
 Entry point yaml
 ----------------
 

--- a/ros_buildfarm/config/__init__.py
+++ b/ros_buildfarm/config/__init__.py
@@ -38,16 +38,22 @@ def load_yaml(url):
     # Resolve relative file paths from CWD
     url = urljoin('file://' + os.getcwd() + '/', url)
 
-    class SafeLoaderWithInclude(yaml.SafeLoader):
+    class BuildfarmConfigSafeLoader(yaml.SafeLoader):
 
         def include(self, node):
-            include_url = urljoin(url, self.construct_scalar(node))
+            include_url = self.relative_url(node)
             return load_yaml(include_url)
 
-    SafeLoaderWithInclude.add_constructor('!include', SafeLoaderWithInclude.include)
+        def relative_url(self, node):
+            return urljoin(url, self.construct_scalar(node))
+
+    BuildfarmConfigSafeLoader.add_constructor(
+        '!include', BuildfarmConfigSafeLoader.include)
+    BuildfarmConfigSafeLoader.add_constructor(
+        '!relative_url', BuildfarmConfigSafeLoader.relative_url)
 
     yaml_str = load_url(url)
-    return yaml.load(yaml_str, SafeLoaderWithInclude)
+    return yaml.load(yaml_str, BuildfarmConfigSafeLoader)
 
 
 def get_index(url):


### PR DESCRIPTION
The purpose of this constructor is to support relative URL resolution in arbitrary locations in the buildfarm's configuration YAML. Some fields in the config already implicitly do this (such as the buildfile references from the index), but this will add support for any field to contain a relative URL.

Staging deployment: https://build.test.ros2.org/job/ci__infra_ubuntu_noble_amd64/

Example use: https://github.com/ros2/ros_buildfarm_config/blob/200fcfd96aceaf2d0791682a6b16e80a59669e52/global/ci-infra.yaml#L43-L44