### PR TITLE
Respect modified dependency behaviors when disabling jobs

### DIFF
--- a/ros_buildfarm/common.py
+++ b/ros_buildfarm/common.py
@@ -681,13 +681,18 @@ def get_package_manifests(dist):
     return cached_pkgs
 
 
-def get_implicitly_ignored_package_names(cached_pkgs, explicitly_ignored_pkg_names):
+def get_implicitly_ignored_package_names(
+    cached_pkgs, explicitly_ignored_pkg_names,
+    include_test_deps=True, include_group_deps=False,
+):
     pkg_names = set(explicitly_ignored_pkg_names).union(cached_pkgs.keys())
     # get direct dependencies from distro cache for each package
     direct_dependencies = {}
     for pkg_name in cached_pkgs.keys():
         direct_dependencies[pkg_name] = get_direct_dependencies(
-            pkg_name, cached_pkgs, pkg_names) or set([])
+            pkg_name, cached_pkgs, pkg_names,
+            include_test_deps=include_test_deps,
+            include_group_deps=include_group_deps) or set([])
 
     # find recursive downstream deps for all explicitly ignored packages
     ignored_pkg_names = set(explicitly_ignored_pkg_names)

--- a/ros_buildfarm/release_job.py
+++ b/ros_buildfarm/release_job.py
@@ -113,7 +113,9 @@ def configure_release_jobs(
             print('  -', pkg_name)
 
         implicitly_ignored_pkg_names = get_implicitly_ignored_package_names(
-            cached_pkgs, explicitly_ignored_pkg_names)
+            cached_pkgs, explicitly_ignored_pkg_names,
+            include_test_deps=build_file.include_test_dependencies,
+            include_group_deps=build_file.include_group_dependencies)
         if implicitly_ignored_pkg_names:
             print(('The following packages are being %s because their ' +
                    'dependencies are being ignored:') % ('ignored'

--- a/ros_buildfarm/status_page_input.py
+++ b/ros_buildfarm/status_page_input.py
@@ -50,7 +50,8 @@ def get_rosdistro_info(dist, build_file):
         set(pkg_names) - set(filtered_pkg_names) - explicitly_ignored_without_recursion_pkg_names
     if explicitly_ignored_pkg_names:
         implicitly_ignored_pkg_names = get_implicitly_ignored_package_names(
-            cached_pkgs, explicitly_ignored_pkg_names)
+            cached_pkgs, explicitly_ignored_pkg_names,
+            include_test_deps=build_file.include_test_dependencies)
         filtered_pkg_names = \
             set(filtered_pkg_names) - implicitly_ignored_pkg_names
     filtered_pkg_names = set(filtered_pkg_names) - explicitly_ignored_without_recursion_pkg_names


### PR DESCRIPTION
This change plumbs the build file configuration values which augment dependency enumeration into the code which disables jobs downstream of other jobs which have been explicitly disabled in the build config.

Closes #1133 