### PR TITLE
Remove obsolete setTriggered() call in disk-space check Groovy script

### DIFF
--- a/ros_buildfarm/templates/snippet/builder_check-docker.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_check-docker.xml.em
@@ -17,12 +17,11 @@ base_image = '%s:%s' % (
     'builder_system-groovy',
     command=
 """// DISABLE SLAVE IF OUTPUT INDICATES DOCKER RUN PROBLEMS
-import hudson.model.Cause.UserIdCause
+import hudson.model.Cause.UpstreamCause
 import hudson.model.ParametersAction
 import hudson.slaves.OfflineCause.UserCause
 import java.io.BufferedReader
 import java.util.regex.Pattern
-import org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildAction
 
 pattern = Pattern.compile("'docker run' returned [^0].*")
 
@@ -41,10 +40,7 @@ while ((line = br.readLine()) != null) {
 
         // rescheduled a build with the same parameters
         // the requeue flag in the project configuration seems to not be sufficient anymore
-        build.getProject().scheduleBuild(1, new UserIdCause(), *build.getActions(ParametersAction))
-
-        // add badge to build
-        build.getActions().add(GroovyPostbuildAction.createInfoBadge("'docker run' failed, disabled agent '" + computer.name + "', rescheduled job"))
+        build.getProject().scheduleBuild(1, new UpstreamCause(build), *build.getActions(ParametersAction))
 
         // abort this build
         throw new InterruptedException()

--- a/ros_buildfarm/templates/snippet/builder_system-groovy_check-free-disk-space.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy_check-free-disk-space.xml.em
@@ -32,7 +32,6 @@ try {
       // mark agent as offline and log event
       def computer = node.toComputer()
       def disk_space = new DiskSpace(root_path.getRemote(), usable_disk_space)
-      disk_space.setTriggered(node_monitor.getClass(), true);
       if (node_monitor.getDescriptor().markOffline(computer, disk_space)) {
         def logger = Logger.getLogger(AbstractDiskSpaceMonitor.class.getName())
         logger.warning(Messages.DiskSpaceMonitor_MarkedOffline(computer.getName()))

--- a/ros_buildfarm/templates/snippet/builder_system-groovy_check-free-disk-space.xml.em
+++ b/ros_buildfarm/templates/snippet/builder_system-groovy_check-free-disk-space.xml.em
@@ -2,7 +2,7 @@
     'builder_system-groovy',
     command=
 """// VERFIY THAT FREE DISK SPACE THRESHOLD IS NOT VIOLATED
-import hudson.model.Cause.UserIdCause
+import hudson.model.Cause.UpstreamCause
 import hudson.model.ParametersAction
 import hudson.node_monitors.AbstractDiskSpaceMonitor
 import hudson.node_monitors.DiskSpaceMonitor
@@ -10,7 +10,6 @@ import hudson.node_monitors.DiskSpaceMonitorDescriptor.DiskSpace
 import hudson.node_monitors.Messages
 import hudson.node_monitors.NodeMonitor
 import java.util.logging.Logger
-import org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildAction
 
 println "# BEGIN SECTION: Check free disk space"
 
@@ -32,17 +31,16 @@ try {
       // mark agent as offline and log event
       def computer = node.toComputer()
       def disk_space = new DiskSpace(root_path.getRemote(), usable_disk_space)
-      if (node_monitor.getDescriptor().markOffline(computer, disk_space)) {
-        def logger = Logger.getLogger(AbstractDiskSpaceMonitor.class.getName())
-        logger.warning(Messages.DiskSpaceMonitor_MarkedOffline(computer.getName()))
-      }
+      disk_space.setThreshold(free_space_threshold)
+      disk_space.setTotalSize(root_path.getTotalDiskSpace())
+      disk_space.setTrigger(node_monitor.getClass())
+      computer.setTemporarilyOffline(true, disk_space)
+      def logger = Logger.getLogger(AbstractDiskSpaceMonitor.class.getName())
+      logger.warning(Messages.DiskSpaceMonitor_MarkedOffline(computer.getName()))
 
       // rescheduled a build with the same parameters
       // the requeue flag in the project configuration seems to not be sufficient anymore
-      build.getProject().scheduleBuild(1, new UserIdCause(), *build.getActions(ParametersAction))
-
-      // add badge to build
-      build.getActions().add(GroovyPostbuildAction.createInfoBadge("Free disk space is too low, disabled agent '" + computer.name + "', rescheduled job"))
+      build.getProject().scheduleBuild(1, new UpstreamCause(build), *build.getActions(ParametersAction))
 
       // abort this build
       throw new InterruptedException()


### PR DESCRIPTION
## Summary

Removes the call to `DiskSpaceMonitorDescriptor.DiskSpace.setTriggered(Class, boolean)` from the "check free disk space" System Groovy builder snippet. This method has been removed from Jenkins core, and any controller running a version built from https://github.com/jenkinsci/jenkins/pull/8593 or later will fail this build step with:

```
groovy.lang.MissingMethodException: No signature of method: hudson.node_monitors.DiskSpaceMonitorDescriptor$DiskSpace.setTriggered()
```

## Root cause: Jenkins 2.555.3 migration

Jenkins core PR #8593 ([JENKINS-72009, JENKINS-72200, JENKINS-24947] various fixes and improvements around disk space monitoring, merged 2023-11-24) removed the triggered boolean field and its public setTriggered(Class, boolean) mutator from DiskSpaceMonitorDescriptor.DiskSpace, in commit [690f76d](https://github.com/jenkinsci/jenkins/pull/8593/changes/690f76dece58646407d1bb8090c334eff206968a) ("remove triggered field").

Current master instead exposes a `protected void setTrigger(Class<? extends AbstractDiskSpaceMonitor> trigger)`, a different name, a different signature (single arg, no boolean), and no longer public, so the old call is simply gone from the public API surface.

Because `setTriggered()` was an internal implementation detail rather than a documented Extension Point, its removal was not called out in the user-facing Jenkins changelog; it only shows up in this PR's diff.