### PR TITLE
24.04 migration

### DIFF
--- a/ros_buildfarm/scripts/generate_all_jobs.py
+++ b/ros_buildfarm/scripts/generate_all_jobs.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import argparse
-import imp
+from importlib.machinery import SourceFileLoader
 import os
 import sys
 
@@ -355,7 +355,7 @@ def _check_call(cmd):
     print('')
     basepath = os.path.dirname(__file__)
     cmd[0] = os.path.join(basepath, cmd[0])
-    module = imp.load_source('script', cmd[0])
+    module = SourceFileLoader('script', cmd[0]).load_module()
     rc = module.main(cmd[1:])
     if rc:
         sys.exit(rc)

--- a/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
+++ b/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
@@ -1,4 +1,4 @@
-import difflib.DiffUtils
+import com.github.difflib.DiffUtils
 import groovy.io.FileType
 @@ThreadInterrupt
 import groovy.transform.ThreadInterrupt

--- a/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
+++ b/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
@@ -41,6 +41,7 @@ println '# BEGIN SECTION: Groovy script - reconfigure'
 dry_run = @('true' if dry_run else 'false')
 dry_run_suffix = dry_run ? ' (dry run)' : ''
 
+println "User: " + System.getProperty("user.name")
 
 @[if vars().get('expected_num_views')]@
 // reconfigure views

--- a/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
+++ b/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
@@ -42,8 +42,6 @@ println '# BEGIN SECTION: Groovy script - reconfigure'
 dry_run = @('true' if dry_run else 'false')
 dry_run_suffix = dry_run ? ' (dry run)' : ''
 
-println "User: " + System.getProperty("user.name")
-
 @[if vars().get('expected_num_views')]@
 // reconfigure views
 println '# BEGIN SUBSECTION: reconfigure @(expected_num_views) views'
@@ -53,9 +51,7 @@ skipped_views = 0
 
 view_config_dir = build.getWorkspace().toString() + '/reconfigure_jobs/view_configs'
 
-println "View Config dir:" + view_config_dir
 def view_dir = new File(view_config_dir)
-println "Views: " + view_dir.listFiles()
 def views = view_dir.listFiles() ?: []
 views.sort()
 

--- a/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
+++ b/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
@@ -53,7 +53,9 @@ skipped_views = 0
 
 view_config_dir = build.getWorkspace().toString() + '/reconfigure_jobs/view_configs'
 
+println "View Config dir:" + view_config_dir
 def view_dir = new File(view_config_dir)
+println "Views: " + view_dir.listFiles()
 def views = view_dir.listFiles() ?: []
 views.sort()
 

--- a/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
+++ b/ros_buildfarm/templates/snippet/reconfigure_jobs.groovy.em
@@ -1,4 +1,5 @@
 import com.github.difflib.DiffUtils
+import com.github.difflib.UnifiedDiffUtils
 import groovy.io.FileType
 @@ThreadInterrupt
 import groovy.transform.ThreadInterrupt
@@ -273,7 +274,7 @@ def diff_configs(current_config, new_config) {
     }
 
     patch = DiffUtils.diff(current_lines, new_lines)
-    return DiffUtils.generateUnifiedDiff('current config', 'new config', current_lines, patch, 0)
+    return UnifiedDiffUtils.generateUnifiedDiff('current config', 'new config', current_lines, patch, 0)
 }
 
 


### PR DESCRIPTION
With these changes I can run the buildfarm in jenkins LTS and 24.04:

* Use `importlib` instead of `imp`. This is suggested by python docs
* Use `UnifiedDiffUtils`