### PR TITLE
Replace vcstool with vcs2l

### DIFF
--- a/doc/jobs/prerelease_jobs.rst
+++ b/doc/jobs/prerelease_jobs.rst
@@ -156,4 +156,4 @@ The following commands are all it takes to run a prerelease job for a custom rep
   ./prerelease.sh -y
 
 The git clone command is just an example.
-It can be substituted with any other commands to populate the workspaces (e.g. `wstool`, `vcstool`).
+It can be substituted with any other commands to populate the workspaces (e.g. `wstool`, `vcs2l`).

--- a/ros_buildfarm/scripts/ci/create_workspace_task_generator.py
+++ b/ros_buildfarm/scripts/ci/create_workspace_task_generator.py
@@ -86,7 +86,7 @@ def main(argv=sys.argv[1:]):
         'python3-colcon-recursive-crawl',
         'python3-colcon-ros',
         'python3-rosdep',
-        'python3-vcstool',
+        'python3-vcs2l',
     ]
 
     # get versions for build dependencies

--- a/ros_buildfarm/scripts/prerelease/generate_prerelease_overlay_script.py
+++ b/ros_buildfarm/scripts/prerelease/generate_prerelease_overlay_script.py
@@ -56,8 +56,8 @@ def main(argv=sys.argv[1:]):
         help='Output overlay information as JSON instead of a shell script'
     )
     group.add_argument(
-        '--vcstool', action='store_true',
-        help='Output overlay information as vcstool repos file'
+        '--vcs2l', action='store_true',
+        help='Output overlay information as vcs2l repos file'
     )
 
     args = parser.parse_args(argv)
@@ -99,7 +99,7 @@ def main(argv=sys.argv[1:]):
 
     if args.json:
         print(json.dumps([vars(r) for r, p in scms], sort_keys=True, indent=2))
-    elif args.vcstool:
+    elif args.vcs2l:
         print('repositories:')
         for r, p in scms:
             print('  %s:' % p)

--- a/ros_buildfarm/templates/prerelease/prerelease_clone_overlay_script.sh.em
+++ b/ros_buildfarm/templates/prerelease/prerelease_clone_overlay_script.sh.em
@@ -9,7 +9,7 @@ if [ -z "$WORKSPACE" ]; then
     echo ""
 fi
 
-PYTHONPATH=@ros_buildfarm_python_path:$PYTHONPATH @python_executable @prerelease_script_path/generate_prerelease_overlay_script.py @config_url @rosdistro_name @os_name @os_code_name @arch --pkg @(' '.join(pkg)) --exclude-pkg @(' '.join(exclude_pkg)) --level @level --vcstool > overlay.repos
+PYTHONPATH=@ros_buildfarm_python_path:$PYTHONPATH @python_executable @prerelease_script_path/generate_prerelease_overlay_script.py @config_url @rosdistro_name @os_name @os_code_name @arch --pkg @(' '.join(pkg)) --exclude-pkg @(' '.join(exclude_pkg)) --level @level --vcs2l > overlay.repos
 echo ""
 
 vcs import $WORKSPACE < overlay.repos

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,6 @@ elif 'SKIP_PYTHON_SCRIPTS' in os.environ:
     kwargs['scripts'] = []
 else:
     kwargs['install_requires'] += [
-        'catkin_pkg >= 0.2.6', 'jenkinsapi', 'rosdistro >= 1.0.0', 'vcstool >= 0.1.37']
+        'catkin_pkg >= 0.2.6', 'jenkinsapi', 'rosdistro >= 1.0.0', 'vcs2l']
 
 setup(**kwargs)

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -11,7 +11,7 @@ X-Python3-Version: >= 3.6
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
 [ros_buildfarm_modules]
-Depends3: python3-catkin-pkg-modules (>= 0.2.6), python3-empy, python3-jenkinsapi, python3-rosdistro-modules (>= 1.0.0), python3-vcstool (>= 0.1.37), python3-yaml
+Depends3: python3-catkin-pkg-modules (>= 0.2.6), python3-empy, python3-jenkinsapi, python3-rosdistro-modules (>= 1.0.0), python3-vcs2l, python3-yaml
 Conflicts3: python3-ros-buildfarm (<< 1.3.0)
 Replaces3: python3-ros-buildfarm (<< 1.3.0)
 Suite3: focal jammy noble bookworm trixie


### PR DESCRIPTION
## Pull Request Description

This PR focuses on migrating Dirk Thomas' [vcstool](https://github.com/dirk-thomas/vcstool) module with the maintained ROS Infrastructure version of [vcs2l](https://github.com/ros-infrastructure/vcs2l).

* The Python dependency has been migrated to use `vcs2l`.
* The Debian references now point to `vcs2l`, along with the command-line arguments.
* Finally, the documentation was updated to point to the usage of `vcs2l` instead.