### PR TITLE
Plumb package_ignore_list into RPM build environment

### DIFF
--- a/ros_buildfarm/binaryrpm_job.py
+++ b/ros_buildfarm/binaryrpm_job.py
@@ -54,7 +54,7 @@ def get_sourcerpm(
 
 def build_binaryrpm(
         rosdistro_name, package_name, sourcepkg_dir, binarypkg_dir, append_timestamp=False,
-        skip_tests=False):
+        skip_tests=False, skip_rosdep_keys=None):
     rpm_package_name = get_os_package_name(rosdistro_name, package_name)
     source_packages = glob.glob(os.path.join(sourcepkg_dir, rpm_package_name + '-*.src.rpm'))
     assert len(source_packages) == 1
@@ -75,6 +75,9 @@ def build_binaryrpm(
 
     if skip_tests:
         cmd += ['--without', 'tests']
+
+    if skip_rosdep_keys:
+        cmd += ['--define', '_bloom_skip_keys ' + ' '.join(skip_rosdep_keys)]
 
     print("Invoking '%s'" % ' '.join(cmd))
     subprocess.check_call(cmd)

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -532,6 +532,7 @@ def configure_release_job(
     source_job_names.append(source_job_name)
     job_configs[source_job_name] = job_config
 
+    skip_rosdep_keys = None
     dependency_names = []
     if build_file.abi_incompatibility_assumed:
         dependency_names = get_direct_dependencies(
@@ -544,6 +545,7 @@ def configure_release_job(
             print(("Skipping binary jobs for package '%s' because it is not " +
                    "yet in the rosdistro cache") % pkg_name, file=sys.stderr)
             return source_job_names, binary_job_names, job_configs
+        skip_rosdep_keys = dependency_names.intersection(build_file.package_ignore_list)
         dependency_names.difference_update(build_file.package_ignore_list)
 
     # binarydeb jobs
@@ -567,7 +569,8 @@ def configure_release_job(
             pkg_name, repo_name, repo.release_repository,
             cached_pkgs=cached_pkgs, upstream_job_names=upstream_job_names,
             is_disabled=is_disabled,
-            docker_base_image_override=docker_base_image_override)
+            docker_base_image_override=docker_base_image_override,
+            skip_rosdep_keys=skip_rosdep_keys)
         # jenkinsapi.jenkins.Jenkins evaluates to false if job count is zero
         if isinstance(jenkins, object) and jenkins is not False:
             configure_job(jenkins, job_name, job_config, dry_run=dry_run)
@@ -690,7 +693,8 @@ def _get_binarydeb_job_config(
         pkg_name, repo_name, release_repository,
         cached_pkgs=None, upstream_job_names=None,
         is_disabled=False,
-        docker_base_image_override=None):
+        docker_base_image_override=None,
+        skip_rosdep_keys=None):
     package_format = package_format_mapping[os_name]
     template_name = 'release/%s/binarypkg_job.xml.em' % package_format
 
@@ -760,6 +764,7 @@ def _get_binarydeb_job_config(
         'notify_emails': build_file.notify_emails,
         'maintainer_emails': maintainer_emails,
         'notify_maintainers': build_file.notify_maintainers,
+        'skip_rosdep_keys': skip_rosdep_keys,
         'skip_tests': not build_file.run_package_tests,
 
         'timeout_minutes': build_file.jenkins_binary_job_timeout,

--- a/ros_buildfarm/scripts/release/rpm/build_binarypkg.py
+++ b/ros_buildfarm/scripts/release/rpm/build_binarypkg.py
@@ -19,6 +19,7 @@ from ros_buildfarm.argument import add_argument_append_timestamp
 from ros_buildfarm.argument import add_argument_binarypkg_dir
 from ros_buildfarm.argument import add_argument_package_name
 from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.argument import add_argument_skip_rosdep_keys
 from ros_buildfarm.argument import add_argument_skip_tests
 from ros_buildfarm.argument import add_argument_sourcepkg_dir
 from ros_buildfarm.binaryrpm_job import build_binaryrpm
@@ -35,11 +36,13 @@ def main(argv=sys.argv[1:]):
         add_argument_binarypkg_dir(parser)
         add_argument_append_timestamp(parser)
         add_argument_skip_tests(parser)
+        add_argument_skip_rosdep_keys(parser)
         args = parser.parse_args(argv)
 
         return build_binaryrpm(
             args.rosdistro_name, args.package_name, args.sourcepkg_dir, args.binarypkg_dir,
-            args.append_timestamp, skip_tests=args.skip_tests)
+            args.append_timestamp, skip_tests=args.skip_tests,
+            skip_rosdep_keys=args.skip_rosdep_keys)
 
 
 if __name__ == '__main__':

--- a/ros_buildfarm/scripts/release/rpm/run_binarypkg_job.py
+++ b/ros_buildfarm/scripts/release/rpm/run_binarypkg_job.py
@@ -31,6 +31,7 @@ from ros_buildfarm.argument import add_argument_package_name
 from ros_buildfarm.argument import add_argument_rosdistro_index_url
 from ros_buildfarm.argument import add_argument_rosdistro_name
 from ros_buildfarm.argument import add_argument_skip_download_sourcepkg
+from ros_buildfarm.argument import add_argument_skip_rosdep_keys
 from ros_buildfarm.argument import add_argument_skip_tests
 from ros_buildfarm.argument import add_argument_target_repository
 from ros_buildfarm.common import get_distribution_repository_keys
@@ -57,6 +58,7 @@ def main(argv=sys.argv[1:]):
     add_argument_env_vars(parser)
     add_argument_binarypkg_dir(parser)
     add_argument_skip_tests(parser)
+    add_argument_skip_rosdep_keys(parser)
     args = parser.parse_args(argv)
 
     data = copy.deepcopy(args.__dict__)
@@ -71,6 +73,7 @@ def main(argv=sys.argv[1:]):
 
         'skip_download_sourcepkg': args.skip_download_sourcepkg,
         'skip_tests': args.skip_tests,
+        'skip_rosdep_keys': args.skip_rosdep_keys,
 
         'sourcepkg_dir': os.path.join(args.binarypkg_dir, 'source'),
     })

--- a/ros_buildfarm/templates/release/rpm/binarypkg_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_job.xml.em
@@ -115,7 +115,8 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
         ' --binarypkg-dir /tmp/binarypkg' +
         ' --env-vars ' + ' '.join(build_environment_variables) +
         (' --append-timestamp' if append_timestamp else '') +
-        (' --skip-tests' if skip_tests else ''),
+        (' --skip-tests' if skip_tests else '') +
+        ((' --skip-rosdep-keys ' + ' '.join(skip_rosdep_keys)) if skip_rosdep_keys else ''),
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Build Dockerfile - build binaryrpm"',

--- a/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
+++ b/ros_buildfarm/templates/release/rpm/binarypkg_task.Dockerfile.em
@@ -51,7 +51,8 @@ cmds = [
     ' --sourcepkg-dir ' + sourcepkg_dir +
     ' --binarypkg-dir ' + binarypkg_dir +
     (' --append-timestamp' if append_timestamp else '') +
-    (' --skip-tests' if skip_tests else ''),
+    (' --skip-tests' if skip_tests else '') +
+    ((' --skip-rosdep-keys ' + ' '.join(skip_rosdep_keys)) if skip_rosdep_keys else ''),
 ]
 }@
 CMD ["@(' && '.join(cmds))"]


### PR DESCRIPTION
By making the global package_ignore_list available within the RPM build environment, we enable the dynamic RPM generator respect the same ignore list that Jenkins is using to build out the job graph.

---

Specifically, this will be critical for RHEL where we need to ignore all references to RTI connext packages.