### PR TITLE
Support empy v3 and v4.

### DIFF
--- a/ros_buildfarm/scripts/release/generate_release_script.py
+++ b/ros_buildfarm/scripts/release/generate_release_script.py
@@ -16,7 +16,17 @@ import argparse
 import re
 import sys
 
-from em import BANGPATH_OPT
+try:
+    # Import bangpath option name from EmPy v3
+    from em import BANGPATH_OPT
+    BANGPATH_VALUE = False
+except ImportError:
+    # EmPy 4 does not define an import-able constant for the updated bangpath
+    # option and inverts its meaning.
+    BANGPATH_OPT = 'ignoreBangpaths'
+    BANGPATH_VALUE = True
+
+
 from em import Hook
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_name
@@ -151,7 +161,7 @@ def main(argv=sys.argv[1:]):
             'source_scripts': source_scripts,
             'binary_scripts': binary_scripts,
             'package_format': package_format},
-        options={BANGPATH_OPT: False})
+        options={BANGPATH_OPT: BANGPATH_VALUE})
     value = re.sub(r'(^| )python3 ', r'\1' + sys.executable + ' ', value, flags=re.M)
     print(value)
 

--- a/ros_buildfarm/scripts/release/generate_release_script.py
+++ b/ros_buildfarm/scripts/release/generate_release_script.py
@@ -27,7 +27,12 @@ except ImportError:
     BANGPATH_VALUE = True
 
 
-from em import Hook
+try:
+    from em import Hook
+except:
+    from emlib import Hook
+
+
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_name
 from ros_buildfarm.argument import add_argument_config_url

--- a/ros_buildfarm/templates/snippet/builder_parameterized-trigger.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_parameterized-trigger.xml.em
@@ -10,7 +10,7 @@
 @[if parameter_files]@
             <hudson.plugins.parameterizedtrigger.FileBuildParameters>
               <propertiesFile>@(','.join(ESCAPE(parameter_files)))</propertiesFile>
-              <failTriggerOnMissing>@(vars().get('missing_parameter_files_skip', False) ? 'true' : 'false')</failTriggerOnMissing>
+              <failTriggerOnMissing>@(vars().get('missing_parameter_files_skip', False) ? 'true' ! 'false')</failTriggerOnMissing>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
               <useMatrixChild>false</useMatrixChild>
               <onlyExactRuns>false</onlyExactRuns>

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ kwargs = {
     'scripts': scripts,
     'zip_safe': False,
     'install_requires': [
-        'empy<4',
+        'empy',
         'PyYAML'],
     'extras_require': {
         'test': [


### PR DESCRIPTION
This is the start of a PR to address #1014 and support empy v4.

I started by reviewing the [changelog](http://www.alcyone.com/software/empy/ANNOUNCE.html#changes) for differences in markup syntax and scanning our template corpus for affected usage and updating it.

Of the new constructs that are present in our code, these are the ones that I found doing basic token scanning:

The new extension markup syntax `@((...))` is present via a grouping/one-tuple literal:
I'm honestly not sure whether this will be affected but it's one to watch.

```
 grep -F "@((" (fd -e em)
ros_buildfarm/templates/status/release_status_page.html.em:<td><span class="@pkg.status"@((' title="%s"' % pkg.status_description) if pkg.status_description else '')/></td>@
```

Use of `:` for “else” was already deprecated and has been removed. Use `!` instead as in `@(...?...!...)`
The `!` syntax is already usable in empy3 so it's been updated.

```
❯ rg "@\(.*\?.*\:.*\)" (fd -e em)
ros_buildfarm/templates/snippet/builder_parameterized-trigger.xml.em
13:              <failTriggerOnMissing>@(vars().get('missing_parameter_files_skip', False) ? 'true' : 'false')</failTriggerOnMissing>
```

I haven't expanded out these changes to include all files but am instead focusing on `generate_release_script.py` in order to smoke out issues and will then apply patches across all affected code before broader testing.

This is still very much a work-in-progress.