### PR TITLE
Set PODMAN_USERNS=keep-id when invoking 'docker run'

### DIFF
--- a/ros_buildfarm/templates/release/rpm/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_job.xml.em
@@ -130,6 +130,8 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
     ] + ([
         'if [ ! -d "$HOME/.ccache" ]; then mkdir $HOME/.ccache; fi',
     ] if shared_ccache else []) + [
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm' +
         ' --privileged' +

--- a/ros_buildfarm/templates/release/rpm/sourcepkg_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/sourcepkg_job.xml.em
@@ -110,6 +110,8 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         'echo "# BEGIN SECTION: Run Dockerfile - generate sourcerpm"',
         'rm -fr $WORKSPACE/sourcepkg',
         'mkdir -p $WORKSPACE/sourcepkg',
+        '# If using Podman, change the user namespace to preserve UID. No effect if using Docker.',
+        'export PODMAN_USERNS=keep-id',
         'docker run' +
         ' --rm' +
         ' --privileged' +


### PR DESCRIPTION
I missed the RPM release jobs when I made this change everywhere else in ros_buildfarm.

Follow-up to #1032