### PR TITLE
Import EmPy Hook type from ros_buildfarm.template

### DIFF
--- a/ros_buildfarm/scripts/ci/generate_ci_script.py
+++ b/ros_buildfarm/scripts/ci/generate_ci_script.py
@@ -18,7 +18,6 @@ import re
 import sys
 
 from em import BANGPATH_OPT
-from em import Hook
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_name
 from ros_buildfarm.argument import add_argument_build_tool
@@ -40,6 +39,7 @@ from ros_buildfarm.config import get_ci_build_files
 from ros_buildfarm.config import get_global_ci_build_files
 from ros_buildfarm.config import get_index as get_config_index
 from ros_buildfarm.templates import expand_template
+from ros_buildfarm.templates import Hook
 
 
 def main(argv=sys.argv[1:]):

--- a/ros_buildfarm/scripts/devel/generate_devel_script.py
+++ b/ros_buildfarm/scripts/devel/generate_devel_script.py
@@ -17,7 +17,6 @@ import re
 import sys
 
 from em import BANGPATH_OPT
-from em import Hook
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_name
 from ros_buildfarm.argument import add_argument_build_tool
@@ -37,6 +36,7 @@ from ros_buildfarm.config import get_index as get_config_index
 from ros_buildfarm.config import get_source_build_files
 from ros_buildfarm.devel_job import configure_devel_job
 from ros_buildfarm.templates import expand_template
+from ros_buildfarm.templates import Hook
 
 
 def main(argv=sys.argv[1:]):

--- a/ros_buildfarm/scripts/doc/generate_doc_script.py
+++ b/ros_buildfarm/scripts/doc/generate_doc_script.py
@@ -17,7 +17,6 @@ import re
 import sys
 
 from em import BANGPATH_OPT
-from em import Hook
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_name
 from ros_buildfarm.argument import add_argument_config_url
@@ -31,6 +30,7 @@ from ros_buildfarm.config import get_doc_build_files
 from ros_buildfarm.config import get_index
 from ros_buildfarm.doc_job import configure_doc_job
 from ros_buildfarm.templates import expand_template
+from ros_buildfarm.templates import Hook
 
 
 def main(argv=sys.argv[1:]):

--- a/ros_buildfarm/scripts/prerelease/generate_prerelease_script.py
+++ b/ros_buildfarm/scripts/prerelease/generate_prerelease_script.py
@@ -21,7 +21,6 @@ import stat
 import sys
 
 from em import BANGPATH_OPT
-from em import Hook
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_name
 from ros_buildfarm.argument import add_argument_build_tool
@@ -37,6 +36,7 @@ from ros_buildfarm.config import get_source_build_files
 from ros_buildfarm.devel_job import configure_devel_job
 from ros_buildfarm.prerelease import add_overlay_arguments
 from ros_buildfarm.templates import expand_template
+from ros_buildfarm.templates import Hook
 from rosdistro import get_distribution_cache
 from rosdistro import get_index
 from rosdistro.repository_specification import RepositorySpecification

--- a/ros_buildfarm/scripts/release/generate_release_script.py
+++ b/ros_buildfarm/scripts/release/generate_release_script.py
@@ -17,7 +17,6 @@ import re
 import sys
 
 from em import BANGPATH_OPT
-from em import Hook
 from ros_buildfarm.argument import add_argument_arch
 from ros_buildfarm.argument import add_argument_build_name
 from ros_buildfarm.argument import add_argument_config_url
@@ -30,6 +29,7 @@ from ros_buildfarm.common import get_sourcedeb_job_name
 from ros_buildfarm.common import package_format_mapping
 from ros_buildfarm.release_job import configure_release_job
 from ros_buildfarm.templates import expand_template
+from ros_buildfarm.templates import Hook
 
 
 def main(argv=sys.argv[1:]):

--- a/ros_buildfarm/templates/__init__.py
+++ b/ros_buildfarm/templates/__init__.py
@@ -23,6 +23,7 @@ import sys
 import time
 from xml.sax.saxutils import escape
 
+from em import Hook
 from em import Interpreter
 
 template_prefix_path = [os.path.abspath(os.path.dirname(__file__))]
@@ -75,6 +76,7 @@ def expand_template(template_name, data, options=None):
     try:
         interpreter = CachingInterpreter(output=output, options=options)
         for template_hook in template_hooks or []:
+            assert isinstance(template_hook, Hook)
             interpreter.addHook(template_hook)
         template_path = get_template_path(template_name)
         # create copy before manipulating


### PR DESCRIPTION
The code in ros_buildfarm.template requires that template_hooks are instances of EmPy Hook. Since we provide the template_hooks API, we should also provide the type for that list, and downstream usage should change to use our provided type.

Existing implementations which directly import from EmPy will continue to work, but this will allow us to centralize the switch to EmPy v4's new Hook type without changing each site where we create hooks for use with template_hooks.