### PR TITLE
Remove legacy osrf/* image default override

### DIFF
--- a/ros_buildfarm/templates/snippet/builder_check-docker.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_check-docker.xml.em
@@ -1,16 +1,7 @@
 @{
 # same logic as in from_base_image.Dockerfile.em
 base_image = '%s:%s' % (
-    vars().get('docker_base_image_override') or (
-        'osrf/%s_%s' % (os_name, arch)
-        if arch in ('i386', 'armhf', 'arm64') and (
-            os_code_name in (
-                'artful', 'bionic', 'cosmic', 'disco', 'focal',
-                'jammy', 'noble', 'wily', 'xenial', 'yakkety',
-                'zesty')
-        )
-        else os_name
-    ),
+    vars().get('docker_base_image_override') or os_name,
     os_code_name,
 )
 }@

--- a/ros_buildfarm/templates/snippet/from_base_image.Dockerfile.em
+++ b/ros_buildfarm/templates/snippet/from_base_image.Dockerfile.em
@@ -1,16 +1,7 @@
 @[if 'base_image' not in locals()]@
 @{
 base_image = '%s:%s' % (
-  vars().get('docker_base_image_override') or (
-      'osrf/%s_%s' % (os_name, arch)
-      if arch in ('i386', 'armhf', 'arm64') and (
-            os_code_name in (
-                'artful', 'bionic', 'cosmic', 'disco', 'focal',
-                'jammy', 'noble', 'wily', 'xenial', 'yakkety',
-                'zesty')
-      )
-      else os_name
-  ),
+  vars().get('docker_base_image_override') or os_name,
   os_code_name,
 )
 }


### PR DESCRIPTION
# Description
Remove legacy `osrf/*` image in the docker template. This aligns the build process with modern multi-arch official library images and simplifies the template logic.

# Changes
* Base image is now built only with the `os_code_name` and the `os_name` or the docker image override attribute

# Considerations
* With this change, we will use always Docker Hub official images by default
* `docker_base_image_override` variable remains functional for cases where a custom base image is required. It can replicate the previous compatibility if `--docker-base-image-override osrf/ubuntu_arm64` is specified.
* Old distributions might not be compatible with this change