### PR TITLE
Add a flag to skip 'Build and install'

### DIFF
--- a/doc/configuration_options.rst
+++ b/doc/configuration_options.rst
@@ -612,6 +612,15 @@ The following options are valid in version ``1`` (beside the generic options):
 * ``underlay_from_ci_jobs``: names of other CI jobs which should be used
   as an underlay to this job.
 
+* ``single_stage``: a boolean flag which, when set to ``true``, skips the
+  *build-and-install* stage and only runs the *build-and-test* stage
+  (default: ``false``).
+  This is useful when the install space is not needed as an underlay for
+  downstream jobs and the goal is solely to verify that packages build and
+  their tests pass.
+  The value serves as the default for the ``single_stage`` Jenkins parameter,
+  which can be overridden per-run from the Jenkins UI.
+
 * ``upload_directory``: a subdirectory name to upload the resulting archive
   to, if desired.
   By default, the resulting archives are only available to other jobs within

--- a/doc/jobs/ci_jobs.rst
+++ b/doc/jobs/ci_jobs.rst
@@ -40,9 +40,16 @@ The actual build is performed within a Docker container in order to ensure
 only declared dependencies are available.
 
 The actual build process starts in the script *create_ci_task_generator.py*.
-It generates three Dockerfiles: one to perform the *create-workspace* task to
-populate the workspace and enumerate prerequisites, one to perform the
-*build-and-install* task, and one to perform the *build-and-test* task.
+It generates up to three Dockerfiles: one to perform the *create-workspace*
+task to populate the workspace and enumerate prerequisites, optionally one to
+perform the *build-and-install* task, and one to perform the *build-and-test*
+task.
+
+When the ``single_stage`` flag is set (either in the CI build file or via the
+Jenkins job parameter), the *build-and-install* stage is skipped entirely and
+only the *build-and-test* stage runs.
+In this mode the install-space archive is produced after *build-and-test*
+completes rather than after *build-and-install*.
 
 Create workspace
 ^^^^^^^^^^^^^^^^
@@ -80,6 +87,8 @@ Build and install
 ^^^^^^^^^^^^^^^^^
 
 This task is identical to `the one used by the devel jobs <devel_jobs.rst#Build-and-install>`_.
+
+This stage is skipped when ``single_stage`` is enabled.
 
 Build and test
 ^^^^^^^^^^^^^^

--- a/ros_buildfarm/argument.py
+++ b/ros_buildfarm/argument.py
@@ -426,6 +426,13 @@ def add_argument_skip_rosdep_keys(parser):
              'and not installed.')
 
 
+def add_argument_single_stage(parser):
+    parser.add_argument(
+        '--single-stage',
+        action='store_true',
+        help='Skip the "Build & Install" stage and only run the "Build & Test" stage.')
+
+
 def add_argument_test_branch(parser):
     parser.add_argument(
         '--test-branch', default=None,

--- a/ros_buildfarm/ci_job.py
+++ b/ros_buildfarm/ci_job.py
@@ -302,6 +302,7 @@ def _get_ci_job_config(
         'build_tool_args': build_file.build_tool_args,
         'build_tool_test_args': build_file.build_tool_test_args,
         'test_branch': build_file.test_branch,
+        'single_stage': build_file.single_stage,
 
         'underlay_source_jobs': underlay_source_jobs,
         'underlay_source_paths': underlay_source_paths,

--- a/ros_buildfarm/config/ci_build_file.py
+++ b/ros_buildfarm/config/ci_build_file.py
@@ -153,6 +153,10 @@ class CIBuildFile(BuildFile):
         if 'upload_directory' in data:
             self.upload_directory = data['upload_directory']
 
+        self.single_stage = False
+        if 'single_stage' in data:
+            self.single_stage = bool(data['single_stage'])
+
         self.custom_rosdep_urls = []
         if '_config' in data['targets']:
             if 'custom_rosdep_urls' in data['targets']['_config']:

--- a/ros_buildfarm/scripts/ci/run_ci_job.py
+++ b/ros_buildfarm/scripts/ci/run_ci_job.py
@@ -38,6 +38,7 @@ from ros_buildfarm.argument import add_argument_repos_file_urls
 from ros_buildfarm.argument import add_argument_repository_names
 from ros_buildfarm.argument import add_argument_ros_version
 from ros_buildfarm.argument import add_argument_rosdistro_name
+from ros_buildfarm.argument import add_argument_single_stage
 from ros_buildfarm.argument import add_argument_skip_rosdep_keys
 from ros_buildfarm.argument import add_argument_test_branch
 from ros_buildfarm.argument import extract_multiple_remainders
@@ -71,6 +72,7 @@ def main(argv=sys.argv[1:]):
     add_argument_package_names(parser, optional=True)
     add_argument_package_dependencies(parser)
     add_argument_ros_version(parser)
+    add_argument_single_stage(parser)
     add_argument_skip_rosdep_keys(parser)
     add_argument_test_branch(parser)
     parser.add_argument(

--- a/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
+++ b/ros_buildfarm/templates/ci/ci_create_tasks.Dockerfile.em
@@ -87,19 +87,20 @@ cmds = [
     ' --test-branch "%s"' % (test_branch) + \
     ' --skip-rosdep-keys ' + ' '.join(skip_rosdep_keys) + \
     ' --package-selection-args ' + ' '.join(package_selection_args),
-
-    'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \
-    ' /tmp/ros_buildfarm/scripts/ci/build_task_generator.py' + \
-    ' --dockerfile-dir /tmp/docker_build_and_install' + \
-    build_args,
-
+]
+if not single_stage:
+    cmds.append(
+        'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \
+        ' /tmp/ros_buildfarm/scripts/ci/build_task_generator.py' + \
+        ' --dockerfile-dir /tmp/docker_build_and_install' + \
+        build_args)
+cmds.append(
     'PYTHONPATH=/tmp/ros_buildfarm:$PYTHONPATH python3 -u' + \
     ' /tmp/ros_buildfarm/scripts/ci/build_task_generator.py' + \
     ' --testing' + \
     ' --dockerfile-dir /tmp/docker_build_and_test' + \
     build_args + \
-    ' --build-tool-test-args ' + ' '.join(build_tool_test_args or []),
-]
+    ' --build-tool-test-args ' + ' '.join(build_tool_test_args or []))
 cmd = ' && '.join(cmds).replace('\\', '\\\\').replace('"', '\\"')
 }@
 CMD ["@cmd"]

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -469,6 +469,23 @@ parameters = [
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
+        'if [ "$single_stage" = "true" ]; then',
+        'echo "# BEGIN SECTION: Compress install space"',
+        'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
+        'python3 -u $WORKSPACE/ros_buildfarm/scripts/ci/create_workspace_archive.py' +
+        ' ' + (rosdistro_name or "''") +
+        ' ' + os_code_name +
+        ' ' + arch +
+        ' --ros-version ' + str(ros_version) +
+        ' --install-dir $WORKSPACE/ws/install_isolated' +
+        ' --output-dir $WORKSPACE',
+        'echo "# END SECTION"',
+        'fi',
+    ]),
+))@
+@(SNIPPET(
+    'builder_shell',
+    script='\n'.join([
         'if [ "$skip_cleanup" = "false" ]; then',
         'echo "# BEGIN SECTION: Clean up to save disk space on agents"',
         'rm -fr ws/build_isolated',

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -381,6 +381,7 @@ parameters = [
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
+        'if [ "$single_stage" != "true" ]; then',
         'echo "# BEGIN SECTION: Compress install space"',
         'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/ci/create_workspace_archive.py' +
@@ -391,6 +392,7 @@ parameters = [
         ' --install-dir $WORKSPACE/ws/install_isolated' +
         ' --output-dir $WORKSPACE',
         'echo "# END SECTION"',
+        'fi',
     ]),
 ))@
 @(SNIPPET(

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -92,6 +92,7 @@ parameters = [
     {
         'type': 'boolean',
         'name': 'single_stage',
+        'default_value': single_stage,
         'description': 'If selected, skip the "Build and Install" stage and only run "Build and Test"',
     },
 ]

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -92,7 +92,7 @@ parameters = [
     {
         'type': 'boolean',
         'name': 'single_stage',
-        'description': 'If selected, skip the "Build & Install" stage and only run "Build & Test"',
+        'description': 'If selected, skip the "Build and Install" stage and only run "Build and Test"',
     },
 ]
 }@

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -89,6 +89,11 @@ parameters = [
         'default_value': build_tool_test_args or '',
         'description': 'Arbitrary arguments passed to the build tool during testing',
     },
+    {
+        'type': 'boolean',
+        'name': 'single_stage',
+        'description': 'If selected, skip the "Build & Install" stage and only run "Build & Test"',
+    },
 ]
 }@
 @(SNIPPET(
@@ -192,6 +197,7 @@ parameters = [
         'export TZ="%s"' % timezone,
         'export PYTHONPATH=$WORKSPACE/ros_buildfarm:$PYTHONPATH',
         'if [ "$package_dependencies" = "true" ]; then package_dependencies_arg=--package-dependencies; fi',
+        'if [ "$single_stage" = "true" ]; then single_stage_arg=--single-stage; fi',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/ci/run_ci_job.py' +
         ' ' + (rosdistro_name or "''") +
         ' ' + os_name +
@@ -214,7 +220,8 @@ parameters = [
         ]) +
         ' --package-selection-args $package_selection_args' +
         ' --build-tool-args $build_tool_args' +
-        ' --build-tool-test-args $build_tool_test_args',
+        ' --build-tool-test-args $build_tool_test_args' +
+        ' $single_stage_arg',
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Build Dockerfile - generating CI tasks"',
@@ -302,6 +309,7 @@ parameters = [
 @(SNIPPET(
     'builder_shell',
     script='\n'.join([
+        'if [ "$single_stage" != "true" ]; then',
         '# monitor all subprocesses and enforce termination',
         'python3 -u $WORKSPACE/ros_buildfarm/scripts/subprocess_reaper.py $$ --cid-file $WORKSPACE/docker_build_and_install/docker.cid > $WORKSPACE/docker_build_and_install/subprocess_reaper.log 2>&1 &',
         '# sleep to give python time to startup',
@@ -366,7 +374,9 @@ parameters = [
         ' $DOCKER_IMAGE_PREFIX.ci_build_and_install.%s' % (rosdistro_name or 'global') +
         ' "ccache -s"',
         'echo "# END SECTION"',
-    ] if shared_ccache else [])),
+    ] if shared_ccache else []) + [
+        'fi',
+    ]),
 ))@
 @(SNIPPET(
     'builder_shell',

--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -218,10 +218,10 @@ parameters = [
         ' --workspace-mount-point /tmp/ws' + ''.join([
             ' /tmp/ws%d' % (i + 2) for i in range(len(underlay_source_paths))
         ]) +
+        ' $single_stage_arg' +
         ' --package-selection-args $package_selection_args' +
         ' --build-tool-args $build_tool_args' +
-        ' --build-tool-test-args $build_tool_test_args' +
-        ' $single_stage_arg',
+        ' --build-tool-test-args $build_tool_test_args',
         'echo "# END SECTION"',
         '',
         'echo "# BEGIN SECTION: Build Dockerfile - generating CI tasks"',


### PR DESCRIPTION
# Description

This PR adds the `--single-stage` flag to `ros_buildfarm` ci tasks, which is intended to: `Skip the "Build & Install" stage and only run the "Build & Test" stage.`

It also modifies the ci job templates to have the `Single Stage` flag on the job. Then it will skip the `build and install` and `Compress install space` sections

This is part of the experiments and mitigations of: https://github.com/osrf/buildfarm-tools/issues/186

Generated by Claude Sonnet 4.6