### PR TITLE
Fix permissions on mock config copied into container

### DIFF
--- a/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
@@ -30,6 +30,7 @@ RUN dnf update --refresh -y
 RUN echo -e "@('\\n'.join(key.splitlines()))" > /etc/pki/mock/RPM-GPG-KEY-ros-buildfarm-@(i)
 @[end for]@
 COPY mock_config.cfg /etc/mock/ros_buildfarm.cfg
+RUN chmod 644 /etc/mock/ros_buildfarm.cfg
 
 USER buildfarm
 ENTRYPOINT ["sh", "-c"]

--- a/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
@@ -25,6 +25,7 @@ RUN dnf update --refresh -y
 RUN echo -e "@('\\n'.join(key.splitlines()))" > /etc/pki/mock/RPM-GPG-KEY-ros-buildfarm-@(i)
 @[end for]@
 COPY mock_config.cfg /etc/mock/ros_buildfarm.cfg
+RUN chmod 644 /etc/mock/ros_buildfarm.cfg
 
 USER buildfarm
 ENTRYPOINT ["sh", "-c"]


### PR DESCRIPTION
The permissions of this file in the container need to allow `o+x`. The `COPY` directive will preserve the mode, which may not have `o+x`  depending on the host's umask and other factors.

Best to be explicit here, and specifically set the mode we want. Note that newer `COPY` directives can set the mode during the operation, but I'm not sure which platforms or versions support that newer syntax.