### PR TITLE
Make apt work with unsigned repositories

### DIFF
--- a/ros_buildfarm/templates/snippet/add_distribution_repositories.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/add_distribution_repositories.Dockerfile.em
@@ -14,10 +14,10 @@ RUN for i in 1 2 3; do apt-get update && apt-get install -q -y gnupg ca-certific
 @[for i, key in enumerate(distribution_repository_keys)]@
 RUN echo "@('\\n'.join(key.splitlines()))" > /tmp/keys/@(i).key@[if key] && apt-key add /tmp/keys/@(i).key@[end if]
 @[end for]@
-@[for url in distribution_repository_urls]@
-RUN echo deb @url @os_code_name main | tee -a /etc/apt/sources.list.d/buildfarm.list
+@[for i, url in enumerate(distribution_repository_urls)]@
+RUN echo deb @[if not distribution_repository_keys[i]][trusted=yes] @[end if]@ @url @os_code_name main | tee -a /etc/apt/sources.list.d/buildfarm.list
 @[if add_source and url == target_repository]@
-RUN echo deb-src @url @os_code_name main | tee -a /etc/apt/sources.list.d/buildfarm.list
+RUN echo deb-src @[if not distribution_repository_keys[i]][trusted=yes] @[end if]@ @url @os_code_name main | tee -a /etc/apt/sources.list.d/buildfarm.list
 @[end if]@
 @[end for]@
 @# On Ubuntu Trusty a newer version of dpkg is required to install Debian packages created by stdeb on newer distros


### PR DESCRIPTION
If an empty key is given for a repository in the buildfarm configuration, use the repository without verifying the GPG signature of the metadata.

This is already how the RPM jobs work.

Follow-up to #947