### PR TITLE
Set `artifact_num_to_keep` to 30 for CI jobs config

### DIFF
--- a/ros_buildfarm/templates/ci/ci_job.xml.em
+++ b/ros_buildfarm/templates/ci/ci_job.xml.em
@@ -15,6 +15,7 @@ but disabled since the package is blacklisted (or not whitelisted) in the config
     'property_log-rotator',
     days_to_keep=730,
     num_to_keep=100,
+    artifact_num_to_keep=30,
 ))@
 @[if job_priority is not None]@
 @(SNIPPET(


### PR DESCRIPTION
# Description

Limit CI artifact retention to 30 builds by reducing Jenkins job artifact storage overhead by retaining only the 30 most recent builds per job.

The artifacts are the heaviest part of a build result. Cleaning this will lead to a ~70% of less size in the CI jobs that leave artifacts