### PR TITLE
Use python standard library to replace bzip2 dependency

### DIFF
--- a/ros_buildfarm/scripts/ci/create_workspace_archive.py
+++ b/ros_buildfarm/scripts/ci/create_workspace_archive.py
@@ -1,0 +1,74 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import hashlib
+import os
+import sys
+import tarfile
+
+from ros_buildfarm.argument import add_argument_arch
+from ros_buildfarm.argument import add_argument_os_code_name
+from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.common import Scope
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description='Create a compressed archive of the workspace install space.')
+    add_argument_rosdistro_name(parser)
+    add_argument_os_code_name(parser)
+    add_argument_arch(parser)
+    parser.add_argument(
+        '--ros-version',
+        type=int,
+        required=True,
+        help='The ROS version (1 or 2)')
+    parser.add_argument(
+        '--install-dir',
+        required=True,
+        help='The path to the install space to archive')
+    parser.add_argument(
+        '--output-dir',
+        default='.',
+        help='The directory to write the archive and checksum to')
+    args = parser.parse_args(argv)
+
+    rosdistro_name = args.rosdistro_name if args.rosdistro_name else 'global'
+    archive_name = 'ros%d-%s-linux-%s-%s-ci.tar.bz2' % (
+        args.ros_version, rosdistro_name, args.os_code_name, args.arch)
+    archive_path = os.path.join(args.output_dir, archive_name)
+    checksum_path = archive_path.replace('.tar.bz2', '-CHECKSUM')
+    arcname = 'ros%d-linux' % args.ros_version
+
+    with Scope('SUBSECTION', 'create workspace archive'):
+        print("Creating archive '%s' from '%s'" % (archive_path, args.install_dir))
+        with tarfile.open(archive_path, 'w:bz2') as t:
+            t.add(args.install_dir, arcname=arcname)
+
+        print("Computing SHA256 checksum")
+        h = hashlib.sha256()
+        with open(archive_path, 'rb') as f:
+            h.update(f.read())
+
+        checksum_content = '%s *%s\n' % (h.hexdigest(), archive_name)
+        print("Writing checksum to '%s'" % checksum_path)
+        with open(checksum_path, 'w') as f:
+            f.write(checksum_content)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/ros_buildfarm/scripts/ci/create_workspace_archive.py
+++ b/ros_buildfarm/scripts/ci/create_workspace_archive.py
@@ -24,7 +24,18 @@ from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.common import Scope
 
 
-def main(argv=sys.argv[1:]):
+def get_file_sha256(path: str, chunk_size: int = 1024 * 1024) -> str:
+    hasher = hashlib.sha256()
+    with open(path, 'rb') as f:
+        while True:
+            chunk = f.read(chunk_size)
+            if not chunk:
+                break
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def main(argv=sys.argv[1:]) -> int:
     parser = argparse.ArgumentParser(
         description='Create a compressed archive of the workspace install space.')
     add_argument_rosdistro_name(parser)
@@ -54,15 +65,12 @@ def main(argv=sys.argv[1:]):
 
     with Scope('SUBSECTION', 'create workspace archive'):
         print("Creating archive '%s' from '%s'" % (archive_path, args.install_dir))
-        with tarfile.open(archive_path, 'w:bz2') as t:
-            t.add(args.install_dir, arcname=arcname)
+        with tarfile.open(archive_path, 'w:bz2') as archive:
+            archive.add(args.install_dir, arcname=arcname)
 
         print("Computing SHA256 checksum")
-        h = hashlib.sha256()
-        with open(archive_path, 'rb') as f:
-            h.update(f.read())
-
-        checksum_content = '%s *%s\n' % (h.hexdigest(), archive_name)
+        checksum_content = '%s *%s\n' % (
+            get_file_sha256(archive_path), archive_name)
         print("Writing checksum to '%s'" % checksum_path)
         with open(checksum_path, 'w') as f:
             f.write(checksum_content)

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -372,6 +372,7 @@ parameters = [
     'builder_shell',
     script='\n'.join([
         'echo "# BEGIN SECTION: Compress install space"',
+        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/ci/create_workspace_archive.py' +
         ' ' + (rosdistro_name or "''") +
         ' ' + os_code_name +

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -373,17 +373,18 @@ parameters = [
     script='\n'.join([
         'echo "# BEGIN SECTION: Compress install space"',
         'cd $WORKSPACE && python3 -c "'
+        'import hashlib; '
         'import tarfile; '
-        't = tarfile.open('
-        '\'ros%d-%s-linux-%s-%s-ci.tar.bz2\', '
-        '\'w:bz2\'); '
+        'archive = \'ros%d-%s-linux-%s-%s-ci.tar.bz2\'; '
+        't = tarfile.open(archive, \'w:bz2\'); '
         't.add(\'ws/install_isolated\', arcname=\'ros%d-linux\'); '
-        't.close()"' % (
+        't.close(); '
+        'h = hashlib.sha256(); '
+        'h.update(open(archive, \'rb\').read()); '
+        'open(archive.replace(\'.tar.bz2\', \'-CHECKSUM\'), \'w\').write(h.hexdigest() + \' *\' + archive + \'\\\\n\')"' % (
           ros_version, rosdistro_name or 'global', os_code_name, arch,
           ros_version
         ),
-        'sha256sum -b ros%d-%s-linux-%s-%s-ci.tar.bz2' % (ros_version, rosdistro_name or 'global', os_code_name, arch) +
-        ' > ros%d-%s-linux-%s-%s-ci-CHECKSUM' % (ros_version, rosdistro_name or 'global', os_code_name, arch),
         'cd -',
         'echo "# END SECTION"',
     ]),

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -372,20 +372,13 @@ parameters = [
     'builder_shell',
     script='\n'.join([
         'echo "# BEGIN SECTION: Compress install space"',
-        'cd $WORKSPACE && python3 -c "'
-        'import hashlib; '
-        'import tarfile; '
-        'archive = \'ros%d-%s-linux-%s-%s-ci.tar.bz2\'; '
-        't = tarfile.open(archive, \'w:bz2\'); '
-        't.add(\'ws/install_isolated\', arcname=\'ros%d-linux\'); '
-        't.close(); '
-        'h = hashlib.sha256(); '
-        'h.update(open(archive, \'rb\').read()); '
-        'open(archive.replace(\'.tar.bz2\', \'-CHECKSUM\'), \'w\').write(h.hexdigest() + \' *\' + archive + \'\\\\n\')"' % (
-          ros_version, rosdistro_name or 'global', os_code_name, arch,
-          ros_version
-        ),
-        'cd -',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/ci/create_workspace_archive.py' +
+        ' ' + (rosdistro_name or "''") +
+        ' ' + os_code_name +
+        ' ' + arch +
+        ' --ros-version ' + str(ros_version) +
+        ' --install-dir $WORKSPACE/ws/install_isolated' +
+        ' --output-dir $WORKSPACE',
         'echo "# END SECTION"',
     ]),
 ))@

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -372,11 +372,16 @@ parameters = [
     'builder_shell',
     script='\n'.join([
         'echo "# BEGIN SECTION: Compress install space"',
-        'cd $WORKSPACE',
-        'tar -cjf ros%d-%s-linux-%s-%s-ci.tar.bz2' % (ros_version, rosdistro_name or 'global', os_code_name, arch) +
-        ' -C ws' +
-        ' --transform "s/^install_isolated/ros%d-linux/"' % (ros_version) +
-        ' install_isolated',
+        'cd $WORKSPACE && python3 -c "'
+        'import tarfile; '
+        't = tarfile.open('
+        '\'ros%d-%s-linux-%s-%s-ci.tar.bz2\', '
+        '\'w:bz2\'); '
+        't.add(\'ws/install_isolated\', arcname=\'ros%d-linux\'); '
+        't.close()"' % (
+          ros_version, rosdistro_name or 'global', os_code_name, arch,
+          ros_version
+        ),
         'sha256sum -b ros%d-%s-linux-%s-%s-ci.tar.bz2' % (ros_version, rosdistro_name or 'global', os_code_name, arch) +
         ' > ros%d-%s-linux-%s-%s-ci-CHECKSUM' % (ros_version, rosdistro_name or 'global', os_code_name, arch),
         'cd -',

--- a/scripts/ci/create_workspace_archive.py
+++ b/scripts/ci/create_workspace_archive.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from runpy import run_module
+
+
+if __name__ == '__main__':
+    run_module('ros_buildfarm.scripts.ci.create_workspace_archive', run_name='__main__')

--- a/test/test_create_workspace_archive.py
+++ b/test/test_create_workspace_archive.py
@@ -1,0 +1,80 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import os
+
+from ros_buildfarm.scripts.ci import create_workspace_archive
+
+
+class ChunkEnforcingReader:
+
+    def __init__(self, file_handle):
+        """Wrap a file handle and reject unbounded reads."""
+        self._file_handle = file_handle
+
+    def __enter__(self):
+        self._file_handle.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return self._file_handle.__exit__(exc_type, exc_value, traceback)
+
+    def __getattr__(self, name):
+        return getattr(self._file_handle, name)
+
+    def read(self, size=-1):
+        if size == -1:
+            raise AssertionError(
+                'Checksum calculation must stream the archive contents')
+        return self._file_handle.read(size)
+
+
+def test_create_workspace_archive_streams_checksum(monkeypatch, tmpdir):
+    install_dir = tmpdir.mkdir('install')
+    install_dir.join('setup.sh').write('echo sourced workspace\n')
+    output_dir = tmpdir.mkdir('output')
+
+    archive_name = 'ros2-humble-linux-jammy-amd64-ci.tar.bz2'
+    archive_path = os.path.join(str(output_dir), archive_name)
+    checksum_path = archive_path.replace('.tar.bz2', '-CHECKSUM')
+    original_open = open
+
+    def guarded_open(path, mode='r', *args, **kwargs):
+        file_handle = original_open(path, mode, *args, **kwargs)
+        if path == archive_path and mode == 'rb':
+            return ChunkEnforcingReader(file_handle)
+        return file_handle
+
+    monkeypatch.setattr(
+        create_workspace_archive, 'open', guarded_open, raising=False)
+
+    rc = create_workspace_archive.main([
+        'humble',
+        'jammy',
+        'amd64',
+        '--ros-version', '2',
+        '--install-dir', str(install_dir),
+        '--output-dir', str(output_dir),
+    ])
+
+    assert rc == 0
+
+    with open(archive_path, 'rb') as f:
+        archive_checksum = hashlib.sha256(f.read()).hexdigest()
+
+    with open(checksum_path, 'r') as f:
+        checksum_content = f.read()
+
+    assert checksum_content == '%s *%s\n' % (archive_checksum, archive_name)


### PR DESCRIPTION
This pull request updates the way install space compression is performed in the CI job template. The main change is switching from a shell-based `tar` command to a Python-based approach using the `tarfile` module. This should save us a dependency on bzip2 for the Jenkins nodes. See https://github.com/ros-infrastructure/ros_buildfarm/issues/1118

Mainly using `arcname` to do the conversion from ws/install_isolated to ros-${version}. Not fully sure if there is a use case that is not be covered by the IA generated regexp.

Local generation:
```diff
   @@ -418,2 +418 @@                                                                                                                                                                                                                                                                                                                  
         -cd $WORKSPACE                                                                                                                                                                                                                                                                                                                     
         -tar -cjf ros2-global-linux-jammy-amd64-ci.tar.bz2 -C ws --transform "s/^install_isolated/ros2-linux/" install_isolated                                                                                                                                                                                                            
         +cd $WORKSPACE &amp;&amp; python3 -c "import tarfile; t = tarfile.open('ros2-global-linux-jammy-amd64-ci.tar.bz2', 'w:bz2'); t.add('ws/install_isolated', arcname='ros2-linux'); t.close()"
```

Tested https://build.osrfoundation.org/job/__test_ci__colcon_any-manual_ubuntu_noble_amd64/3/ . Tar seems like:
```shell
~/Downloads/ros2-global-linux-noble-amd64-ci via 🐏 25GiB/31GiB | 964kiB/8GiB ❯ tree -L 2
.
└── ros2-linux
    ├── COLCON_IGNORE
    ├── gz-cmake
    ├── gz-common
    ├── gz-fuel_tools
    ├── gz-gui
    ├── gz-math
    ├── gz-msgs
    ├── gz-physics
    ├── gz-plugin
    ├── gz-rendering
    ├── gz-sensors
    ├── gz-sim
    ├── gz-tools2
    ├── gz-transport
    ├── gz-utils
    ├── local_setup.sh
    ├── _local_setup_util_sh.py
    ├── sdformat
    └── setup.sh

17 directories, 4 files
```
