### PR TITLE
Make rosdep database available to RPM builds

### DIFF
--- a/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
@@ -11,7 +11,9 @@ FROM @(os_name):@(os_code_name)
 
 RUN dnf update --refresh -y
 
-RUN dnf install --refresh -y --setopt=install_weak_deps=False dnf{,-command\(download\)} git mock{,-{core-configs,scm}} python3{,-{catkin_pkg,empy,rosdistro,yaml}}
+RUN dnf install --refresh -y --setopt=install_weak_deps=False dnf{,-command\(download\)} git mock{,-{core-configs,scm}} python3{,-{catkin_pkg,empy,rosdep,rosdistro,yaml}}
+
+RUN rosdep init
 
 @(TEMPLATE(
     'snippet/setup_bazel_single_thread_builds.Dockerfile.em',
@@ -33,6 +35,7 @@ COPY mock_config.cfg /etc/mock/ros_buildfarm.cfg
 RUN chmod 644 /etc/mock/ros_buildfarm.cfg
 
 USER buildfarm
+RUN env ROSDISTRO_INDEX_URL=@(rosdistro_index_url) rosdep update --rosdistro=@(rosdistro_name)
 ENTRYPOINT ["sh", "-c"]
 @{
 cmds = [

--- a/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
+++ b/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
@@ -46,6 +46,12 @@ config_opts['use_nspawn'] = False
 # Add g++, which is an assumed dependency in ROS
 config_opts['chroot_setup_cmd'] += ' gcc-c++ make'
 
+# Mount through the rosdep DB
+if os.path.isdir(os.path.expanduser('~/.ros/rosdep')):
+    config_opts['plugin_conf']['mount_enable'] = True
+    config_opts['plugin_conf']['bind_mount_opts']['dirs'].append((os.path.expanduser('~/.ros/rosdep'), '/builddir/.ros/rosdep' ))
+    config_opts['exclude_from_homedir_cleanup'] += ['.ros/rosdep']
+
 config_opts[f'dnf.conf'] += """
 @[for i, url in enumerate(distribution_repository_urls)]@
 [ros-buildfarm-@(i)]

--- a/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/sourcepkg_task.Dockerfile.em
@@ -11,7 +11,9 @@ FROM @(os_name):@(os_code_name)
 
 RUN dnf update --refresh -y
 
-RUN dnf install --refresh -y --setopt=install_weak_deps=False dnf{,-command\(download\)} git mock{,-{core-configs,scm}} python3{,-{catkin_pkg,empy,rosdistro,yaml}}
+RUN dnf install --refresh -y --setopt=install_weak_deps=False dnf{,-command\(download\)} git mock{,-{core-configs,scm}} python3{,-{catkin_pkg,empy,rosdep,rosdistro,yaml}}
+
+RUN rosdep init
 
 RUN useradd -u @(uid) -l -m buildfarm
 RUN usermod -a -G mock buildfarm


### PR DESCRIPTION
The rosdep database will be used to resolve dependencies during the build of dynamic RPM packages. Rather than updating it inside the pristine build environment, we can mount an up-to-date rosdep cache into the buildroot.