### PR TITLE
Use parallel testing by default

### DIFF
--- a/ros_buildfarm/scripts/ci/build_task_generator.py
+++ b/ros_buildfarm/scripts/ci/build_task_generator.py
@@ -84,6 +84,7 @@ def main(argv=sys.argv[1:]):
             'python3-colcon-package-selection',
             'python3-colcon-parallel-executor',
             'python3-colcon-ros',
+            'python3-colcon-ros-domain-id-coordinator',
             'python3-colcon-test-result',
             'python3-rosdistro-modules',
         ])

--- a/ros_buildfarm/scripts/ci/create_workspace_task_generator.py
+++ b/ros_buildfarm/scripts/ci/create_workspace_task_generator.py
@@ -85,6 +85,7 @@ def main(argv=sys.argv[1:]):
         'python3-colcon-package-selection',
         'python3-colcon-recursive-crawl',
         'python3-colcon-ros',
+        'python3-colcon-ros-domain-id-coordinator',
         'python3-rosdep',
         'python3-vcstool',
     ]

--- a/ros_buildfarm/scripts/devel/create_devel_task_generator.py
+++ b/ros_buildfarm/scripts/devel/create_devel_task_generator.py
@@ -118,6 +118,7 @@ def main(argv=sys.argv[1:]):
             'python3-colcon-output',
             'python3-colcon-parallel-executor',
             'python3-colcon-ros',
+            'python3-colcon-ros-domain-id-coordinator',
             'python3-colcon-test-result',
         ]
     elif 'catkin' not in pkg_names:

--- a/ros_buildfarm/workspace.py
+++ b/ros_buildfarm/workspace.py
@@ -48,7 +48,8 @@ def clean_workspace(workspace_root):
 def call_build_tool(
     build_tool, rosdistro_name, workspace_root, cmake_args=None,
     force_cmake=False, cmake_clean_cache=False, install=False, make_args=None,
-    args=None, parent_result_spaces=None, env=None, colcon_verb='build'
+    args=None, parent_result_spaces=None, env=None, colcon_verb='build',
+    test_executor='parallel'
 ):
     # command to run
     assert build_tool in ('catkin_make_isolated', 'colcon')
@@ -84,9 +85,18 @@ def call_build_tool(
         # process packages sequentially assuming tests from different packages
         # can't be executed in parallel
         if colcon_verb == 'test':
-            cmd += [
-                '--event-handlers', 'console_direct+',
-                '--executor', 'sequential']
+            if test_executor == 'parallel':
+                cmd += [
+                    '--event-handlers', 'console_cohesion+']
+            elif test_executor == 'sequential':
+                cmd += [
+                    '--event-handlers', 'console_direct+',
+                    '--executor', 'sequential']
+            else:
+                print("Using executor: '%s'" % test_executor)
+                cmd += [
+                    '--event-handlers', 'console_direct+',
+                    '--executor', test_executor]
 
             # In Foxy and prior, xunit2 format is needed to make Jenkins xunit plugin 2.x happy
             # After Foxy, we introduced per-package changes to make local builds and CI


### PR DESCRIPTION
Currently, build.ros2.org jobs use sequential executor for testing. This leads to ~2 hours of testing. Parallelization might save around 1 hour of testing.

This is kind of a cherry pick from: https://github.com/ros2/ci/pull/723