### PR TITLE
Don't warn of script location in rosdoc2

### DIFF
--- a/ros_buildfarm/scripts/doc/build_rosdoc2.py
+++ b/ros_buildfarm/scripts/doc/build_rosdoc2.py
@@ -54,6 +54,7 @@ def main(argv=sys.argv[1:]):
                                   '-m',
                                   'pip',
                                   'install',
+                                  '--no-warn-script-location',
                                   '.'],
                                  env=env,
                                  cwd=args.rosdoc2_dir)


### PR DESCRIPTION
Fixes #1051 which is concerned with ```WARNING: The script normalizer is installed in '/home/buildfarm/.local/bin' ```

@nuclearsandwich asked "it's also worth determining whether this warning is valid"

No, the warning is not valid. In the build step following the rosdoc2 install, the PATH is extended to include the warned-about directory.

This warning used to be repressed. That repression was removed in PR #1031, possibly inadvertently. This PR simply restores the original option.