### PR TITLE
Always output full build logs from RPM builds

### DIFF
--- a/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
+++ b/ros_buildfarm/templates/release/rpm/mock_config.cfg.em
@@ -1,5 +1,8 @@
 include('/etc/mock/default.cfg')
 
+# Always output full build logs
+config_opts['print_main_output'] = True
+
 # Workaround for dnf5 download command (see rpm-software-management/mock#1750)
 config_opts.setdefault("dnf5_avoid_opts", {}).setdefault("download", []).append("--allowerasing")
 


### PR DESCRIPTION
I think something changed on the invocation side that has caused the Jenkins log output to no longer appear as a TTY, so `mock` is hiding the full build logs.

This flag forces them back to the output.