### PR TITLE
Make RPM buildroot search failure a warning

### DIFF
--- a/ros_buildfarm/binaryrpm_job.py
+++ b/ros_buildfarm/binaryrpm_job.py
@@ -16,6 +16,7 @@ from datetime import datetime
 import glob
 import os
 import subprocess
+import sys
 
 from ros_buildfarm.common import get_os_package_name
 
@@ -86,13 +87,17 @@ def build_binaryrpm(
         ['mock', '--root', 'ros_buildfarm', '--print-root-path']).decode('utf-8').strip()
     mock_build_path = os.path.join(mock_root_path, 'builddir', 'build', 'BUILD')
     for subdir in os.listdir(mock_build_path):
-        if subdir.endswith('-SPECPARTS'):
+        if any(subdir.endswith(suffix) for suffix in ('-build', '-SPECPARTS')):
             continue
 
         package_root = os.path.join(mock_build_path, subdir)
         break
     else:
-        assert False, "Failed to determine package build root"
+        print(
+            'WARNING: Failed to determine package build root. '
+            'Maintainer E-mail addresses could not be determined.',
+            file=sys.stderr)
+        return
 
     # output package maintainers for job notification
     from catkin_pkg.package import parse_package


### PR DESCRIPTION
The process for extracting the maintainer E-mail addresses wasn't done very well in the initial RPM build implementation in ros_buildfarm, and this fragile code has bit us in the past.

Modern RPM build has changed the directory layout again and I think it's time to try a different approach here. To unblock Fedora builds, I'm proposing that we make this failure non-fatal. We won't have maintainer E-mails turned on for Fedora anyway, so this shouldn't result in any change in behavior (unless RHEL adopts Fedora's newer RPM version, which I can't see happening until RHEL 11).

Demo build using this change: https://build.test.ros2.org/view/Rbin_fedora_fc4364/job/Rbin_fedora_fc4364__ament_package__fedora_43_x86_64__binary/5/