### PR TITLE
Rewrite inline EmPy conditional as Python expression

### DIFF
--- a/ros_buildfarm/templates/snippet/builder_parameterized-trigger.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_parameterized-trigger.xml.em
@@ -10,7 +10,7 @@
 @[if parameter_files]@
             <hudson.plugins.parameterizedtrigger.FileBuildParameters>
               <propertiesFile>@(','.join(ESCAPE(parameter_files)))</propertiesFile>
-              <failTriggerOnMissing>@(vars().get('missing_parameter_files_skip', False) ? 'true' : 'false')</failTriggerOnMissing>
+              <failTriggerOnMissing>@('true' if vars().get('missing_parameter_files_skip', False) else 'false')</failTriggerOnMissing>
               <textParamValueOnNewLine>false</textParamValueOnNewLine>
               <useMatrixChild>false</useMatrixChild>
               <onlyExactRuns>false</onlyExactRuns>


### PR DESCRIPTION
This expression is deprecated in EmPy 4 and the new syntax doesn't appear to be compatible with EmPy 3. It's easy enough to just make this a simple Python expression and avoid the EmPy syntax altogether.