### PR TITLE
Add pytest 'linter' mark to other linter tests

### DIFF
--- a/test/test_pep8.py
+++ b/test/test_pep8.py
@@ -14,11 +14,14 @@
 
 import os
 
-from pep8 import StyleGuide
+import pytest
 
 
+@pytest.mark.linter
 def test_pep8_conformance():
     """Test source code for PEP8 conformance."""
+    from pep8 import StyleGuide
+
     pep8style = StyleGuide(max_line_length=100)
     report = pep8style.options.report
     report.start()

--- a/test/test_pyflakes.py
+++ b/test/test_pyflakes.py
@@ -15,12 +15,15 @@
 import os
 import sys
 
-from pyflakes.api import checkRecursive
-from pyflakes.reporter import Reporter
+import pytest
 
 
+@pytest.mark.linter
 def test_pyflakes_conformance():
     """Test source code for PyFlakes conformance."""
+    from pyflakes.api import checkRecursive
+    from pyflakes.reporter import Reporter
+
     reporter = Reporter(sys.stdout, sys.stderr)
     base_path = os.path.join(os.path.dirname(__file__), '..')
     paths = [


### PR DESCRIPTION
Additionally, move their test-specific imports into the test body so that the dependencies don't need to be present to invoke the tests with "-m 'not linter'".

This aligns the two tests with how test_flake8.py already works.