### PR TITLE
Set ROS_DISTRO for rosdoc2 to enable link to repository

### DIFF
--- a/ros_buildfarm/templates/doc/rosdoc2_job.xml.em
+++ b/ros_buildfarm/templates/doc/rosdoc2_job.xml.em
@@ -184,6 +184,7 @@ else:
         ' -v $WORKSPACE/ros_buildfarm:/tmp/ros_buildfarm:ro' +
         ' -v $WORKSPACE/rosdoc2:/tmp/rosdoc2' +
         ' -v $WORKSPACE/ws:/tmp/ws' +
+        ' -e ROS_DISTRO=%s' % (rosdistro_name) +
         ' rosdoc2.%s_%s' % (rosdistro_name, doc_repo_spec.name.lower()),
         'echo "# END SECTION"',
     ]),


### PR DESCRIPTION
rosdoc2 added a feature to automatically generate a link to the package repository in https://github.com/ros-infrastructure/rosdoc2/pull/161 but it relies on the environment variable ROS_DISTRO being available at runtime. This PR sets that for buildfarm runs to enable this feature.

This has been tested locally using generate_doc_script but not on a buildfarm run.
