### PR TITLE
Switch to rosdistro.get_package_condition_context API

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -742,6 +742,10 @@ def filter_buildfile_packages_recursively(package_names, buildfile, rosdistro_na
 
 
 def get_package_condition_context(index, rosdistro_name):
+    warnings.warn(
+        'ros_buildfarm.common.get_package_condition_context is deprecated, '
+        'use rosdistro.get_package_condition_context instead.',
+        DeprecationWarning, stacklevel=2)
     python_version = index.distributions[rosdistro_name].get('python_version')
     ros_version = {
         'ros1': '1',

--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -19,6 +19,7 @@ try:
     from urllib.parse import urlparse
 except ImportError:
     from urlparse import urlparse
+import warnings
 
 
 package_format_mapping = {

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -26,7 +26,6 @@ from ros_buildfarm.common import get_github_project_url
 from ros_buildfarm.common import get_implicitly_ignored_package_names
 from ros_buildfarm.common import get_node_label
 from ros_buildfarm.common import get_os_package_name
-from ros_buildfarm.common import get_package_condition_context
 from ros_buildfarm.common import get_package_manifests
 from ros_buildfarm.common import get_release_binary_view_name
 from ros_buildfarm.common import get_release_job_prefix
@@ -50,6 +49,7 @@ from rosdistro import get_cached_distribution
 from rosdistro import get_distribution_cache
 from rosdistro import get_distribution_file as rosdistro_get_distribution_file
 from rosdistro import get_index
+from rosdistro import get_package_condition_context
 
 
 def configure_release_jobs(

--- a/ros_buildfarm/scripts/doc/create_doc_task_generator.py
+++ b/ros_buildfarm/scripts/doc/create_doc_task_generator.py
@@ -41,7 +41,6 @@ from ros_buildfarm.common import get_devel_job_urls
 from ros_buildfarm.common import get_distribution_repository_keys
 from ros_buildfarm.common import get_doc_job_url
 from ros_buildfarm.common import get_os_package_name
-from ros_buildfarm.common import get_package_condition_context
 from ros_buildfarm.common import get_release_job_urls
 from ros_buildfarm.common import get_user_id
 from ros_buildfarm.common import Scope
@@ -62,6 +61,7 @@ from rosdep2.catkin_support import get_catkin_view
 from rosdep2.catkin_support import resolve_for_os
 from rosdistro import get_distribution_file
 from rosdistro import get_index
+from rosdistro import get_package_condition_context
 import yaml
 
 

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,6 @@ elif 'SKIP_PYTHON_SCRIPTS' in os.environ:
     kwargs['scripts'] = []
 else:
     kwargs['install_requires'] += [
-        'catkin_pkg >= 0.2.6', 'jenkinsapi', 'rosdistro >= 0.4.0', 'vcstool >= 0.1.37']
+        'catkin_pkg >= 0.2.6', 'jenkinsapi', 'rosdistro >= 1.0.0', 'vcstool >= 0.1.37']
 
 setup(**kwargs)

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,11 +3,11 @@ Debian-Version: 100
 ; ros-buildfarm-modules same version (without the branch suffix) as in:
 ; - ros_buildfarm/__init__.py
 ; - setup.py
-Depends: python-argparse, python-catkin-pkg-modules, python-ros-buildfarm-modules (>= 3.0.0), python-rosdistro-modules, python-yaml
+Depends: python-argparse, python-catkin-pkg-modules, python-ros-buildfarm-modules (>= 3.0.0), python-rosdistro-modules (>= 1.0.0), python-yaml
 ; ros-buildfarm-modules same version (without the branch suffix) as in:
 ; - ros_buildfarm/__init__.py
 ; - setup.py
-Depends3: python3-catkin-pkg-modules, python3-ros-buildfarm-modules (>= 3.0.0), python3-rosdistro-modules, python3-yaml
+Depends3: python3-catkin-pkg-modules, python3-ros-buildfarm-modules (>= 3.0.0), python3-rosdistro-modules (>= 1.0.0), python3-yaml
 Conflicts: python3-ros-buildfarm
 Conflicts3: python-ros-buildfarm
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan stretch buster
@@ -16,8 +16,8 @@ Python2-Depends-Name: python
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
 [ros_buildfarm_modules]
-Depends: python-catkin-pkg-modules, python-configparser, python-empy, python-rosdistro-modules, python-yaml, python3-empy, python3-vcstool (>= 0.1.37)
-Depends3: python3-catkin-pkg-modules, python3-empy, python3-rosdistro-modules, python3-vcstool (>= 0.1.37), python3-yaml
+Depends: python-catkin-pkg-modules, python-configparser, python-empy, python-rosdistro-modules (>= 1.0.0), python-yaml, python3-empy, python3-vcstool (>= 0.1.37)
+Depends3: python3-catkin-pkg-modules, python3-empy, python3-rosdistro-modules (>= 1.0.0), python3-vcstool (>= 0.1.37), python3-yaml
 Conflicts: python-ros-buildfarm (<< 1.3.0)
 Conflicts3: python3-ros-buildfarm (<< 1.3.0)
 Replaces: python-ros-buildfarm (<< 1.3.0)


### PR DESCRIPTION
This is a more centralized location for this code, and ensures that other packages share the same logic.

In draft until ros-infrastructure/rosdistro#190 lands.