### PR TITLE
Support multiple targets on import upstream

### DIFF
--- a/ros_buildfarm/scripts/release/generate_release_maintenance_jobs.py
+++ b/ros_buildfarm/scripts/release/generate_release_maintenance_jobs.py
@@ -122,12 +122,33 @@ def get_trigger_missed_jobs_job_config(args, config, build_file):
 def get_import_upstream_job_config(args, config, build_file, package_format):
     template_name = 'release/%s/import_upstream_job.xml.em' % package_format
     data = {
-        'import_targets': build_file.targets,
+        'import_targets': _get_all_import_targets(config, package_format),
         'credential_id': build_file.upload_credential_id,
     }
     return _get_job_config(
         args, config, config.notify_emails, template_name,
         additional_data=data)
+
+
+def _get_all_import_targets(config, package_format):
+    # the 'import_upstream' job name is not qualified by the ROS distribution
+    # or the build name, so every release build file using this package format
+    # writes the same job. Consider all of their targets, otherwise generating
+    # the job for one build file drops the targets of all the others.
+    targets = {}
+    for dist_name in sorted(config.distributions.keys()):
+        build_files = get_release_build_files(config, dist_name)
+        for _, build_file in sorted(build_files.items()):
+            for os_name, os_code_names in build_file.targets.items():
+                if package_format_mapping.get(os_name) != package_format:
+                    continue
+                known_os_code_names = targets.setdefault(os_name, {})
+                for os_code_name, arches in os_code_names.items():
+                    known_arches = known_os_code_names.setdefault(
+                        os_code_name, {})
+                    for arch, arch_data in arches.items():
+                        known_arches.setdefault(arch, arch_data)
+    return targets
 
 
 def _get_job_config(

--- a/ros_buildfarm/templates/release/rpm/import_upstream_job.xml.em
+++ b/ros_buildfarm/templates/release/rpm/import_upstream_job.xml.em
@@ -55,14 +55,9 @@
         'echo "# BEGIN SECTION: import upstream packages"',
         'for f in $repo_list_file; do',
     ] + [
-        "  sed 's/$distname/%s/g;s/$releasever/%s/g' $f | xargs -L1 createrepo-agent /var/repos/%s/building/%s/ --invalidate-family --arch=SRPMS --arch=%s --sync" % (os_name, os_code_name, os_name, os_code_name, ' --arch='.join(arches))
+        "  sed 's/$distname/%s/g;s/$releasever/%s/g' $f | xargs -L1 createrepo-agent /var/repos/%s/%s/%s/ --invalidate-family --arch=SRPMS --arch=%s --sync" % (os_name, os_code_name, os_name, repo, os_code_name, ' --arch='.join(arches))
         for os_name, os_versions in import_targets.items() for os_code_name, arches in os_versions.items()
-    ] + [
-        "  sed 's/$distname/%s/g;s/$releasever/%s/g' $f | xargs -L1 createrepo-agent /var/repos/%s/testing/%s/ --invalidate-family --arch=SRPMS --arch=%s --sync" % (os_name, os_code_name, os_name, os_code_name, ' --arch='.join(arches))
-        for os_name, os_versions in import_targets.items() for os_code_name, arches in os_versions.items()
-    ] + [
-        "  sed 's/$distname/%s/g;s/$releasever/%s/g' $f | xargs -L1 createrepo-agent /var/repos/%s/main/%s/ --invalidate-family --arch=SRPMS --arch=%s --sync" % (os_name, os_code_name, os_name, os_code_name, ' --arch='.join(arches))
-        for os_name, os_versions in import_targets.items() for os_code_name, arches in os_versions.items()
+        for repo in ('building', 'testing', 'main')
     ] + [
         'done',
         'echo "# END SECTION"',


### PR DESCRIPTION
### Description 

The import_upstream jobs don't support the scenario for multiple os targets/repositories under the same package format.  That had the side effect that subsequent runs with different OS compited and only the last one succedded. This reworks that job to aggregate all targets regardless of the specific OS being configured.

Though the import_upstream_rpm configuration is updated multiple times on a single deployment, it's the simplest way to keep the repository configuration as part of the job config.

