### PR TITLE
Add per-package configuration for release binary job weight

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -199,6 +199,11 @@ The following options are valid in version ``2`` (beside the generic options):
 * ``jenkins_source_job_priority``: the job priority of *source* jobs.
 * ``jenkins_source_job_timeout``: the job timeout for *source* jobs.
 
+* ``jenkins_binary_job_weight_override``: per-package override of the number of
+  executors on a worker which are required to execute a job.
+  All jobs default to ``1``.
+  Uses the Jenkins Heavy Job plugin.
+
 * ``notifications``: a dictionary with the following keys:
 
   * ``emails``: a list of static email addresses.

--- a/ros_buildfarm/config/release_build_file.py
+++ b/ros_buildfarm/config/release_build_file.py
@@ -69,6 +69,11 @@ class ReleaseBuildFile(BuildFile):
             self.jenkins_source_job_timeout = \
                 int(data['jenkins_source_job_timeout'])
 
+        self.jenkins_binary_job_weight_overrides = {}
+        if 'jenkins_binary_job_weight_overrides' in data:
+            self.jenkins_binary_job_weight_overrides = data['jenkins_binary_job_weight_overrides']
+            assert isinstance(self.jenkins_binary_job_weight_overrides, dict)
+
         self.package_whitelist = []
         if 'package_whitelist' in data and data['package_whitelist']:
             self.package_whitelist = data['package_whitelist']

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -719,6 +719,7 @@ def _get_binarydeb_job_config(
         'github_url': get_github_project_url(release_repository.url),
 
         'job_priority': build_file.jenkins_binary_job_priority,
+        'job_weight': build_file.jenkins_binary_job_weight_overrides.get(pkg_name),
         'node_label': get_node_label(
             build_file.jenkins_binary_job_label,
             get_default_node_label('%s_%s%s_%s' % (

--- a/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
@@ -40,6 +40,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 ))@
 @(SNIPPET(
     'property_job-weight',
+    weight=job_weight,
 ))@
   </properties>
 @(SNIPPET(


### PR DESCRIPTION
This new configuration parameter will allow us to specify a larger job weight for a manually curated list of binary package jobs.

Example config change:
```yaml
jenkins_binary_job_weight_overrides:
  openvdb_vendor: 4
```

Example job diff:
```
Updating job 'Jbin_uN64__openvdb_vendor__ubuntu_noble_amd64__binary' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -39 +39 @@
    -      <weight>1</weight>
    +      <weight>4</weight>
    >>>
```

Open question: should we support a similar thing for:
* other job types
* timeout overrides