### PR TITLE
Add test_require_gpu to ci jobs

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -598,6 +598,8 @@ The following options are valid in version ``1`` (beside the generic options):
   By default, the resulting archives are only available to other jobs within
   Jenkins.
 
+* ``tests_require_gpu``: a boolean flag to indicate if software tests needs gpu
+  support to run correctly.
 The following options are valid as keys in the ``_config`` dict under
 ``targets``:
 

--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -281,6 +281,8 @@ def _get_ci_job_config(
         'ros_version': ros_version,
         'build_environment_variables': build_environment_variables,
 
+        'require_gpu_support': build_file.tests_require_gpu_default,
+
         'timeout_minutes': build_file.jenkins_job_timeout,
 
         'repos_file_urls': repos_files,

--- a/ros_buildfarm/config/ci_build_file.py
+++ b/ros_buildfarm/config/ci_build_file.py
@@ -136,6 +136,11 @@ class CIBuildFile(BuildFile):
                     self.show_plots[plot_group].append(
                         PlotConfig(name, plot_config_data))
 
+        self.tests_require_gpu_default = False
+        if 'tests_require_gpu' in data:
+            self.tests_require_gpu_default = bool(
+                data['tests_require_gpu'])
+
         self.benchmark_patterns = []
         if 'benchmark_patterns' in data:
             self.benchmark_patterns = data['benchmark_patterns']

--- a/ros_buildfarm/scripts/ci/build_task_generator.py
+++ b/ros_buildfarm/scripts/ci/build_task_generator.py
@@ -29,7 +29,6 @@ from ros_buildfarm.argument import add_argument_env_vars
 from ros_buildfarm.argument import add_argument_install_packages
 from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
-from ros_buildfarm.argument import add_argument_require_gpu_support
 from ros_buildfarm.argument import add_argument_ros_version
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.argument import add_argument_run_abichecker
@@ -61,7 +60,6 @@ def main(argv=sys.argv[1:]):
     add_argument_install_packages(parser)
     add_argument_ros_version(parser)
     add_argument_run_abichecker(parser)
-    add_argument_require_gpu_support(parser)
     add_argument_testing(parser)
     parser.add_argument(
         '--workspace-root', nargs='+',
@@ -132,7 +130,6 @@ def main(argv=sys.argv[1:]):
 
         'testing': args.testing,
         'run_abichecker': args.run_abichecker,
-        'require_gpu_support': args.require_gpu_support,
         'workspace_root': mapped_workspaces[-1][1],
         'parent_result_space': [mapping[1] for mapping in mapped_workspaces[:-1]],
     }

--- a/ros_buildfarm/scripts/devel/build_and_test.py
+++ b/ros_buildfarm/scripts/devel/build_and_test.py
@@ -19,7 +19,6 @@ import sys
 from ros_buildfarm.argument import add_argument_build_tool
 from ros_buildfarm.argument import add_argument_build_tool_args
 from ros_buildfarm.argument import add_argument_build_tool_test_args
-from ros_buildfarm.argument import add_argument_require_gpu_support
 from ros_buildfarm.argument import add_argument_ros_version
 from ros_buildfarm.argument import extract_multiple_remainders
 from ros_buildfarm.common import Scope
@@ -58,7 +57,6 @@ def main(argv=sys.argv[1:]):
         action='store_true',
         help='The flag if the workspace should be cleaned after the '
              'invocation')
-    add_argument_require_gpu_support(parser)
 
     remainder_args = extract_multiple_remainders(argv, (a1, a2))
     args = parser.parse_args(argv)

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -421,11 +421,13 @@ parameters = [
         'export UNDERLAY%d_JOB_SPACE=$WORKSPACE/underlay%d/ros%d-linux' % (i + 1, i + 1, local_ros_version)
         for i, local_ros_version in zip(range(len(underlay_source_jobs)), [ros_version] * len(underlay_source_jobs))
     ] + [
+        ('if [ ! -c /dev/nvidia[0-9] ]; then echo "--require-gpu-support is enabled but can not detect nvidia support installed" && exit 1; fi' if require_gpu_support else ''),
         'rm -fr $WORKSPACE/ws/test_results',
         'mkdir -p $WORKSPACE/ws/test_results',
         '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
         'export PODMAN_USERNS=keep-id',
         'docker run' +
+        (' --env=DISPLAY=:0.0 --env=QT_X11_NO_MITSHM=1 --volume=/tmp/.X11-unix:/tmp/.X11-unix:rw  --gpus all' if require_gpu_support else '') +
         ' --rm ' +
         ' --cidfile=$WORKSPACE/docker_build_and_test/docker.cid' +
         ((' -e CCACHE_DIR=/home/buildfarm/.ccache' +

--- a/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
+++ b/ros_buildfarm/templates/devel/devel_task.Dockerfile.em
@@ -129,8 +129,6 @@ else:
         ' /tmp/ros_buildfarm/scripts/devel/build_and_test.py' + \
         ' --rosdistro-name %s' % (rosdistro_name or "''") + \
         ' --ros-version ' + str(ros_version)
-    if require_gpu_support:
-        cmd += ' --require-gpu-support'
 cmd += \
     ' --build-tool ' + build_tool + \
     ' --workspace-root ' + workspace_root + \


### PR DESCRIPTION
Thew PR implements the `test_require_gpu` parameter for the CI kind of jobs in the buildfarm.

The first commit 4e0466e7c09eeb4c5a514047059f123198327b13 adds the necessary code to support the `test_require_gpu` parameter in the ci build files and the docker run necessary arguments to the ci_job template when running "build and test".

The second commit d6a39c3612b3d6617fae0b8a728f1dd3cb09aa62 fixes current code existing in devel jobs used by the ci jobs.

Tested: the code was used for testing gz-rendering OpenGL tests in the testing buildfarm of the Gazebo team. https://citest.build.osrfoundation.org/view/Rci/job/Rci__nightly-release_ubuntu_noble_amd64/68/testReport/projectroot.test/integration/

P.D: there is a need to audit the existing gpu code in the devel jobs that I plan to do in a different PR.