### PR TITLE
Install ca-certificates before processing repository keys

### DIFF
--- a/ros_buildfarm/templates/snippet/add_distribution_repositories.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/add_distribution_repositories.Dockerfile.em
@@ -9,7 +9,7 @@ ubuntu_before_bionic = (
 @[if os_name == 'debian' and os_code_name not in debian_before_stretch or os_name == 'ubuntu' and os_code_name not in ubuntu_before_bionic]@
 @# In Debian Stretch apt doesn't depend on gnupg anymore
 @# https://anonscm.debian.org/cgit/apt/apt.git/commit/?id=87d468fe355c87325c943c40043a0bb236b2407f
-RUN for i in 1 2 3; do apt-get update && apt-get install -q -y gnupg && apt-get clean && break || if [ $i -lt 3 ]; then sleep 5; else false; fi; done
+RUN for i in 1 2 3; do apt-get update && apt-get install -q -y gnupg ca-certificates && apt-get clean && break || if [ $i -lt 3 ]; then sleep 5; else false; fi; done
 @[end if]@
 @[for i, key in enumerate(distribution_repository_keys)]@
 RUN echo "@('\\n'.join(key.splitlines()))" > /tmp/keys/@(i).key && apt-key add /tmp/keys/@(i).key


### PR DESCRIPTION
Detected the problem while installing the packages.o.o key in testing for the Jammy distribution, not happening on Noble.

 
https://citest.build.osrfoundation.org/view/ci/job/ci__colcon_gpu_any-manual_ubuntu_jammy_amd64/4/console
```
....
 > [18/21] RUN python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y git python3-apt python3-empy python3-yaml:
235.0 W: https://packages.osrfoundation.org/gazebo/ubuntu-stable/dists/jammy/InRelease: No system certificates available. Try installing ca-certificates.
235.0 W: http://repos.ros.org/repos/ros_bootstrap/dists/jammy/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
235.0 W: https://packages.osrfoundation.org/gazebo/ubuntu-stable/dists/jammy/InRelease: No system certificates available. Try installing ca-certificates.
235.0 W: https://packages.osrfoundation.org/gazebo/ubuntu-stable/dists/jammy/InRelease: No system certificates available. Try installing ca-certificates.
235.0 W: https://packages.osrfoundation.org/gazebo/ubuntu-stable/dists/jammy/InRelease: No system certificates available. Try installing ca-certificates.
235.0 W: Failed to fetch https://packages.osrfoundation.org/gazebo/ubuntu-stable/dists/jammy/InRelease  Certificate verification failed: The certificate is NOT trusted. The certificate issuer is unknown.  Could not handshake: Error in the certificate verification. [IP: 52.52.171.73 443]
```

The certificate issuer is unknown for the vanilla Jammy system. I solved the problem by installing the `ca-certificates` before installing the packages.o.o repo.