### PR TITLE
Add flags to separate generate_release_script parts

### DIFF
--- a/ros_buildfarm/scripts/release/generate_release_script.py
+++ b/ros_buildfarm/scripts/release/generate_release_script.py
@@ -43,9 +43,17 @@ def main(argv=sys.argv[1:]):
     add_argument_os_code_name(parser)
     add_argument_arch(parser)
     parser.add_argument(
+        '--skip-binary',
+        action='store_true',
+        help='Skip the entire binary package build process')
+    parser.add_argument(
         '--skip-install',
         action='store_true',
         help='Skip trying to install binarydeb')
+    parser.add_argument(
+        '--skip-source',
+        action='store_true',
+        help='Skip the entire source package build process')
     args = parser.parse_args(argv)
 
     package_format = package_format_mapping[args.os_name]
@@ -103,28 +111,29 @@ def main(argv=sys.argv[1:]):
         args.package_name, args.os_name, args.os_code_name, args.arch)
 
     separator_index = hook.scripts.index('--')
-    source_scripts = hook.scripts[:separator_index]
-    binary_scripts = hook.scripts[separator_index + 1:]
+    source_scripts = [] if args.skip_source else hook.scripts[:separator_index]
+    binary_scripts = [] if args.skip_binary else hook.scripts[separator_index + 1:]
 
-    # inject additional argument to skip fetching sourcedeb from repo
-    script_name = '/run_binary%s_job.py ' % deb_or_pkg
-    additional_argument = '--skip-download-sourcepkg '
-    for i, script in enumerate(binary_scripts):
-        offset = script.find(script_name)
-        if offset != -1:
-            offset += len(script_name)
-            script = script[:offset] + additional_argument + script[offset:]
-            binary_scripts[i] = script
-            break
+    if source_scripts:
+        # inject additional argument to skip fetching sourcedeb from repo
+        script_name = '/run_binary%s_job.py ' % deb_or_pkg
+        additional_argument = '--skip-download-sourcepkg '
+        for i, script in enumerate(binary_scripts):
+            offset = script.find(script_name)
+            if offset != -1:
+                offset += len(script_name)
+                script = script[:offset] + additional_argument + script[offset:]
+                binary_scripts[i] = script
+                break
 
-    # remove rm command for sourcedeb location
-    rm_command = 'rm -fr $WORKSPACE/binary%s' % deb_or_pkg
-    for i, script in enumerate(binary_scripts):
-        offset = script.find(rm_command)
-        if offset != -1:
-            script = script[:offset] + script[offset + len(rm_command):]
-            binary_scripts[i] = script
-            break
+        # remove rm command for sourcedeb location
+        rm_command = 'rm -fr $WORKSPACE/binary%s' % deb_or_pkg
+        for i, script in enumerate(binary_scripts):
+            offset = script.find(rm_command)
+            if offset != -1:
+                script = script[:offset] + script[offset + len(rm_command):]
+                binary_scripts[i] = script
+                break
 
     if args.skip_install:
         # remove install step

--- a/ros_buildfarm/templates/release/release_script.sh.em
+++ b/ros_buildfarm/templates/release/release_script.sh.em
@@ -45,6 +45,7 @@ echo "Using workspace for binary: $WORKSPACE"
 mkdir -p $WORKSPACE
 cd $WORKSPACE
 
+@[if source_scripts]@
 echo ""
 echo "Get artifacts from source job"
 @[if package_format == 'deb']@
@@ -55,6 +56,7 @@ mkdir -p $WORKSPACE/binarypkg/source
 (set -x; cp $BASEPATH/source/sourcepkg/*.src.rpm $WORKSPACE/binarypkg/source/)
 @[else]@
 @{assert False, "Unsupported packaging format '%s'" % package_format}@
+@[end if]@
 @[end if]@
 
 @(TEMPLATE(


### PR DESCRIPTION
These flags will enable script invocations of the source and binary jobs separately, supporting a build process more like the Jenkins buildfarm.

Most of the line changes are indenting the code block in the middle of `generate_release_script.py`, so best reviewed with whitespace changes hidden.