### PR TITLE
Remove crates supplied by ROS packages before vendoring

### DIFF
--- a/ros_buildfarm/cargo.py
+++ b/ros_buildfarm/cargo.py
@@ -35,20 +35,22 @@ def is_vendoring_requested(pkg):
     return requested
 
 
-def _get_non_crates_io_dependencies(sources_dir):
-    CRATES_IO_SOURCE = 'registry+https://github.com/rust-lang/crates.io-index'
-
+def _get_cargo_metadata(sources_dir):
     # '--no-deps' restricts this to the manifests in the workspace and skips
     # resolving the dependency graph, so it needs neither a lock file nor
-    # network access. The manifests are enough to cover the whole graph:
-    # crates.io refuses to publish a crate depending on a git repository or on
-    # another registry, so no crates.io crate can pull one in transitively
+    # network access
     cmd = [
         'cargo', 'metadata', '--no-deps', '--offline', '--format-version', '1']
     print("Invoking '%s' in '%s'" % (' '.join(cmd), sources_dir))
-    metadata = json.loads(
-        subprocess.check_output(cmd, cwd=sources_dir).decode())
+    return json.loads(subprocess.check_output(cmd, cwd=sources_dir).decode())
 
+
+def _get_non_crates_io_dependencies(metadata):
+    CRATES_IO_SOURCE = 'registry+https://github.com/rust-lang/crates.io-index'
+
+    # the manifests are enough to cover the whole graph: crates.io refuses to
+    # publish a crate depending on a git repository or on another registry, so
+    # no crates.io crate can pull one in transitively
     dependencies = []
     for package in metadata['packages']:
         for dependency in package['dependencies']:
@@ -59,6 +61,26 @@ def _get_non_crates_io_dependencies(sources_dir):
     return dependencies
 
 
+def _get_ros_crates(metadata):
+    # crates supplied by other ROS packages, which are not published to
+    # crates.io and are resolved from the ROS registry when the package builds
+    crates = []
+    for package in metadata['packages']:
+        package_metadata = package.get('metadata') or {}
+        crates += (package_metadata.get('ros') or {}).get('crates', [])
+    return crates
+
+
+def _remove_ros_crates(sources_dir, crates):
+    # ROS crates are assumed to be declared in '[dependencies]', which is what
+    # 'cargo remove' operates on. It fails when the crate is not there, so a
+    # typo in the manifest metadata is reported instead of silently ignored
+    for crate in crates:
+        cmd = ['cargo', 'remove', crate]
+        print("Invoking '%s' in '%s'" % (' '.join(cmd), sources_dir))
+        subprocess.check_call(cmd, cwd=sources_dir)
+
+
 def vendor_cargo_crates(sources_dir, vendor_dir):
     manifest_path = os.path.join(sources_dir, 'Cargo.toml')
     if not os.path.exists(manifest_path):
@@ -66,11 +88,13 @@ def vendor_cargo_crates(sources_dir, vendor_dir):
               sources_dir)
         return
 
+    metadata = _get_cargo_metadata(sources_dir)
+
     # crates from git repositories or from registries other than crates.io do
     # not go through a crates.io release and can change or disappear without
     # notice, refuse to ship them in the source package. Checked before
     # vendoring so that none of them is fetched in the first place
-    external_deps = _get_non_crates_io_dependencies(sources_dir)
+    external_deps = _get_non_crates_io_dependencies(metadata)
     if external_deps:
         raise RuntimeError(
             'Cannot vendor cargo crates: crates.io is the only permitted '
@@ -86,20 +110,36 @@ def vendor_cargo_crates(sources_dir, vendor_dir):
     # set rather than being rejected.
 
     lock_path = os.path.join(sources_dir, 'Cargo.lock')
-    generated_lock = not os.path.exists(lock_path)
-    if not generated_lock:
+    if os.path.exists(lock_path):
         cmd.append('--locked')
     cmd.append(os.path.join(*vendor_dir))
-    print("Invoking '%s' in '%s'" % (' '.join(cmd), sources_dir))
-    vendor_config = subprocess.check_output(cmd, cwd=sources_dir).decode()
-    # the source replacement configuration which the build recipe needs to use
-    # to build against the vendored crates, the recipe hardcodes it since it
-    # only ever describes crates.io as long as the check above passes
-    print(vendor_config)
 
-    # a lock file cargo just resolved is a modification of the upstream part
-    # of the source tree, which dpkg-source refuses to represent as a quilt
-    # patch, the vendored crates are the pinned dependency set in this case
-    if generated_lock:
-        print("Removing the '%s' generated while vendoring" % lock_path)
-        os.remove(lock_path)
+    # cargo cannot vendor a crate which is not published to crates.io, so the
+    # ones other ROS packages supply are taken out of the manifest for the
+    # duration of the vendoring
+    with open(manifest_path, 'r') as h:
+        manifest_backup = h.read()
+    lock_backup = None
+    if os.path.exists(lock_path):
+        with open(lock_path, 'r') as h:
+            lock_backup = h.read()
+
+    try:
+        _remove_ros_crates(sources_dir, _get_ros_crates(metadata))
+        print("Invoking '%s' in '%s'" % (' '.join(cmd), sources_dir))
+        vendor_config = subprocess.check_output(cmd, cwd=sources_dir).decode()
+        # the source replacement configuration which the build recipe needs to
+        # use to build against the vendored crates, the recipe hardcodes it
+        # since it only ever describes crates.io as long as the check passed
+        print(vendor_config)
+    finally:
+        # whatever cargo left behind is a modification of the upstream part of
+        # the source tree, which dpkg-source refuses to represent as a quilt
+        # patch, the vendored crates are the pinned dependency set instead
+        with open(manifest_path, 'w') as h:
+            h.write(manifest_backup)
+        if lock_backup is not None:
+            with open(lock_path, 'w') as h:
+                h.write(lock_backup)
+        elif os.path.exists(lock_path):
+            os.remove(lock_path)


### PR DESCRIPTION
As the title says. We currently remove crate dependencies that are marked as `[package.metadata.ros]`  as part of the Cargo.toml of a crate to be released in the buildfarm.

Those are removed temporarily to be able of running cargo vendor without conflicts related to those crates not being available in crates.io.

As a potential follow up, we can get the packages released into a distro, and remove them from the Cargo.toml instead. However, I think that's a decision that might introduce some subtleities in terms of where the crates are obtained implicitly. I prefer the simpler approach taken in this PR, we can improve `_get_ros_crates` in subsequent iterations as we see fit.

We also create an in-memory copy of the Cargo.toml and Cargo.lock to be restored after the vendoring step.