### PR TITLE
Add support for EmPy v4

### DIFF
--- a/ros_buildfarm/templates/__init__.py
+++ b/ros_buildfarm/templates/__init__.py
@@ -39,7 +39,35 @@ try:
     from em import Hook
 except ImportError:
     # EmPy v4
-    from emlib import Hook
+    from emlib import Hook as _Hook
+
+    class Hook(_Hook):
+        """Hook implementation with compatibility back to EmPy v3."""
+
+        def beforeFileLines(self, file, locals, *args, **kwargs):
+            return self.beforeFile(None, file, locals)
+
+        def afterFileLines(self):
+            return self.afterFile()
+
+        def beforeFileChunks(self, file, bufferSize, locals, *args, **kwargs):
+            return self.beforeFile(None, file, locals)
+
+        def afterFileChunks(self):
+            return self.afterFile()
+
+        def beforeFileFull(self, file, locals, *args, **kwargs):
+            return self.beforeFile(None, file, locals)
+
+        def afterFileFull(self):
+            return self.afterFile()
+
+        def beforeFile(self, name, file, locals):
+            pass
+
+        def afterFile(self):
+            pass
+
 
 from em import Interpreter
 
@@ -138,7 +166,6 @@ def expand_template(
             dispatcher=False)
     try:
         for template_hook in template_hooks or []:
-            assert isinstance(template_hook, Hook)
             interpreter.addHook(template_hook)
         # create copy before manipulating
         data = dict(data)

--- a/ros_buildfarm/templates/__init__.py
+++ b/ros_buildfarm/templates/__init__.py
@@ -34,7 +34,13 @@ except ImportError:
     BANGPATH_OPT = 'ignoreBangpaths'
     BANGPATH_VALUE = True
 
-from em import Hook
+try:
+    # EmPy v3
+    from em import Hook
+except ImportError:
+    # EmPy v4
+    from emlib import Hook
+
 from em import Interpreter
 
 template_prefix_path = [os.path.abspath(os.path.dirname(__file__))]

--- a/ros_buildfarm/templates/__init__.py
+++ b/ros_buildfarm/templates/__init__.py
@@ -24,7 +24,16 @@ import time
 import warnings
 from xml.sax.saxutils import escape
 
-from em import BANGPATH_OPT
+try:
+    # Import bangpath option name from EmPy v3
+    from em import BANGPATH_OPT
+    BANGPATH_VALUE = False
+except ImportError:
+    # EmPy 4 does not define an import-able constant for the updated bangpath
+    # option and inverts its meaning.
+    BANGPATH_OPT = 'ignoreBangpaths'
+    BANGPATH_VALUE = True
+
 from em import Hook
 from em import Interpreter
 
@@ -85,7 +94,7 @@ def expand_template(
     if ignore_bangpath:
         options = {
             **(options or {}),
-            BANGPATH_OPT: False,
+            BANGPATH_OPT: BANGPATH_VALUE,
         }
 
     template_path = get_template_path(template_name)

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ kwargs = {
     'scripts': scripts,
     'zip_safe': False,
     'install_requires': [
-        'empy<4',
+        'empy',
         'PyYAML'],
     'extras_require': {
         'test': [


### PR DESCRIPTION
This is a series of changes necessary for supporting both EmPy v4 and v3. There are a lot of hoops to jump through to make this possible, and I think we should deprecate EmPy v3 support as soon as possible and switch to the newer EmPy v4 mechanisms to simplify the code substantially. I think that's pretty far off, however.

I'd like to avoid squashing these changes since the individual commit messages are valuable.

Once I get a good build with the changes, I'll push a commit to relax the pinned version to run CI with EmPy v4.

Closes #1076