### PR TITLE
Avoid syntax collision with EmPy v4 extension markup

### DIFF
--- a/ros_buildfarm/templates/status/release_status_page.html.em
+++ b/ros_buildfarm/templates/status/release_status_page.html.em
@@ -165,7 +165,7 @@ if regressions and True in regressions[pkg.name].values():
 @# package status
 @
 @[if has_status_column]@
-<td><span class="@pkg.status"@((' title="%s"' % pkg.status_description) if pkg.status_description else '')/></td>@
+<td><span class="@pkg.status"@( (' title="%s"' % pkg.status_description) if pkg.status_description else '' )/></td>@
 @[end if]@
 @
 @# package maintainers


### PR DESCRIPTION
In EmPy v4, a double-paren (or double-brace, etc) signifies a "custom extension". Because the content is an expression, we can just add some whitespace after the opening paren to avoid the syntax collision.