### PR TITLE
Add mechanism for specifying additional arguments to 'docker run'

### DIFF
--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -160,6 +160,13 @@ def add_argument_dockerfile_dir(parser):
         help="The directory where the 'Dockerfile' will be generated")
 
 
+def add_argument_docker_run_args(parser):
+    parser.add_argument(
+        '--docker-run-args',
+        nargs=argparse.REMAINDER,
+        help="Arbitrary arguments passed to 'docker run' invocations.")
+
+
 def add_argument_debian_repository_urls(parser, nargs='+'):
     parser.add_argument(
         'debian_repository_urls',

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -403,7 +403,8 @@ def configure_release_job(
         is_disabled=False, other_build_files_same_platform=None,
         groovy_script=None,
         filter_arches=None,
-        dry_run=False):
+        dry_run=False,
+        docker_run_args=None):
     """
     Configure a Jenkins release job.
 
@@ -523,7 +524,8 @@ def configure_release_job(
         config, build_file, os_name, os_code_name,
         pkg_name, repo_name, repo.release_repository, cached_pkgs=cached_pkgs,
         is_disabled=is_source_disabled,
-        other_build_files_same_platform=other_build_files_same_platform)
+        other_build_files_same_platform=other_build_files_same_platform,
+        docker_run_args=docker_run_args)
     # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
     if isinstance(jenkins, object) and jenkins is not False:
         from ros_buildfarm.jenkins import configure_job
@@ -565,7 +567,7 @@ def configure_release_job(
             config, build_file, os_name, os_code_name, arch,
             pkg_name, repo_name, repo.release_repository,
             cached_pkgs=cached_pkgs, upstream_job_names=upstream_job_names,
-            is_disabled=is_disabled)
+            is_disabled=is_disabled, docker_run_args=docker_run_args)
         # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
         if isinstance(jenkins, object) and jenkins is not False:
             configure_job(jenkins, job_name, job_config, dry_run=dry_run)
@@ -601,7 +603,8 @@ def _get_sourcedeb_job_config(
         config_url, rosdistro_name, release_build_name,
         config, build_file, os_name, os_code_name,
         pkg_name, repo_name, release_repository, cached_pkgs=None,
-        is_disabled=False, other_build_files_same_platform=None):
+        is_disabled=False, other_build_files_same_platform=None,
+        docker_run_args=None):
     package_format = package_format_mapping[os_name]
     template_name = 'release/%s/sourcepkg_job.xml.em' % package_format
 
@@ -677,6 +680,8 @@ def _get_sourcedeb_job_config(
         'credential_id': build_file.upload_credential_id,
 
         'git_ssh_credential_id': config.git_ssh_credential_id,
+
+        'docker_run_args': docker_run_args,
     }
     job_config = expand_template(template_name, job_data)
     return job_config
@@ -687,7 +692,7 @@ def _get_binarydeb_job_config(
         config, build_file, os_name, os_code_name, arch,
         pkg_name, repo_name, release_repository,
         cached_pkgs=None, upstream_job_names=None,
-        is_disabled=False):
+        is_disabled=False, docker_run_args=None):
     package_format = package_format_mapping[os_name]
     template_name = 'release/%s/binarypkg_job.xml.em' % package_format
 
@@ -765,6 +770,8 @@ def _get_binarydeb_job_config(
         'credential_id': build_file.upload_credential_id,
 
         'shared_ccache': build_file.shared_ccache,
+
+        'docker_run_args': docker_run_args,
     }
     job_config = expand_template(template_name, job_data)
     return job_config

--- a/ros_buildfarm/scripts/release/generate_release_script.py
+++ b/ros_buildfarm/scripts/release/generate_release_script.py
@@ -21,6 +21,7 @@ from em import Hook
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_name
 from ros_buildfarm.argument import add_argument_config_url
+from ros_buildfarm.argument import add_argument_docker_run_args
 from ros_buildfarm.argument import add_argument_os_code_name
 from ros_buildfarm.argument import add_argument_os_name
 from ros_buildfarm.argument import add_argument_package_name
@@ -46,6 +47,7 @@ def main(argv=sys.argv[1:]):
         '--skip-install',
         action='store_true',
         help='Skip trying to install binarydeb')
+    add_argument_docker_run_args(parser)
     args = parser.parse_args(argv)
 
     package_format = package_format_mapping[args.os_name]
@@ -90,7 +92,8 @@ def main(argv=sys.argv[1:]):
         args.config_url, args.rosdistro_name, args.release_build_name,
         args.package_name, args.os_name, args.os_code_name,
         jenkins=False, views=[], generate_import_package_job=False,
-        generate_sync_packages_jobs=False, filter_arches=args.arch)
+        generate_sync_packages_jobs=False, filter_arches=args.arch,
+        docker_run_args=args.docker_run_args)
 
     templates.template_hooks = None
 

--- a/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/binarypkg_job.xml.em
@@ -143,6 +143,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' -v $WORKSPACE/binarydeb:/tmp/binarydeb' +
         ' -v $WORKSPACE/docker_build_binarydeb:/tmp/docker_build_binarydeb' +
         (' -v $HOME/.ccache:/home/buildfarm/.ccache' if shared_ccache else '') +
+        (' ' + ' '.join(docker_run_args) if docker_run_args else '') +
         ' binarydeb_task_generation.%s_%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
         'echo "# END SECTION"',
     ]),
@@ -179,6 +180,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/binarydeb:/tmp/binarydeb' +
         (' -v $HOME/.ccache:/home/buildfarm/.ccache' if shared_ccache else '') +
+        (' ' + ' '.join(docker_run_args) if docker_run_args else '') +
         ' binarydeb_build.%s_%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
         'echo "# END SECTION"',
     ]),
@@ -235,6 +237,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
 @#         ' --cidfile=$WORKSPACE/docker_install_binarydeb/docker.cid' +
 @#         ' -e=TRAVIS=$TRAVIS' +
 @#         ' -v $WORKSPACE/binarydeb:/tmp/binarydeb:ro' +
+@#         (' ' + ' '.join(docker_run_args) if docker_run_args else '') +
 @#         ' binarydeb_install.%s_%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
 @#         'echo "# END SECTION"',
 @#     ]),

--- a/ros_buildfarm/templates/release/deb/sourcepkg_job.xml.em
+++ b/ros_buildfarm/templates/release/deb/sourcepkg_job.xml.em
@@ -122,6 +122,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         (' -v $HOME/.ssh/known_hosts:/etc/ssh/ssh_known_hosts:ro' +
          ' -v $SSH_AUTH_SOCK:/tmp/ssh_auth_sock' +
          ' -e SSH_AUTH_SOCK=/tmp/ssh_auth_sock' if git_ssh_credential_id else '') +
+        (' ' + ' '.join(docker_run_args) if docker_run_args else '') +
         ' sourcedeb.%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, pkg_name),
         'echo "# END SECTION"',
     ]),

--- a/ros_buildfarm/templates/release/rpm/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_job.xml.em
@@ -139,6 +139,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/binarypkg:/tmp/binarypkg' +
         (' -v $HOME/.ccache:/home/buildfarm/.ccache' if shared_ccache else '') +
+        (' ' + ' '.join(docker_run_args) if docker_run_args else '') +
         ' binaryrpm.%s_%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, arch, pkg_name),
         'echo "# END SECTION"',
     ]),

--- a/ros_buildfarm/templates/release/rpm/sourcepkg_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sourcepkg_job.xml.em
@@ -118,6 +118,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' --net=host' +
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/sourcepkg:/tmp/sourcepkg' +
+        (' ' + ' '.join(docker_run_args) if docker_run_args else '') +
         ' sourcerpm.%s_%s_%s_%s' % (rosdistro_name, os_name, os_code_name, pkg_name),
         'echo "# END SECTION"',
     ]),


### PR DESCRIPTION
This change adds an escape hatch for passing additional arguments to 'docker run' invocations for release jobs. One possible motivation would be to mount local package repositories into the containers when running release jobs in script mode.