### PR TITLE
Update target platform list for making debs

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -11,7 +11,7 @@ Depends3: python3-catkin-pkg-modules, python3-ros-buildfarm-modules (>= 3.0.0), 
 Conflicts: python3-ros-buildfarm
 Conflicts3: python-ros-buildfarm
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan stretch buster
-Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal stretch buster
+Suite3: focal jammy noble bookworm trixie
 Python2-Depends-Name: python
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
@@ -23,6 +23,6 @@ Conflicts3: python3-ros-buildfarm (<< 1.3.0)
 Replaces: python-ros-buildfarm (<< 1.3.0)
 Replaces3: python3-ros-buildfarm (<< 1.3.0)
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan stretch buster
-Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal stretch buster
+Suite3: focal jammy noble bookworm trixie
 Python2-Depends-Name: python
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
The Python 2 suite list will be removed by #1067 so I'm not updating it here.