### PR TITLE
Add a workaround for DNF 5 (on Fedora)

### DIFF
--- a/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
+++ b/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
@@ -1,5 +1,8 @@
 include('/etc/mock/default.cfg')
 
+# Workaround for dnf5 download command (see rpm-software-management/mock#1750)
+config_opts.setdefault("dnf5_avoid_opts", {}).setdefault("download", []).append("--allowerasing")
+
 def _expanded(k, opts):
     """Get a config value and ensure it has been expanded."""
     exp, opts['__jinja_expand'] = opts.get('__jinja_expand', False), True


### PR DESCRIPTION
The 'download' command to dnf doesn't accept the `--allowerasing` argument. There is an exclusion list in mock, but it needs to be updated to list the 'download' command.

See rpm-software-management/mock#1750 for the upstream fix.