### PR TITLE
Align stdeb dependencies with setup.py

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -7,7 +7,7 @@ Depends: python-argparse, python-catkin-pkg-modules, python-ros-buildfarm-module
 ; ros-buildfarm-modules same version (without the branch suffix) as in:
 ; - ros_buildfarm/__init__.py
 ; - setup.py
-Depends3: python3-catkin-pkg-modules, python3-ros-buildfarm-modules (>= 3.0.0), python3-rosdistro-modules (>= 1.0.0), python3-yaml
+Depends3: python3-catkin-pkg-modules (>= 0.2.6), python3-ros-buildfarm-modules (>= 3.0.0), python3-rosdistro-modules (>= 1.0.0), python3-yaml
 Conflicts: python3-ros-buildfarm
 Conflicts3: python-ros-buildfarm
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan stretch buster
@@ -17,7 +17,7 @@ Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
 [ros_buildfarm_modules]
 Depends: python-catkin-pkg-modules, python-configparser, python-empy, python-rosdistro-modules (>= 1.0.0), python-yaml, python3-empy, python3-vcstool (>= 0.1.37)
-Depends3: python3-catkin-pkg-modules, python3-empy, python3-rosdistro-modules (>= 1.0.0), python3-vcstool (>= 0.1.37), python3-yaml
+Depends3: python3-catkin-pkg-modules (>= 0.2.6), python3-empy (< 4), python3-jenkinsapi, python3-rosdistro-modules (>= 1.0.0), python3-vcstool (>= 0.1.37), python3-yaml
 Conflicts: python-ros-buildfarm (<< 1.3.0)
 Conflicts3: python3-ros-buildfarm (<< 1.3.0)
 Replaces: python-ros-buildfarm (<< 1.3.0)


### PR DESCRIPTION
Some of the dependencies were missing version constraints, and jenkinsapi was missing completely.

The Python 2 dependency list will be removed by #1067 so I'm not updating it here.