### PR TITLE
Convert to subprocess model for flake8 test

### DIFF
--- a/ros_buildfarm/config/build_file.py
+++ b/ros_buildfarm/config/build_file.py
@@ -27,7 +27,7 @@ class BuildFile(object):
         if 'build_environment_variables' in data:
             self.build_environment_variables = \
                 data['build_environment_variables']
-            assert(isinstance(self.build_environment_variables, dict))
+            assert isinstance(self.build_environment_variables, dict)
 
         self.notify_emails = []
         self.notify_maintainers = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,19 @@
+[tool:pytest]
+junit_suite_name = ros_buildfarm
+markers =
+    flake8
+    linter
+
+[flake8]
+extend_ignore =
+    A     # flake8-builtins is not supported
+    C     # flake8-comprehensions is not supported
+    D100
+    D101
+    D102
+    D103
+    D104
+    D105
+    E501
+    Q     # flake8-quotes is not supported
+import-order-style = google

--- a/setup.py
+++ b/setup.py
@@ -45,13 +45,12 @@ kwargs = {
         'PyYAML'],
     'extras_require': {
         'test': [
-            'flake8 >= 3.7, < 5',
+            'flake8 >= 3.7',
             'flake8-class-newline',
             'flake8_docstrings',
             'flake8-import-order',
             'pep8',
-            'pycodestyle < 2.9.0',
-            'pyflakes < 2.5.0',
+            'pyflakes',
             'pytest'],
     },
     'author': 'Dirk Thomas',

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -1,73 +1,23 @@
-# Copyright 2016 Open Source Robotics Foundation, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+# Licensed under the Apache License, Version 2.0
 
 import os
+import subprocess
+import sys
 
-from flake8 import configure_logging
-from flake8.api.legacy import StyleGuide
-from flake8.main.application import Application
-from flake8.options import config
-
-
-def test_flake8_conformance():
-    """Test source code for flake8 conformance."""
-    argv = [
-        '--extend-ignore=%s' % ','.join([
-            'D100', 'D101', 'D102', 'D103', 'D104', 'D105',
-            'E501']),
-        '--import-order-style=google',
-    ]
-    style_guide = get_style_guide(argv)
-    base_path = os.path.join(os.path.dirname(__file__), '..')
-    paths = [
-        os.path.join(base_path, 'ros_buildfarm'),
-        os.path.join(base_path, 'scripts'),
-        os.path.join(base_path, 'test'),
-    ]
-    report = style_guide.check_files(paths)
-    assert report.total_errors == 0, \
-        'Found %d code style warnings' % report.total_errors
+import pytest
 
 
-def get_style_guide(argv=None):
-    # this is a fork of flake8.api.legacy.get_style_guide
-    # to allow passing command line argument
-    application = Application()
-    if not hasattr(application, 'parse_preliminary_options_and_args'):  # flake8 >= 3.8
-        prelim_opts, remaining_args = application.parse_preliminary_options(argv)
-        config_finder = config.ConfigFileFinder(
-            application.program,
-            prelim_opts.append_config,
-            config_file=prelim_opts.config,
-            ignore_config_files=prelim_opts.isolated,
-        )
-        application.find_plugins(config_finder)
-        application.register_plugin_options()
-        application.parse_configuration_and_cli(config_finder, remaining_args)
-    else:
-        application.parse_preliminary_options_and_args(argv)
-        configure_logging(
-            application.prelim_opts.verbose, application.prelim_opts.output_file)
-        application.make_config_finder()
-        application.find_plugins()
-        application.register_plugin_options()
-        application.parse_configuration_and_cli(argv)
-    application.make_formatter()
-    application.make_guide()
-    application.make_file_checker_manager()
-    return StyleGuide(application)
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8() -> None:
+    # flake8 doesn't have a stable public API as of ver 6.1.0.
+    # See: https://flake8.pycqa.org/en/latest/user/python-api.html
+    # Calling through subprocess is the most stable way to run it.
 
-
-if __name__ == '__main__':
-    test_flake8_conformance()
+    result = subprocess.run(
+        [sys.executable, '-m', 'flake8'],
+        cwd=os.path.dirname(os.path.dirname(__file__)),
+        check=False,
+    )
+    assert 0 == result.returncode, 'flake8 found violations'


### PR DESCRIPTION
This strategy for invoking flake8 has been successful in other ROS-adjacent projects.

This change is needed to use modern versions of flake8.

Reverts #970